### PR TITLE
Include transitively affected modules in report mode

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -19,6 +19,8 @@ public final class ScalpelReport {
 
     public static final String REASON_SOURCE_CHANGE = "SOURCE_CHANGE";
     public static final String REASON_POM_CHANGE = "POM_CHANGE";
+    public static final String REASON_TRANSITIVE_DEPENDENCY = "TRANSITIVE_DEPENDENCY";
+    public static final String REASON_MANAGED_PLUGIN = "MANAGED_PLUGIN";
 
     private final String baseBranch;
     private final boolean fullBuildTriggered;

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ScalpelReportTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void toJson_directlyAffectedModule() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-a",
+                        "module-a",
+                        Collections.singletonList(ScalpelReport.REASON_SOURCE_CHANGE)))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"SOURCE_CHANGE\""));
+        assertTrue(json.contains("\"module-a\""));
+        assertFalse(json.contains("\"TRANSITIVE_DEPENDENCY\""));
+    }
+
+    @Test
+    void toJson_transitivelyAffectedModule() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("pom.xml"))
+                .changedManagedDependencies(Collections.singleton("org.apache.kafka:kafka-clients"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-a",
+                        "module-a",
+                        Collections.singletonList(ScalpelReport.REASON_POM_CHANGE)))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-b",
+                        "module-b",
+                        Collections.singletonList(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"POM_CHANGE\""));
+        assertTrue(json.contains("\"TRANSITIVE_DEPENDENCY\""));
+        assertTrue(json.contains("\"module-a\""));
+        assertTrue(json.contains("\"module-b\""));
+        assertTrue(json.contains("\"org.apache.kafka:kafka-clients\""));
+    }
+
+    @Test
+    void toJson_managedPluginAffectedModule() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("pom.xml"))
+                .changedManagedPlugins(Collections.singleton("org.apache.maven.plugins:maven-compiler-plugin"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-a",
+                        "module-a",
+                        Collections.singletonList(ScalpelReport.REASON_MANAGED_PLUGIN)))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"MANAGED_PLUGIN\""));
+        assertTrue(json.contains("\"org.apache.maven.plugins:maven-compiler-plugin\""));
+    }
+
+    @Test
+    void toJson_multipleReasons() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("pom.xml"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-a",
+                        "module-a",
+                        Arrays.asList(ScalpelReport.REASON_MANAGED_PLUGIN, ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"MANAGED_PLUGIN\""));
+        assertTrue(json.contains("\"TRANSITIVE_DEPENDENCY\""));
+    }
+
+    @Test
+    void toJson_fullBuildTriggered() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(true)
+                .triggerFile(".mvn/extensions.xml")
+                .changedFiles(Collections.singleton(".mvn/extensions.xml"))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"fullBuildTriggered\": true"));
+        assertTrue(json.contains("\".mvn/extensions.xml\""));
+        assertTrue(json.contains("\"affectedModules\": []"));
+    }
+
+    @Test
+    void toJson_emptyReport() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"version\": \"1\""));
+        assertTrue(json.contains("\"fullBuildTriggered\": false"));
+        assertTrue(json.contains("\"affectedModules\": []"));
+        assertTrue(json.contains("\"changedFiles\": []"));
+    }
+
+    @Test
+    void writeToFile_createsFileWithCorrectContent() throws IOException {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("pom.xml"))
+                .changedManagedDependencies(Collections.singleton("commons-lang:commons-lang"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-b",
+                        "module-b",
+                        Collections.singletonList(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
+                .build();
+
+        report.writeToFile(tempDir, "target/scalpel-report.json");
+
+        Path reportFile = tempDir.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String content = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertEquals(report.toJson(), content);
+    }
+
+    @Test
+    void toJson_escapesSpecialCharacters() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("path/with\"quotes.java"))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("path/with\\\"quotes.java"));
+    }
+}

--- a/extension3/pom.xml
+++ b/extension3/pom.xml
@@ -69,6 +69,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -22,8 +22,10 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -182,7 +184,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             changedManagedPluginGAs,
                             Collections.<MavenProject>emptySet(),
                             Collections.<MavenProject>emptySet(),
-                            Collections.<MavenProject>emptySet());
+                            Collections.<MavenProject>emptySet(),
+                            Collections.<MavenProject, List<String>>emptyMap());
                 } else if (config.isModeSkipTests()) {
                     skipTestsOnAll(allProjects);
                 }
@@ -195,6 +198,33 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     projectKeys(directlyAffected));
 
             if (config.isModeReport()) {
+                // Check remaining modules for transitive dependency/plugin impact
+                Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
+                if (!changedManagedDepGAs.isEmpty() || !changedManagedPluginGAs.isEmpty()) {
+                    for (MavenProject project : allProjects) {
+                        if (directlyAffected.contains(project)) {
+                            continue;
+                        }
+                        List<String> reasons = new ArrayList<>();
+                        if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
+                            reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
+                        }
+                        if (!changedManagedDepGAs.isEmpty()
+                                && hasChangedTransitiveDependency(project, session, changedManagedDepGAs)) {
+                            reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+                        }
+                        if (!reasons.isEmpty()) {
+                            transitivelyAffected.put(project, reasons);
+                        }
+                    }
+                    if (!transitivelyAffected.isEmpty()) {
+                        logger.info(
+                                "Scalpel: {} modules transitively affected: {}",
+                                transitivelyAffected.size(),
+                                projectKeys(transitivelyAffected.keySet()));
+                    }
+                }
+
                 writeReport(
                         config,
                         reactorRoot,
@@ -204,7 +234,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         changedManagedPluginGAs,
                         directlyAffected,
                         affectedBySource,
-                        affectedByPom);
+                        affectedByPom,
+                        transitivelyAffected);
                 return;
             }
 
@@ -330,7 +361,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedPluginGAs,
             Set<MavenProject> directlyAffected,
             Set<MavenProject> affectedBySource,
-            Set<MavenProject> affectedByPom)
+            Set<MavenProject> affectedByPom,
+            Map<MavenProject, List<String>> transitivelyAffected)
             throws MavenExecutionException {
         ScalpelReport.Builder builder = ScalpelReport.builder()
                 .baseBranch(config.getBaseBranch())
@@ -341,11 +373,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .changedManagedPlugins(changedManagedPluginGAs);
 
         for (MavenProject project : directlyAffected) {
-            String path = reactorRoot
-                    .toAbsolutePath()
-                    .normalize()
-                    .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
-                    .toString();
+            String path = relativePath(reactorRoot, project);
             List<String> reasons = new ArrayList<>();
             if (affectedBySource.contains(project)) {
                 reasons.add(ScalpelReport.REASON_SOURCE_CHANGE);
@@ -357,6 +385,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     new ScalpelReport.AffectedModule(project.getGroupId(), project.getArtifactId(), path, reasons));
         }
 
+        for (Map.Entry<MavenProject, List<String>> entry : transitivelyAffected.entrySet()) {
+            MavenProject project = entry.getKey();
+            String path = relativePath(reactorRoot, project);
+            builder.addAffectedModule(new ScalpelReport.AffectedModule(
+                    project.getGroupId(), project.getArtifactId(), path, entry.getValue()));
+        }
+
         try {
             ScalpelReport report = builder.build();
             report.writeToFile(reactorRoot, config.getReportFile());
@@ -364,6 +399,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         } catch (IOException e) {
             throw new MavenExecutionException("Scalpel: Failed to write report", e);
         }
+    }
+
+    private static String relativePath(Path reactorRoot, MavenProject project) {
+        return reactorRoot
+                .toAbsolutePath()
+                .normalize()
+                .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
+                .toString();
     }
 
     private void skipTestsOnAll(List<MavenProject> projects) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -272,6 +272,34 @@ class PomChangeAnalyzerTest {
     }
 
     @Test
+    void analyzeChanges_returnsChangedProperties() throws Exception {
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root);
+
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties>\n"
+                + "    <dep.version>1.0</dep.version>\n"
+                + "  </properties>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(
+                result.getChangedProperties().contains("dep.version"), "Changed properties should include dep.version");
+    }
+
+    @Test
     void analyzeChanges_propertyIndirectionReturnsChangedGAs() throws Exception {
         // Verify that the result includes the changed managed dep GAs for transitive checking
         Path root = setupReactorRoot();

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
+import eu.maveniverse.maven.scalpel.core.ScalpelCore;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.DefaultDependencyResolutionRequest;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectDependenciesResolver;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ScalpelLifecycleParticipantTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ScalpelCore scalpelCore;
+    private ProjectDependenciesResolver dependenciesResolver;
+    private ScalpelLifecycleParticipant participant;
+
+    @BeforeEach
+    void setUp() {
+        scalpelCore = mock(ScalpelCore.class);
+        dependenciesResolver = mock(ProjectDependenciesResolver.class);
+        participant = new ScalpelLifecycleParticipant(
+                scalpelCore, new ModuleMapper(), new PomChangeAnalyzer(), new ReactorTrimmer(), dependenciesResolver);
+    }
+
+    @Test
+    void reportMode_includesTransitivelyAffectedModules() throws Exception {
+        // Setup: parent POM manages commons-lang with property-based version
+        // module-a declares commons-lang (directly affected)
+        // module-b depends on module-a (transitively affected via dependency resolution)
+        // module-c has no deps (not affected)
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // Old parent POM (before property change)
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module><module>module-c</module></modules>\n"
+                + "  <properties>\n"
+                + "    <lib.version>1.0</lib.version>\n"
+                + "  </properties>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency>\n"
+                + "      <groupId>commons-lang</groupId>\n"
+                + "      <artifactId>commons-lang</artifactId>\n"
+                + "      <version>${lib.version}</version>\n"
+                + "    </dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "</project>\n";
+
+        // New parent POM (after property change)
+        String newParentPom = oldParentPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
+        writePom(root, "pom.xml", newParentPom);
+
+        // module-a: directly uses managed dep commons-lang
+        String moduleAPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        // module-b: depends on module-a (gets commons-lang transitively)
+        String moduleBPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        // module-c: no dependencies
+        String moduleCPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-c</artifactId>\n"
+                + "</project>\n";
+        writePom(root, "module-c/pom.xml", moduleCPom);
+
+        // Build MavenProject objects
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
+        moduleC.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB, moduleC);
+
+        // Mock ScalpelCore to return changed files
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        ChangeDetectionResult detectionResult = new ChangeDetectionResult(changedFiles, oldPoms);
+        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(detectionResult);
+
+        // Mock dependency resolution: module-b has commons-lang transitively
+        DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
+        org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
+        when(moduleBResolution.getResolvedDependencies()).thenReturn(Collections.singletonList(commonsLangDep));
+
+        // Mock dependency resolution: module-c has no matching deps
+        DependencyResolutionResult moduleCResolution = mock(DependencyResolutionResult.class);
+        when(moduleCResolution.getResolvedDependencies())
+                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+
+        // Route resolution calls based on project
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    if ("module-b".equals(req.getMavenProject().getArtifactId())) {
+                        return moduleBResolution;
+                    }
+                    return moduleCResolution;
+                });
+
+        // Mock MavenSession
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+
+        // Set report mode
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+
+        // Run
+        participant.afterProjectsRead(session);
+
+        // Verify report file
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // module-a should be directly affected (POM_CHANGE)
+        assertTrue(json.contains("\"module-a\""), "module-a should be in report");
+        assertTrue(json.contains("\"POM_CHANGE\""), "POM_CHANGE reason should be present");
+
+        // module-b should be transitively affected
+        assertTrue(json.contains("\"module-b\""), "module-b should be in report");
+        assertTrue(json.contains("\"TRANSITIVE_DEPENDENCY\""), "TRANSITIVE_DEPENDENCY reason should be present");
+
+        // module-c should NOT be in the report
+        assertFalse(json.contains("\"module-c\""), "module-c should NOT be in report");
+    }
+
+    @Test
+    void reportMode_managedPluginChange() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties>\n"
+                + "    <compiler.version>3.11.0</compiler.version>\n"
+                + "  </properties>\n"
+                + "  <build><pluginManagement><plugins>\n"
+                + "    <plugin>\n"
+                + "      <groupId>org.apache.maven.plugins</groupId>\n"
+                + "      <artifactId>maven-compiler-plugin</artifactId>\n"
+                + "      <version>${compiler.version}</version>\n"
+                + "    </plugin>\n"
+                + "  </plugins></pluginManagement></build>\n"
+                + "</project>\n";
+
+        String newParentPom = oldParentPom.replace(
+                "<compiler.version>3.11.0</compiler.version>", "<compiler.version>3.12.0</compiler.version>");
+        writePom(root, "pom.xml", newParentPom);
+
+        // module-a: no plugins
+        String moduleAPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        // module-b: uses maven-compiler-plugin
+        String moduleBPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "  <build><plugins>\n"
+                + "    <plugin>\n"
+                + "      <groupId>org.apache.maven.plugins</groupId>\n"
+                + "      <artifactId>maven-compiler-plugin</artifactId>\n"
+                + "    </plugin>\n"
+                + "  </plugins></build>\n"
+                + "</project>\n";
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        // Add the managed plugin to the parent model for child resolution
+        Build parentBuild = new Build();
+        parentProject.getModel().setBuild(parentBuild);
+
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        // Set build plugins on the effective model so usesChangedPlugin can find them
+        Build build = new Build();
+        Plugin compilerPlugin = new Plugin();
+        compilerPlugin.setGroupId("org.apache.maven.plugins");
+        compilerPlugin.setArtifactId("maven-compiler-plugin");
+        build.addPlugin(compilerPlugin);
+        moduleB.getModel().setBuild(build);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        // No transitive deps to resolve
+        DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
+        when(emptyResolution.getResolvedDependencies())
+                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenReturn(emptyResolution);
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"module-b\""), "module-b should be in report");
+        assertTrue(
+                json.contains("\"POM_CHANGE\""),
+                "POM_CHANGE reason should be present (PomChangeAnalyzer detects managed plugin use)");
+        assertFalse(json.contains("\"module-a\""), "module-a should NOT be in report (no plugin, no dep change)");
+    }
+
+    private void writePom(Path root, String relativePath, String content) throws Exception {
+        Path pomFile = root.resolve(relativePath);
+        Files.createDirectories(pomFile.getParent());
+        Files.write(pomFile, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private MavenProject createProject(
+            String groupId, String artifactId, String version, Path root, String relativePom, String pomXml) {
+        Model model = new Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion(version);
+        File pomFile = root.resolve(relativePom).toFile();
+        model.setPomFile(pomFile);
+        MavenProject project = new MavenProject(model);
+        project.setFile(pomFile);
+        project.setOriginalModel(parseModel(pomXml));
+        return project;
+    }
+
+    private Model parseModel(String xml) {
+        try {
+            return new org.apache.maven.model.io.xpp3.MavenXpp3Reader()
+                    .read(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -192,15 +192,15 @@ class ScalpelLifecycleParticipantTest {
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
 
         // module-a should be directly affected (POM_CHANGE)
-        assertTrue(json.contains("\"module-a\""), "module-a should be in report");
-        assertTrue(json.contains("\"POM_CHANGE\""), "POM_CHANGE reason should be present");
+        assertTrue(moduleHasReason(json, "module-a", "POM_CHANGE"), "module-a should have POM_CHANGE reason");
 
         // module-b should be transitively affected
-        assertTrue(json.contains("\"module-b\""), "module-b should be in report");
-        assertTrue(json.contains("\"TRANSITIVE_DEPENDENCY\""), "TRANSITIVE_DEPENDENCY reason should be present");
+        assertTrue(
+                moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY"),
+                "module-b should have TRANSITIVE_DEPENDENCY reason");
 
         // module-c should NOT be in the report
-        assertFalse(json.contains("\"module-c\""), "module-c should NOT be in report");
+        assertFalse(modulePresent(json, "module-c"), "module-c should NOT be in report");
     }
 
     @Test
@@ -309,11 +309,10 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(Files.exists(reportFile), "Report file should be created");
 
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
-        assertTrue(json.contains("\"module-b\""), "module-b should be in report");
         assertTrue(
-                json.contains("\"POM_CHANGE\""),
-                "POM_CHANGE reason should be present (PomChangeAnalyzer detects managed plugin use)");
-        assertFalse(json.contains("\"module-a\""), "module-a should NOT be in report (no plugin, no dep change)");
+                moduleHasReason(json, "module-b", "POM_CHANGE"),
+                "module-b should have POM_CHANGE reason (PomChangeAnalyzer detects managed plugin use)");
+        assertFalse(modulePresent(json, "module-a"), "module-a should NOT be in report (no plugin, no dep change)");
     }
 
     private void writePom(Path root, String relativePath, String content) throws Exception {
@@ -336,12 +335,31 @@ class ScalpelLifecycleParticipantTest {
         return project;
     }
 
+    private boolean modulePresent(String json, String artifactId) {
+        return json.contains("\"artifactId\": \"" + artifactId + "\"");
+    }
+
+    private boolean moduleHasReason(String json, String artifactId, String reason) {
+        String marker = "\"artifactId\": \"" + artifactId + "\"";
+        int idx = json.indexOf(marker);
+        if (idx < 0) {
+            return false;
+        }
+        int start = json.lastIndexOf("{", idx);
+        int end = json.indexOf("}", idx);
+        if (start < 0 || end < 0) {
+            return false;
+        }
+        String block = json.substring(start, end + 1);
+        return block.contains("\"" + reason + "\"");
+    }
+
     private Model parseModel(String xml) {
         try {
             return new org.apache.maven.model.io.xpp3.MavenXpp3Reader()
                     .read(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to parse POM XML: " + xml.substring(0, Math.min(xml.length(), 100)), e);
         }
     }
 }

--- a/it/extension3-its/src/it/report-transitive/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/report-transitive/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/report-transitive/invoker.properties
+++ b/it/extension3-its/src/it/report-transitive/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=report

--- a/it/extension3-its/src/it/report-transitive/module-a/pom.xml
+++ b/it/extension3-its/src/it/report-transitive/module-a/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.reporttransitive</groupId>
+        <artifactId>report-transitive</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/report-transitive/module-b/pom.xml
+++ b/it/extension3-its/src/it/report-transitive/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.reporttransitive</groupId>
+        <artifactId>report-transitive</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.reporttransitive</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/report-transitive/module-c/pom.xml
+++ b/it/extension3-its/src/it/report-transitive/module-c/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.reporttransitive</groupId>
+        <artifactId>report-transitive</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/report-transitive/pom.xml
+++ b/it/extension3-its/src/it/report-transitive/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.reporttransitive</groupId>
+    <artifactId>report-transitive</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <commons-lang.version>2.5</commons-lang.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/report-transitive/setup.groovy
+++ b/it/extension3-its/src/it/report-transitive/setup.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, bump managed dependency version
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Bump the managed dependency version in parent POM
+def pomFile = new File(dir, 'pom.xml')
+def pomText = pomFile.text
+pomText = pomText.replace('<commons-lang.version>2.5</commons-lang.version>', '<commons-lang.version>2.6</commons-lang.version>')
+pomFile.text = pomText
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'bump commons-lang version')

--- a/it/extension3-its/src/it/report-transitive/verify.groovy
+++ b/it/extension3-its/src/it/report-transitive/verify.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated in report mode
+assert log.contains('Scalpel')
+assert log.contains('mode=report')
+
+// Report should have been written
+assert log.contains('Report written to')
+
+// All modules should still be present in reactor (no trimming in report mode)
+assert log.contains('BUILD SUCCESS')
+
+// module-a should be directly affected (uses changed managed dependency)
+assert log.contains('directly affected')
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine != null : "Expected 'directly affected' log line"
+assert directlyAffectedLine.contains('module-a') : "module-a should be directly affected"
+
+// module-b should be transitively affected
+assert log.contains('transitively affected')
+def transitivelyAffectedLine = log.readLines().find { it.contains('transitively affected') }
+assert transitivelyAffectedLine != null : "Expected 'transitively affected' log line"
+assert transitivelyAffectedLine.contains('module-b') : "module-b should be transitively affected"
+
+// Check the report file
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists() : "Report file should have been created"
+
+String json = reportFile.text
+assert json.contains('"version": "1"') : "Report should contain version field"
+assert json.contains('"fullBuildTriggered": false') : "fullBuildTriggered should be false"
+assert json.contains('"changedManagedDependencies"') : "Report should contain changedManagedDependencies"
+assert json.contains('"commons-lang:commons-lang"') : "commons-lang:commons-lang should be in changedManagedDependencies"
+
+// module-a should be affected with POM_CHANGE reason
+assert json.contains('"module-a"') : "module-a should appear in the report"
+assert json.contains('"POM_CHANGE"') : "module-a should have POM_CHANGE reason"
+
+// module-b should be affected with TRANSITIVE_DEPENDENCY reason
+assert json.contains('"module-b"') : "module-b should appear in the report"
+assert json.contains('"TRANSITIVE_DEPENDENCY"') : "module-b should have TRANSITIVE_DEPENDENCY reason"
+
+// module-c should NOT appear in the report (no relationship to changed dependency)
+assert !json.contains('"module-c"') : "module-c should NOT appear in the report"

--- a/it/extension3-its/src/it/report-transitive/verify.groovy
+++ b/it/extension3-its/src/it/report-transitive/verify.groovy
@@ -36,18 +36,24 @@ File reportFile = new File(basedir, 'target/scalpel-report.json')
 assert reportFile.exists() : "Report file should have been created"
 
 String json = reportFile.text
-assert json.contains('"version": "1"') : "Report should contain version field"
-assert json.contains('"fullBuildTriggered": false') : "fullBuildTriggered should be false"
-assert json.contains('"changedManagedDependencies"') : "Report should contain changedManagedDependencies"
-assert json.contains('"commons-lang:commons-lang"') : "commons-lang:commons-lang should be in changedManagedDependencies"
+def report = new groovy.json.JsonSlurper().parseText(json)
 
-// module-a should be affected with POM_CHANGE reason
-assert json.contains('"module-a"') : "module-a should appear in the report"
-assert json.contains('"POM_CHANGE"') : "module-a should have POM_CHANGE reason"
+assert report.version == '1' : "Report should have version 1"
+assert report.fullBuildTriggered == false : "fullBuildTriggered should be false"
+assert report.changedManagedDependencies.contains('commons-lang:commons-lang') : "changedManagedDependencies should contain commons-lang"
 
-// module-b should be affected with TRANSITIVE_DEPENDENCY reason
-assert json.contains('"module-b"') : "module-b should appear in the report"
-assert json.contains('"TRANSITIVE_DEPENDENCY"') : "module-b should have TRANSITIVE_DEPENDENCY reason"
+def modules = report.affectedModules
+def moduleA = modules.find { it.artifactId == 'module-a' }
+def moduleB = modules.find { it.artifactId == 'module-b' }
+def moduleC = modules.find { it.artifactId == 'module-c' }
+
+// module-a should be affected with POM_CHANGE reason (directly uses changed managed dep)
+assert moduleA != null : "module-a should appear in the report"
+assert moduleA.reasons.contains('POM_CHANGE') : "module-a should have POM_CHANGE reason, got: ${moduleA.reasons}"
+
+// module-b should be affected with TRANSITIVE_DEPENDENCY reason (gets it through module-a)
+assert moduleB != null : "module-b should appear in the report"
+assert moduleB.reasons.contains('TRANSITIVE_DEPENDENCY') : "module-b should have TRANSITIVE_DEPENDENCY reason, got: ${moduleB.reasons}"
 
 // module-c should NOT appear in the report (no relationship to changed dependency)
-assert !json.contains('"module-c"') : "module-c should NOT appear in the report"
+assert moduleC == null : "module-c should NOT appear in the report"


### PR DESCRIPTION
## Summary

- Report mode now checks all reactor modules for transitive dependency and managed plugin impact when parent POM managed versions change
- Modules affected through transitive dependencies are tagged with `TRANSITIVE_DEPENDENCY` or `MANAGED_PLUGIN` reasons in the JSON report
- This enables CI scripts (e.g. Apache Camel's `incremental-build.sh`) to test transitively affected modules that the current grep-based approach misses entirely

## Test plan

- [x] Unit tests pass (`mvn test`)
- [x] Spotless formatting passes (`mvn compile`)
- [x] Integration test with a multi-module reactor where a managed dependency version changes and a non-declaring module pulls it transitively

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports now include transitively affected modules and two new reason types: TRANSITIVE_DEPENDENCY and MANAGED_PLUGIN.
* **Tests**
  * New unit and integration tests validate report JSON, multiple-reason classifications, managed-dependency/plugin detection, and report writing/escaping.
* **Chores**
  * Added test project scaffolding, integration-test setup and scripts to exercise multi-module scenarios and verify report-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->