### PR TITLE
Add SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,56 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  sonarcloud:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+        cache: 'maven'
+
+    - name: Build and analyze (PR)
+      if: github.event_name == 'pull_request'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: >-
+        ./mvnw --no-transfer-progress
+        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
+        -Dsonar.projectKey=maveniverse_scalpel
+        -Dsonar.organization=maveniverse
+        -Dsonar.host.url=https://sonarcloud.io
+        -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+        -Dsonar.pullrequest.branch=${{ github.head_ref }}
+        -Dsonar.pullrequest.base=${{ github.base_ref }}
+
+    - name: Build and analyze (push)
+      if: github.event_name == 'push'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: >-
+        ./mvnw --no-transfer-progress
+        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
+        -Dsonar.projectKey=maveniverse_scalpel
+        -Dsonar.organization=maveniverse
+        -Dsonar.host.url=https://sonarcloud.io
+        -Dsonar.branch.name=main

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,15 +32,18 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_PR_KEY: ${{ github.event.pull_request.number }}
+        SONAR_PR_BRANCH: ${{ github.head_ref }}
+        SONAR_PR_BASE: ${{ github.base_ref }}
       run: >-
         ./mvnw --no-transfer-progress
         org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
         -Dsonar.projectKey=maveniverse_scalpel
         -Dsonar.organization=maveniverse
         -Dsonar.host.url=https://sonarcloud.io
-        -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-        -Dsonar.pullrequest.branch=${{ github.head_ref }}
-        -Dsonar.pullrequest.base=${{ github.base_ref }}
+        "-Dsonar.pullrequest.key=$SONAR_PR_KEY"
+        "-Dsonar.pullrequest.branch=$SONAR_PR_BRANCH"
+        "-Dsonar.pullrequest.base=$SONAR_PR_BASE"
 
     - name: Build and analyze (push)
       if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- Add SonarCloud GitHub Actions workflow for code quality and coverage analysis
- Uses JaCoCo for coverage reporting, matching the domtrip project setup
- Separate analysis steps for PRs and pushes to main

## Test plan
- [ ] Verify `SONAR_TOKEN` secret is configured in repo settings
- [ ] Verify project is set up on SonarCloud with key `maveniverse_scalpel`
- [ ] Merge and confirm analysis runs on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated code-quality workflow that runs on pushes and pull requests to main. It sets up a Java build environment with cached dependencies, runs tests with coverage reporting, and submits results to the code-quality service. PRs and direct pushes are handled with appropriate analysis parameters. No functional code changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->