### PR TITLE
Close the GIB feature gap with 14 new configuration properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,4 @@ jobs:
     name: Verify
     uses: maveniverse/parent/.github/workflows/ci.yml@release-52
     with:
-      maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'
+      maven-test: './mvnw clean verify -e -B -V -P run-its'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,5 @@ jobs:
     name: Verify
     uses: maveniverse/parent/.github/workflows/ci.yml@release-52
     with:
-      maven-test: './mvnw clean verify -e -B -V -P run-its'
+      maven-test: './mvnw clean verify -e -B -V -P run-its -Denforcer.skip'
+      maven-matrix: '[ "3.9.12" ]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,5 +11,5 @@ jobs:
     name: Verify
     uses: maveniverse/parent/.github/workflows/ci.yml@release-52
     with:
-      maven-test: './mvnw clean verify -e -B -V -P run-its -Denforcer.skip'
+      maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'
       maven-matrix: '[ "3.9.12" ]'

--- a/README.md
+++ b/README.md
@@ -13,19 +13,23 @@ or produce a JSON report of affected modules for consumption by CI scripts.
 Scalpel hooks into Maven's lifecycle via `AbstractMavenLifecycleParticipant.afterProjectsRead()` and performs
 the following steps:
 
-1. **Find the merge base** between the current HEAD and the configured base branch using JGit.
-2. **Detect changed files** by diffing the merge base against HEAD.
-3. **Check full-build triggers** — if any changed file matches a trigger pattern (e.g. `.mvn/**`), a full
-   build is triggered.
-4. **Map source changes to modules** — non-POM file changes are mapped to the owning module by directory
+1. **Check disable conditions** — skip if disabled by property, branch match, or `-pl` selection.
+2. **Fetch base branch** (if configured) — in CI with shallow clones, fetch the base branch ref.
+3. **Find the merge base** between the current HEAD and the configured base branch using JGit.
+4. **Detect changed files** by diffing the merge base against HEAD, optionally including
+   uncommitted and untracked files.
+5. **Apply path filters** — check disable triggers, exclude paths, and full-build triggers.
+6. **Map source changes to modules** — non-POM file changes are mapped to the owning module by directory
    prefix matching.
-5. **Analyze POM changes directly** — for changed `pom.xml` files, the old POM is read from the base commit
+7. **Analyze POM changes directly** — for changed `pom.xml` files, the old POM is read from the base commit
    and compared field-by-field. Only modules whose POM actually changed (dependencies, plugins, properties,
    etc.) are marked as affected. Property indirection is resolved: if a parent POM changes a property used
    in a managed dependency version (`${spring.version}`), child modules using that dependency are detected.
-6. **Check transitive impact** — modules not directly affected are checked for transitive exposure to changed
+8. **Check transitive impact** — modules not directly affected are checked for transitive exposure to changed
    managed dependencies (via dependency resolution) and changed managed plugins.
-7. **Apply the selected mode** — trim the reactor, skip tests, or write a report.
+9. **Add force-build modules** — always include modules matching `forceBuildModules` patterns.
+10. **Apply the selected mode** — trim the reactor (with upstream/downstream control), skip tests,
+    or write a report.
 
 ## Usage
 
@@ -88,6 +92,24 @@ mvn validate -Dscalpel.mode=report -Dscalpel.baseBranch=origin/main
 
 The report is written to `target/scalpel-report.json` by default (configurable via `scalpel.reportFile`).
 
+### Impacted Module Log
+
+For CI scripts that need a simple flat file (e.g. for GitHub Actions matrix filtering), Scalpel can
+write a list of directly impacted module paths — one per line:
+
+```
+mvn validate -Dscalpel.mode=report -Dscalpel.impactedLog=target/scalpel-impacted.log
+```
+
+Example output:
+```
+module-a
+module-b/sub-module
+```
+
+This works in all modes (trim, skip-tests, report) and is written alongside the JSON report,
+not as a replacement. It contains only directly affected modules (not upstream/downstream).
+
 #### Report Format
 
 ```json
@@ -106,13 +128,15 @@ The report is written to `target/scalpel-report.json` by default (configurable v
       "groupId": "com.example",
       "artifactId": "module-a",
       "path": "module-a",
-      "reasons": ["POM_CHANGE"]
+      "reasons": ["POM_CHANGE"],
+      "category": "DIRECT"
     },
     {
       "groupId": "com.example",
       "artifactId": "module-b",
       "path": "module-b",
-      "reasons": ["TRANSITIVE_DEPENDENCY"]
+      "reasons": ["TRANSITIVE_DEPENDENCY"],
+      "category": "DOWNSTREAM"
     }
   ]
 }
@@ -126,6 +150,15 @@ The report is written to `target/scalpel-report.json` by default (configurable v
 | `POM_CHANGE` | This module's POM is affected by a POM change (property, dependency, or plugin) |
 | `TRANSITIVE_DEPENDENCY` | A changed managed dependency reaches this module transitively |
 | `MANAGED_PLUGIN` | This module uses a plugin whose managed version changed |
+| `FORCE_BUILD` | This module was force-included via `forceBuildModules` |
+
+**Affected module categories:**
+
+| Category | Description |
+|----------|-------------|
+| `DIRECT` | Directly affected by a change |
+| `UPSTREAM` | Included as an upstream dependency (via `alsoMake`) |
+| `DOWNSTREAM` | Included as a downstream dependent (via `alsoMakeDependents`) |
 
 ## Configuration
 
@@ -140,8 +173,36 @@ All properties can be set via `-D` on the command line or in `.mvn/maven.config`
 | `scalpel.alsoMake` | `true` | Include upstream dependencies of affected modules (trim mode) |
 | `scalpel.alsoMakeDependents` | `true` | Include downstream dependents of affected modules (trim mode) |
 | `scalpel.fullBuildTriggers` | `.mvn/**` | Comma-separated glob patterns; if a changed file matches, a full build is triggered |
+| `scalpel.excludePaths` | *(none)* | Comma-separated glob patterns; changed files matching these are ignored |
+| `scalpel.disableTriggers` | *(none)* | Comma-separated glob patterns; if any changed file matches, Scalpel is disabled entirely |
 | `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report (report mode), relative to reactor root |
+| `scalpel.impactedLog` | *(none)* | Write impacted module paths to this file (one per line) |
+| `scalpel.forceBuildModules` | *(none)* | Comma-separated regex patterns; always include modules whose artifactId matches |
+| `scalpel.buildAllIfNoChanges` | `false` | Build everything when no changes are detected (useful for cron builds) |
+| `scalpel.disableOnBranch` | *(none)* | Comma-separated regex patterns; disable if current branch matches |
+| `scalpel.disableOnBaseBranch` | *(none)* | Comma-separated regex patterns; disable if base branch matches |
+| `scalpel.disableOnSelectedProjects` | `false` | Disable Scalpel when `-pl` is used |
+| `scalpel.skipTestsForUpstream` | `false` | Skip tests on modules included only as upstream dependencies |
+| `scalpel.upstreamArgs` | *(none)* | Comma-separated `key=value` properties to set on upstream-only modules |
+| `scalpel.downstreamArgs` | *(none)* | Comma-separated `key=value` properties to set on downstream-only modules |
+| `scalpel.fetchBaseBranch` | `false` | Fetch base branch from remote before change detection |
+| `scalpel.uncommitted` | `false` | Include uncommitted (staged + unstaged) changes |
+| `scalpel.untracked` | `false` | Include untracked files in change detection |
 | `scalpel.failSafe` | `true` | On error, fall back to a full build instead of failing |
+
+## Local Developer Usage
+
+By default, Scalpel only considers committed changes (diff between merge base and HEAD).
+For local development, you can include uncommitted and/or untracked files:
+
+```
+# In .mvn/maven.config for local dev:
+-Dscalpel.uncommitted=true
+-Dscalpel.untracked=true
+```
+
+This detects staged, unstaged, and new files without requiring a commit. CI environments
+should leave these as `false` (the default).
 
 ## CI Auto-Detection
 
@@ -156,6 +217,18 @@ Scalpel automatically detects the base branch on common CI systems:
 If no CI environment is detected and `scalpel.baseBranch` is not set, Scalpel is a **no-op** —
 all modules are built normally. This makes it safe to keep Scalpel in `.mvn/extensions.xml` permanently
 without affecting local developer builds.
+
+### Fetching the Base Branch
+
+In CI environments with shallow clones or forks, the base branch may not exist locally.
+Scalpel can fetch it automatically before change detection:
+
+```
+-Dscalpel.fetchBaseBranch=true
+```
+
+This parses the base branch reference (e.g. `origin/main`) to extract the remote and branch
+name, then fetches only that ref. If the ref already exists locally, no fetch is performed.
 
 ## Full Build Triggers
 
@@ -173,6 +246,45 @@ build. You can customize this with comma-separated glob patterns:
 > -Dscalpel.fullBuildTriggers=
 > ```
 
+## Path Filtering
+
+Scalpel provides three levels of path-based control over change detection. All use
+comma-separated glob patterns:
+
+- **`scalpel.excludePaths`** — Ignore matching files from change detection. Use this for files
+  that shouldn't trigger rebuilds (documentation, editor config, etc.):
+  ```
+  -Dscalpel.excludePaths=*.md,LICENSE,.sdkmanrc,.editorconfig
+  ```
+
+- **`scalpel.fullBuildTriggers`** — Force a full build if any changed file matches (default:
+  `.mvn/**`). See [Full Build Triggers](#full-build-triggers) below.
+
+- **`scalpel.disableTriggers`** — Disable Scalpel entirely if any changed file matches. Use this
+  when certain changes (e.g. CI configuration) should always result in a full, unmodified build:
+  ```
+  -Dscalpel.disableTriggers=.github/**
+  ```
+
+These filters are applied in order: disable triggers are checked first, then excluded paths are
+removed, then full build triggers are checked on the remaining files.
+
+## Force-Build Modules
+
+Some modules should always be built regardless of change detection (e.g. integration test runners).
+Use `forceBuildModules` with regex patterns matching artifactIds:
+
+```
+-Dscalpel.forceBuildModules=.*-it,.*-tests
+```
+
+For scheduled/cron builds where no changes may be detected, use `buildAllIfNoChanges` to fall back
+to a full build instead of building nothing:
+
+```
+-Dscalpel.buildAllIfNoChanges=true
+```
+
 ## Disabling Scalpel
 
 To run a full build without Scalpel:
@@ -180,6 +292,56 @@ To run a full build without Scalpel:
 ```
 mvn verify -Dscalpel.enabled=false
 ```
+
+### Branch-Based Disable
+
+Scalpel can automatically disable itself based on the current or base branch name. This is useful
+for CI systems where incremental builds should be skipped on main, release, or maintenance branches:
+
+```
+# Disable on main and release branches
+-Dscalpel.disableOnBranch=main,release/.*
+
+# Disable when the base branch is a maintenance branch
+-Dscalpel.disableOnBaseBranch=\d+\.\d+
+```
+
+Branch patterns are Java regular expressions. For `disableOnBaseBranch`, the remote prefix
+(e.g. `origin/`) is stripped before matching.
+
+### Selected Projects (`-pl`) Handling
+
+By default, when Maven is invoked with `-pl` (selected projects), Scalpel trims within
+the `-pl` scope — this is usually the correct behavior. However, in CI downstream test
+jobs where `-pl` selects a specific test module, you may want to disable Scalpel entirely:
+
+```
+# In CI downstream test jobs:
+mvn verify -pl integration-tests/maven -Dscalpel.disableOnSelectedProjects=true
+```
+
+## Upstream and Downstream Module Handling
+
+When Scalpel detects affected modules, it includes upstream dependencies (`alsoMake`) and
+downstream dependents (`alsoMakeDependents`) in the build set. The following properties give
+fine-grained control over how these categories are treated:
+
+**Skip tests on upstream modules:**
+
+```
+mvn verify -Dscalpel.skipTestsForUpstream=true
+```
+
+This builds upstream dependencies but skips their tests, since they weren't directly changed.
+
+**Inject properties per category:**
+
+```
+mvn verify -Dscalpel.upstreamArgs=skipITs=true -Dscalpel.downstreamArgs=skipITs=true
+```
+
+In `report` mode, each affected module in the JSON report includes a `"category"` field
+(`DIRECT`, `UPSTREAM`, or `DOWNSTREAM`) so CI scripts can apply their own policies.
 
 ## POM Change Analysis
 
@@ -207,6 +369,63 @@ effective version changed and marks child modules that use it as affected.
 
 Scalpel works correctly in git worktrees, where `.git` is a file pointing to the main repository
 rather than a directory.
+
+## Migrating from GIB (gitflow-incremental-builder)
+
+| GIB Property | Scalpel Equivalent | Notes |
+|---|---|---|
+| `gib.enabled` | `scalpel.enabled` | Same semantics |
+| `gib.referenceBranch` | `scalpel.baseBranch` | Same semantics |
+| `gib.disableIfBranchMatches` | `scalpel.disableOnBranch` | Same (regex CSV) |
+| `gib.disableIfReferenceBranchMatches` | `scalpel.disableOnBaseBranch` | Same (regex CSV) |
+| `gib.fetchReferenceBranch` | `scalpel.fetchBaseBranch` | Same |
+| `gib.disableSelectedProjectsHandling` | `scalpel.disableOnSelectedProjects` | Inverted default |
+| `gib.logImpactedTo` | `scalpel.impactedLog` | Same format |
+| `gib.buildUpstream` | `scalpel.alsoMake` | Boolean (no "derived" mode) |
+| `gib.buildDownstream` | `scalpel.alsoMakeDependents` | Boolean |
+| `gib.skipTestsForUpstreamModules` | `scalpel.skipTestsForUpstream` | Same |
+| `gib.argsForUpstreamModules` | `scalpel.upstreamArgs` | CSV `key=value` |
+| `gib.argsForDownstreamModules` | `scalpel.downstreamArgs` | CSV `key=value` |
+| `gib.excludePathsMatching` | `scalpel.excludePaths` | Glob patterns (GIB uses regex) |
+| `gib.skipIfPathMatches` | `scalpel.disableTriggers` | Glob patterns (GIB uses regex) |
+| `gib.uncommitted` | `scalpel.uncommitted` | Default differs (`false` in Scalpel) |
+| `gib.untracked` | `scalpel.untracked` | Default differs (`false` in Scalpel) |
+| `gib.forceBuildModules` | `scalpel.forceBuildModules` | Same (regex CSV) |
+| `gib.buildAll` | `scalpel.enabled=false` | Use enabled flag directly |
+| `gib.buildAllIfNoChanges` | `scalpel.buildAllIfNoChanges` | Same |
+| `gib.failOnError` | `scalpel.failSafe` | Inverted semantics (`failSafe=true` ≈ `failOnError=false`) |
+
+### Example Migration
+
+**Before (GIB in `.mvn/maven.config`):**
+
+```
+-Dgib.referenceBranch=refs/remotes/origin/main
+-Dgib.disableIfBranchMatches=main,release/.*
+-Dgib.fetchReferenceBranch=true
+-Dgib.excludePathsMatching=.*\.md|LICENSE
+-Dgib.skipTestsForUpstreamModules=true
+-Dgib.forceBuildModules=.*-it
+-Dgib.uncommitted=false
+-Dgib.untracked=false
+```
+
+**After (Scalpel in `.mvn/maven.config`):**
+
+```
+-Dscalpel.baseBranch=origin/main
+-Dscalpel.disableOnBranch=main,release/.*
+-Dscalpel.fetchBaseBranch=true
+-Dscalpel.excludePaths=*.md,LICENSE
+-Dscalpel.skipTestsForUpstream=true
+-Dscalpel.forceBuildModules=.*-it
+```
+
+Key differences:
+- `scalpel.baseBranch` uses `origin/main` (not `refs/remotes/origin/main`)
+- `scalpel.excludePaths` uses glob patterns (not regex)
+- `uncommitted` and `untracked` default to `false`, so they can be omitted
+- `failSafe` defaults to `true` (GIB's `failOnError` defaults to `true`)
 
 ## Snapshot Repository
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Add Scalpel to your project's `.mvn/extensions.xml`:
 Then run Maven as usual. On a feature branch, Scalpel will automatically detect the base branch on
 supported CI systems and trim the reactor:
 
-```
+```text
 $ mvn verify
 [INFO] Scalpel 0.1.0 activated (mode=trim)
 [INFO] Scalpel: 3 changed files detected
@@ -66,7 +66,7 @@ Scalpel supports three modes, selected via `-Dscalpel.mode=<mode>`:
 Removes unaffected modules from the reactor. Only affected modules and their upstream/downstream
 dependencies are built. This is the most aggressive mode — unaffected modules are completely skipped.
 
-```
+```bash
 mvn verify -Dscalpel.baseBranch=origin/main
 ```
 
@@ -76,7 +76,7 @@ Builds all modules but skips tests on modules that are not affected by changes. 
 transitive dependency or managed plugin changes also have their tests run. This is useful when you
 want a full compile but only want to test what changed.
 
-```
+```bash
 mvn verify -Dscalpel.mode=skip-tests -Dscalpel.baseBranch=origin/main
 ```
 
@@ -86,7 +86,7 @@ Writes a JSON report of affected modules to a file without modifying the reactor
 built normally. This is useful when a CI script needs Scalpel's change detection results but wants
 to control the build flow itself.
 
-```
+```bash
 mvn validate -Dscalpel.mode=report -Dscalpel.baseBranch=origin/main
 ```
 
@@ -97,12 +97,12 @@ The report is written to `target/scalpel-report.json` by default (configurable v
 For CI scripts that need a simple flat file (e.g. for GitHub Actions matrix filtering), Scalpel can
 write a list of directly impacted module paths — one per line:
 
-```
+```bash
 mvn validate -Dscalpel.mode=report -Dscalpel.impactedLog=target/scalpel-impacted.log
 ```
 
 Example output:
-```
+```text
 module-a
 module-b/sub-module
 ```
@@ -195,7 +195,7 @@ All properties can be set via `-D` on the command line or in `.mvn/maven.config`
 By default, Scalpel only considers committed changes (diff between merge base and HEAD).
 For local development, you can include uncommitted and/or untracked files:
 
-```
+```text
 # In .mvn/maven.config for local dev:
 -Dscalpel.uncommitted=true
 -Dscalpel.untracked=true
@@ -223,7 +223,7 @@ without affecting local developer builds.
 In CI environments with shallow clones or forks, the base branch may not exist locally.
 Scalpel can fetch it automatically before change detection:
 
-```
+```bash
 -Dscalpel.fetchBaseBranch=true
 ```
 
@@ -235,14 +235,14 @@ name, then fetches only that ref. If the ref already exists locally, no fetch is
 By default, changes to files under `.mvn/` (e.g. `extensions.xml`, `maven.config`) trigger a full
 build. You can customize this with comma-separated glob patterns:
 
-```
+```bash
 -Dscalpel.fullBuildTriggers=.mvn/**,Jenkinsfile,*.gradle
 ```
 
 > **Note:** Since Scalpel itself lives in `.mvn/extensions.xml`, any change to that file (e.g. a
 > Dependabot PR bumping Scalpel's version) will trigger a full build by default. If this is undesired,
 > override the triggers to be more specific or set them to empty:
-> ```
+> ```bash
 > -Dscalpel.fullBuildTriggers=
 > ```
 
@@ -253,7 +253,7 @@ comma-separated glob patterns:
 
 - **`scalpel.excludePaths`** — Ignore matching files from change detection. Use this for files
   that shouldn't trigger rebuilds (documentation, editor config, etc.):
-  ```
+  ```bash
   -Dscalpel.excludePaths=*.md,LICENSE,.sdkmanrc,.editorconfig
   ```
 
@@ -262,7 +262,7 @@ comma-separated glob patterns:
 
 - **`scalpel.disableTriggers`** — Disable Scalpel entirely if any changed file matches. Use this
   when certain changes (e.g. CI configuration) should always result in a full, unmodified build:
-  ```
+  ```bash
   -Dscalpel.disableTriggers=.github/**
   ```
 
@@ -274,14 +274,14 @@ removed, then full build triggers are checked on the remaining files.
 Some modules should always be built regardless of change detection (e.g. integration test runners).
 Use `forceBuildModules` with regex patterns matching artifactIds:
 
-```
+```bash
 -Dscalpel.forceBuildModules=.*-it,.*-tests
 ```
 
 For scheduled/cron builds where no changes may be detected, use `buildAllIfNoChanges` to fall back
 to a full build instead of building nothing:
 
-```
+```bash
 -Dscalpel.buildAllIfNoChanges=true
 ```
 
@@ -289,7 +289,7 @@ to a full build instead of building nothing:
 
 To run a full build without Scalpel:
 
-```
+```bash
 mvn verify -Dscalpel.enabled=false
 ```
 
@@ -298,7 +298,7 @@ mvn verify -Dscalpel.enabled=false
 Scalpel can automatically disable itself based on the current or base branch name. This is useful
 for CI systems where incremental builds should be skipped on main, release, or maintenance branches:
 
-```
+```bash
 # Disable on main and release branches
 -Dscalpel.disableOnBranch=main,release/.*
 
@@ -315,7 +315,7 @@ By default, when Maven is invoked with `-pl` (selected projects), Scalpel trims 
 the `-pl` scope — this is usually the correct behavior. However, in CI downstream test
 jobs where `-pl` selects a specific test module, you may want to disable Scalpel entirely:
 
-```
+```bash
 # In CI downstream test jobs:
 mvn verify -pl integration-tests/maven -Dscalpel.disableOnSelectedProjects=true
 ```
@@ -328,7 +328,7 @@ fine-grained control over how these categories are treated:
 
 **Skip tests on upstream modules:**
 
-```
+```bash
 mvn verify -Dscalpel.skipTestsForUpstream=true
 ```
 
@@ -336,7 +336,7 @@ This builds upstream dependencies but skips their tests, since they weren't dire
 
 **Inject properties per category:**
 
-```
+```bash
 mvn verify -Dscalpel.upstreamArgs=skipITs=true -Dscalpel.downstreamArgs=skipITs=true
 ```
 
@@ -399,7 +399,7 @@ rather than a directory.
 
 **Before (GIB in `.mvn/maven.config`):**
 
-```
+```text
 -Dgib.referenceBranch=refs/remotes/origin/main
 -Dgib.disableIfBranchMatches=main,release/.*
 -Dgib.fetchReferenceBranch=true
@@ -412,7 +412,7 @@ rather than a directory.
 
 **After (Scalpel in `.mvn/maven.config`):**
 
-```
+```text
 -Dscalpel.baseBranch=origin/main
 -Dscalpel.disableOnBranch=main,release/.*
 -Dscalpel.fetchBaseBranch=true

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ comma-separated glob patterns:
   ```
 
 - **`scalpel.fullBuildTriggers`** — Force a full build if any changed file matches (default:
-  `.mvn/**`). See [Full Build Triggers](#full-build-triggers) below.
+  `.mvn/**`). See [Full Build Triggers](#full-build-triggers).
 
 - **`scalpel.disableTriggers`** — Disable Scalpel entirely if any changed file matches. Use this
   when certain changes (e.g. CI configuration) should always result in a full, unmodified build:

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -34,6 +34,10 @@ public class GitChangeDetector {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
+    public String getCurrentBranch(Repository repository) throws IOException {
+        return repository.getBranch();
+    }
+
     public ObjectId findMergeBase(Repository repository, String baseBranch, String head) throws IOException {
         ObjectId baseId = repository.resolve(baseBranch);
         if (baseId == null) {
@@ -106,6 +110,55 @@ public class GitChangeDetector {
                 loader.copyTo(out);
                 return out.toByteArray();
             }
+        }
+    }
+
+    public Set<String> getUncommittedFiles(Repository repository) throws IOException {
+        Set<String> files = new LinkedHashSet<>();
+        try (org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repository)) {
+            org.eclipse.jgit.api.Status status = git.status().call();
+            files.addAll(status.getModified());
+            files.addAll(status.getChanged());
+            files.addAll(status.getAdded());
+            files.addAll(status.getRemoved());
+        } catch (org.eclipse.jgit.api.errors.GitAPIException e) {
+            throw new IOException("Failed to get uncommitted files", e);
+        }
+        logger.debug("Uncommitted files: {}", files);
+        return files;
+    }
+
+    public Set<String> getUntrackedFiles(Repository repository) throws IOException {
+        Set<String> files = new LinkedHashSet<>();
+        try (org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repository)) {
+            org.eclipse.jgit.api.Status status = git.status().call();
+            files.addAll(status.getUntracked());
+        } catch (org.eclipse.jgit.api.errors.GitAPIException e) {
+            throw new IOException("Failed to get untracked files", e);
+        }
+        logger.debug("Untracked files: {}", files);
+        return files;
+    }
+
+    public void fetchBranch(Repository repository, String baseBranch) throws IOException {
+        // Parse "origin/main" → remote="origin", branch="main"
+        int slashIndex = baseBranch.indexOf('/');
+        if (slashIndex < 0) {
+            logger.debug("Cannot parse remote from baseBranch '{}', skipping fetch", baseBranch);
+            return;
+        }
+        String remote = baseBranch.substring(0, slashIndex);
+        String branch = baseBranch.substring(slashIndex + 1);
+        String refspec = "+refs/heads/" + branch + ":refs/remotes/" + remote + "/" + branch;
+
+        logger.info("Scalpel: Fetching {} from {}", branch, remote);
+        try (org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repository)) {
+            git.fetch()
+                    .setRemote(remote)
+                    .setRefSpecs(new org.eclipse.jgit.transport.RefSpec(refspec))
+                    .call();
+        } catch (org.eclipse.jgit.api.errors.GitAPIException e) {
+            throw new IOException("Failed to fetch " + baseBranch, e);
         }
     }
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -25,6 +25,25 @@ public final class ScalpelConfiguration {
     public static final String FAIL_SAFE = PREFIX + "failSafe";
     public static final String MODE = PREFIX + "mode";
 
+    public static final String DISABLE_ON_BRANCH = PREFIX + "disableOnBranch";
+    public static final String DISABLE_ON_BASE_BRANCH = PREFIX + "disableOnBaseBranch";
+    public static final String EXCLUDE_PATHS = PREFIX + "excludePaths";
+    public static final String DISABLE_TRIGGERS = PREFIX + "disableTriggers";
+
+    public static final String DISABLE_ON_SELECTED_PROJECTS = PREFIX + "disableOnSelectedProjects";
+
+    public static final String SKIP_TESTS_FOR_UPSTREAM = PREFIX + "skipTestsForUpstream";
+    public static final String UPSTREAM_ARGS = PREFIX + "upstreamArgs";
+    public static final String DOWNSTREAM_ARGS = PREFIX + "downstreamArgs";
+
+    public static final String FETCH_BASE_BRANCH = PREFIX + "fetchBaseBranch";
+
+    public static final String UNCOMMITTED = PREFIX + "uncommitted";
+    public static final String UNTRACKED = PREFIX + "untracked";
+
+    public static final String FORCE_BUILD_MODULES = PREFIX + "forceBuildModules";
+    public static final String BUILD_ALL_IF_NO_CHANGES = PREFIX + "buildAllIfNoChanges";
+    public static final String IMPACTED_LOG = PREFIX + "impactedLog";
     public static final String REPORT_FILE = PREFIX + "reportFile";
 
     public static final String MODE_TRIM = "trim";
@@ -40,6 +59,20 @@ public final class ScalpelConfiguration {
     private final boolean alsoMake;
     private final boolean alsoMakeDependents;
     private final List<String> fullBuildTriggers;
+    private final List<String> disableOnBranch;
+    private final List<String> disableOnBaseBranch;
+    private final List<String> excludePaths;
+    private final List<String> disableTriggers;
+    private final boolean disableOnSelectedProjects;
+    private final boolean fetchBaseBranch;
+    private final boolean skipTestsForUpstream;
+    private final List<String> upstreamArgs;
+    private final List<String> downstreamArgs;
+    private final boolean uncommitted;
+    private final boolean untracked;
+    private final List<String> forceBuildModules;
+    private final boolean buildAllIfNoChanges;
+    private final String impactedLog;
     private final boolean failSafe;
     private final String mode;
     private final String reportFile;
@@ -51,6 +84,20 @@ public final class ScalpelConfiguration {
             boolean alsoMake,
             boolean alsoMakeDependents,
             List<String> fullBuildTriggers,
+            List<String> disableOnBranch,
+            List<String> disableOnBaseBranch,
+            List<String> excludePaths,
+            List<String> disableTriggers,
+            boolean disableOnSelectedProjects,
+            boolean fetchBaseBranch,
+            boolean skipTestsForUpstream,
+            List<String> upstreamArgs,
+            List<String> downstreamArgs,
+            boolean uncommitted,
+            boolean untracked,
+            List<String> forceBuildModules,
+            boolean buildAllIfNoChanges,
+            String impactedLog,
             boolean failSafe,
             String mode,
             String reportFile) {
@@ -60,6 +107,20 @@ public final class ScalpelConfiguration {
         this.alsoMake = alsoMake;
         this.alsoMakeDependents = alsoMakeDependents;
         this.fullBuildTriggers = fullBuildTriggers;
+        this.disableOnBranch = disableOnBranch;
+        this.disableOnBaseBranch = disableOnBaseBranch;
+        this.excludePaths = excludePaths;
+        this.disableTriggers = disableTriggers;
+        this.disableOnSelectedProjects = disableOnSelectedProjects;
+        this.fetchBaseBranch = fetchBaseBranch;
+        this.skipTestsForUpstream = skipTestsForUpstream;
+        this.upstreamArgs = upstreamArgs;
+        this.downstreamArgs = downstreamArgs;
+        this.uncommitted = uncommitted;
+        this.untracked = untracked;
+        this.forceBuildModules = forceBuildModules;
+        this.buildAllIfNoChanges = buildAllIfNoChanges;
+        this.impactedLog = impactedLog;
         this.failSafe = failSafe;
         this.mode = mode;
         this.reportFile = reportFile;
@@ -75,15 +136,50 @@ public final class ScalpelConfiguration {
         boolean alsoMake = Boolean.parseBoolean(resolve(system, user, ALSO_MAKE, "true"));
         boolean alsoMakeDependents = Boolean.parseBoolean(resolve(system, user, ALSO_MAKE_DEPENDENTS, "true"));
         String triggers = resolve(system, user, FULL_BUILD_TRIGGERS, DEFAULT_FULL_BUILD_TRIGGERS);
-        List<String> fullBuildTriggers = triggers != null && !triggers.isEmpty()
-                ? Arrays.asList(triggers.split(","))
-                : Collections.<String>emptyList();
+        List<String> fullBuildTriggers = parseList(triggers);
+        List<String> disableOnBranch = parseList(resolve(system, user, DISABLE_ON_BRANCH, null));
+        List<String> disableOnBaseBranch = parseList(resolve(system, user, DISABLE_ON_BASE_BRANCH, null));
+        List<String> excludePaths = parseList(resolve(system, user, EXCLUDE_PATHS, null));
+        List<String> disableTriggers = parseList(resolve(system, user, DISABLE_TRIGGERS, null));
+        boolean disableOnSelectedProjects =
+                Boolean.parseBoolean(resolve(system, user, DISABLE_ON_SELECTED_PROJECTS, "false"));
+        boolean fetchBaseBranch = Boolean.parseBoolean(resolve(system, user, FETCH_BASE_BRANCH, "false"));
+        boolean skipTestsForUpstream = Boolean.parseBoolean(resolve(system, user, SKIP_TESTS_FOR_UPSTREAM, "false"));
+        List<String> upstreamArgs = parseList(resolve(system, user, UPSTREAM_ARGS, null));
+        List<String> downstreamArgs = parseList(resolve(system, user, DOWNSTREAM_ARGS, null));
+        boolean uncommitted = Boolean.parseBoolean(resolve(system, user, UNCOMMITTED, "false"));
+        boolean untracked = Boolean.parseBoolean(resolve(system, user, UNTRACKED, "false"));
+        List<String> forceBuildModules = parseList(resolve(system, user, FORCE_BUILD_MODULES, null));
+        boolean buildAllIfNoChanges = Boolean.parseBoolean(resolve(system, user, BUILD_ALL_IF_NO_CHANGES, "false"));
+        String impactedLog = resolve(system, user, IMPACTED_LOG, null);
         boolean failSafe = Boolean.parseBoolean(resolve(system, user, FAIL_SAFE, "true"));
         String mode = resolve(system, user, MODE, MODE_TRIM);
         String reportFile = resolve(system, user, REPORT_FILE, DEFAULT_REPORT_FILE);
 
         return new ScalpelConfiguration(
-                enabled, baseBranch, head, alsoMake, alsoMakeDependents, fullBuildTriggers, failSafe, mode, reportFile);
+                enabled,
+                baseBranch,
+                head,
+                alsoMake,
+                alsoMakeDependents,
+                fullBuildTriggers,
+                disableOnBranch,
+                disableOnBaseBranch,
+                excludePaths,
+                disableTriggers,
+                disableOnSelectedProjects,
+                fetchBaseBranch,
+                skipTestsForUpstream,
+                upstreamArgs,
+                downstreamArgs,
+                uncommitted,
+                untracked,
+                forceBuildModules,
+                buildAllIfNoChanges,
+                impactedLog,
+                failSafe,
+                mode,
+                reportFile);
     }
 
     private static String resolve(Properties system, Properties user, String key, String defaultValue) {
@@ -96,6 +192,13 @@ public final class ScalpelConfiguration {
             return value;
         }
         return defaultValue;
+    }
+
+    private static List<String> parseList(String value) {
+        if (value == null || value.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(value.split(","));
     }
 
     private static String detectBaseBranch(Properties system) {
@@ -141,6 +244,62 @@ public final class ScalpelConfiguration {
         return fullBuildTriggers;
     }
 
+    public List<String> getDisableOnBranch() {
+        return disableOnBranch;
+    }
+
+    public List<String> getDisableOnBaseBranch() {
+        return disableOnBaseBranch;
+    }
+
+    public List<String> getExcludePaths() {
+        return excludePaths;
+    }
+
+    public List<String> getDisableTriggers() {
+        return disableTriggers;
+    }
+
+    public boolean isDisableOnSelectedProjects() {
+        return disableOnSelectedProjects;
+    }
+
+    public boolean isFetchBaseBranch() {
+        return fetchBaseBranch;
+    }
+
+    public boolean isSkipTestsForUpstream() {
+        return skipTestsForUpstream;
+    }
+
+    public List<String> getUpstreamArgs() {
+        return upstreamArgs;
+    }
+
+    public List<String> getDownstreamArgs() {
+        return downstreamArgs;
+    }
+
+    public boolean isUncommitted() {
+        return uncommitted;
+    }
+
+    public boolean isUntracked() {
+        return untracked;
+    }
+
+    public List<String> getForceBuildModules() {
+        return forceBuildModules;
+    }
+
+    public boolean isBuildAllIfNoChanges() {
+        return buildAllIfNoChanges;
+    }
+
+    public String getImpactedLog() {
+        return impactedLog;
+    }
+
     public boolean isFailSafe() {
         return failSafe;
     }
@@ -175,6 +334,20 @@ public final class ScalpelConfiguration {
                 + ", alsoMake=" + alsoMake
                 + ", alsoMakeDependents=" + alsoMakeDependents
                 + ", fullBuildTriggers=" + fullBuildTriggers
+                + ", disableOnBranch=" + disableOnBranch
+                + ", disableOnBaseBranch=" + disableOnBaseBranch
+                + ", excludePaths=" + excludePaths
+                + ", disableTriggers=" + disableTriggers
+                + ", disableOnSelectedProjects=" + disableOnSelectedProjects
+                + ", fetchBaseBranch=" + fetchBaseBranch
+                + ", skipTestsForUpstream=" + skipTestsForUpstream
+                + ", upstreamArgs=" + upstreamArgs
+                + ", downstreamArgs=" + downstreamArgs
+                + ", uncommitted=" + uncommitted
+                + ", untracked=" + untracked
+                + ", forceBuildModules=" + forceBuildModules
+                + ", buildAllIfNoChanges=" + buildAllIfNoChanges
+                + ", impactedLog='" + impactedLog + '\''
                 + ", failSafe=" + failSafe
                 + ", reportFile='" + reportFile + '\''
                 + '}';

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -63,10 +63,63 @@ public class ScalpelCore {
         }
 
         try {
+            // Check branch-based disable conditions
+            if (!config.getDisableOnBranch().isEmpty()) {
+                String currentBranch = gitChangeDetector.getCurrentBranch(repository);
+                if (currentBranch != null) {
+                    for (String pattern : config.getDisableOnBranch()) {
+                        if (currentBranch.matches(pattern.trim())) {
+                            logger.info(
+                                    "Scalpel: Disabled because current branch '{}' matches pattern '{}'",
+                                    currentBranch,
+                                    pattern);
+                            return null;
+                        }
+                    }
+                }
+            }
+
             String baseBranch = config.getBaseBranch();
+
+            if (!config.getDisableOnBaseBranch().isEmpty() && baseBranch != null) {
+                // Strip remote prefix for matching (e.g., "origin/main" → "main")
+                String baseBranchName = baseBranch;
+                int slashIndex = baseBranchName.indexOf('/');
+                if (slashIndex >= 0) {
+                    baseBranchName = baseBranchName.substring(slashIndex + 1);
+                }
+                for (String pattern : config.getDisableOnBaseBranch()) {
+                    if (baseBranchName.matches(pattern.trim())) {
+                        logger.info(
+                                "Scalpel: Disabled because base branch '{}' matches pattern '{}'", baseBranch, pattern);
+                        return null;
+                    }
+                }
+            }
+
             if (baseBranch == null) {
                 logger.info("Scalpel: No base branch configured or detected, building all modules");
                 return null;
+            }
+
+            // Fetch base branch if configured and ref cannot be resolved
+            if (config.isFetchBaseBranch()) {
+                ObjectId baseId = repository.resolve(baseBranch);
+                if (baseId == null) {
+                    try {
+                        gitChangeDetector.fetchBranch(repository, baseBranch);
+                    } catch (IOException e) {
+                        if (config.isFailSafe()) {
+                            logger.warn(
+                                    "Scalpel: Failed to fetch {}, building all modules: {}",
+                                    baseBranch,
+                                    e.getMessage());
+                            return null;
+                        } else {
+                            throw new ScalpelException("Failed to fetch " + baseBranch, e);
+                        }
+                    }
+                }
             }
 
             String head = config.getHead();
@@ -85,6 +138,22 @@ public class ScalpelCore {
 
             ObjectId headId = repository.resolve(head);
             Set<String> changedFiles = gitChangeDetector.getChangedFiles(repository, mergeBase, headId);
+
+            // Merge in uncommitted/untracked files if configured
+            if (config.isUncommitted()) {
+                Set<String> uncommittedFiles = gitChangeDetector.getUncommittedFiles(repository);
+                if (!uncommittedFiles.isEmpty()) {
+                    logger.info("Scalpel: {} uncommitted files detected", uncommittedFiles.size());
+                    changedFiles.addAll(uncommittedFiles);
+                }
+            }
+            if (config.isUntracked()) {
+                Set<String> untrackedFiles = gitChangeDetector.getUntrackedFiles(repository);
+                if (!untrackedFiles.isEmpty()) {
+                    logger.info("Scalpel: {} untracked files detected", untrackedFiles.size());
+                    changedFiles.addAll(untrackedFiles);
+                }
+            }
 
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: No changes detected between {} and {}", baseBranch, head);

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -21,6 +21,11 @@ public final class ScalpelReport {
     public static final String REASON_POM_CHANGE = "POM_CHANGE";
     public static final String REASON_TRANSITIVE_DEPENDENCY = "TRANSITIVE_DEPENDENCY";
     public static final String REASON_MANAGED_PLUGIN = "MANAGED_PLUGIN";
+    public static final String REASON_FORCE_BUILD = "FORCE_BUILD";
+
+    public static final String CATEGORY_DIRECT = "DIRECT";
+    public static final String CATEGORY_UPSTREAM = "UPSTREAM";
+    public static final String CATEGORY_DOWNSTREAM = "DOWNSTREAM";
 
     private final String baseBranch;
     private final boolean fullBuildTriggered;
@@ -55,12 +60,18 @@ public final class ScalpelReport {
         private final String artifactId;
         private final String path;
         private final List<String> reasons;
+        private final String category;
 
         public AffectedModule(String groupId, String artifactId, String path, List<String> reasons) {
+            this(groupId, artifactId, path, reasons, null);
+        }
+
+        public AffectedModule(String groupId, String artifactId, String path, List<String> reasons, String category) {
             this.groupId = groupId;
             this.artifactId = artifactId;
             this.path = path;
             this.reasons = reasons;
+            this.category = category;
         }
 
         public String getGroupId() {
@@ -77,6 +88,10 @@ public final class ScalpelReport {
 
         public List<String> getReasons() {
             return reasons;
+        }
+
+        public String getCategory() {
+            return category;
         }
     }
 
@@ -113,9 +128,15 @@ public final class ScalpelReport {
                         .append(jsonString(m.artifactId))
                         .append(",\n");
                 sb.append("      \"path\": ").append(jsonString(m.path)).append(",\n");
-                sb.append("      \"reasons\": ")
-                        .append(jsonStringArray(m.reasons))
-                        .append("\n");
+                sb.append("      \"reasons\": ").append(jsonStringArray(m.reasons));
+                if (m.category != null) {
+                    sb.append(",\n");
+                    sb.append("      \"category\": ")
+                            .append(jsonString(m.category))
+                            .append("\n");
+                } else {
+                    sb.append("\n");
+                }
                 sb.append("    }");
                 if (i < affectedModules.size() - 1) {
                     sb.append(",");

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -22,6 +22,8 @@ public final class ScalpelReport {
     public static final String REASON_TRANSITIVE_DEPENDENCY = "TRANSITIVE_DEPENDENCY";
     public static final String REASON_MANAGED_PLUGIN = "MANAGED_PLUGIN";
     public static final String REASON_FORCE_BUILD = "FORCE_BUILD";
+    public static final String REASON_UPSTREAM_DEPENDENCY = "UPSTREAM_DEPENDENCY";
+    public static final String REASON_DOWNSTREAM_DEPENDENT = "DOWNSTREAM_DEPENDENT";
 
     public static final String CATEGORY_DIRECT = "DIRECT";
     public static final String CATEGORY_UPSTREAM = "UPSTREAM";

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -25,17 +25,23 @@ class ReactorTrimmer {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    public List<MavenProject> computeBuildSet(
+    public TrimResult computeBuildSet(
             Set<MavenProject> directlyAffected, ProjectDependencyGraph graph, ScalpelConfiguration config) {
 
         Set<MavenProject> buildSet = new LinkedHashSet<>(directlyAffected);
+        Set<MavenProject> downstreamOnly = new LinkedHashSet<>();
+        Set<MavenProject> upstreamOnly = new LinkedHashSet<>();
 
         if (config.isAlsoMakeDependents()) {
             for (MavenProject project : new ArrayList<>(directlyAffected)) {
                 List<MavenProject> downstream = graph.getDownstreamProjects(project, true);
                 if (!downstream.isEmpty()) {
                     logger.debug("Adding downstream dependents of {}: {}", key(project), keys(downstream));
-                    buildSet.addAll(downstream);
+                    for (MavenProject ds : downstream) {
+                        if (!directlyAffected.contains(ds) && buildSet.add(ds)) {
+                            downstreamOnly.add(ds);
+                        }
+                    }
                 }
             }
         }
@@ -45,7 +51,11 @@ class ReactorTrimmer {
                 List<MavenProject> upstream = graph.getUpstreamProjects(project, true);
                 if (!upstream.isEmpty()) {
                     logger.debug("Adding upstream dependencies of {}: {}", key(project), keys(upstream));
-                    buildSet.addAll(upstream);
+                    for (MavenProject us : upstream) {
+                        if (!directlyAffected.contains(us) && !downstreamOnly.contains(us) && buildSet.add(us)) {
+                            upstreamOnly.add(us);
+                        }
+                    }
                 }
             }
         }
@@ -59,7 +69,7 @@ class ReactorTrimmer {
             }
         }
 
-        return result;
+        return new TrimResult(result, directlyAffected, upstreamOnly, downstreamOnly);
     }
 
     private static String key(MavenProject project) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -47,6 +47,9 @@ import org.slf4j.LoggerFactory;
 @Named
 class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
+    private static final String MAVEN_TEST_SKIP = "maven.test.skip";
+    private static final String GLOB_PREFIX = "glob:";
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ScalpelCore scalpelCore;
     private final ModuleMapper moduleMapper;
@@ -73,8 +76,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         ScalpelConfiguration config =
                 ScalpelConfiguration.fromProperties(session.getSystemProperties(), session.getUserProperties());
 
+        String version = Version.version();
+
         if (!config.isEnabled()) {
-            logger.info("Scalpel {} is disabled", Version.version());
+            logger.info("Scalpel {} is disabled", version);
             return;
         }
 
@@ -89,12 +94,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         if (config.isDisableOnSelectedProjects()) {
             List<String> selectedProjects = session.getRequest().getSelectedProjects();
             if (selectedProjects != null && !selectedProjects.isEmpty()) {
-                logger.info("Scalpel {} disabled due to -pl project selection", Version.version());
+                logger.info("Scalpel {} disabled due to -pl project selection", version);
                 return;
             }
         }
 
-        logger.info("Scalpel {} activated (mode={})", Version.version(), config.getMode());
+        logger.info("Scalpel {} activated (mode={})", version, config.getMode());
         logger.debug("Configuration: {}", config);
 
         Path reactorRoot = session.getRequest().getMultiModuleProjectDirectory().toPath();
@@ -127,7 +132,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Check disable triggers (bail out entirely if any changed file matches)
             for (String pattern : config.getDisableTriggers()) {
-                PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern.trim());
+                PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern.trim());
                 for (String changedFile : changedFiles) {
                     if (matcher.matches(Paths.get(changedFile))) {
                         logger.info(
@@ -143,7 +148,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (!config.getExcludePaths().isEmpty()) {
                 List<PathMatcher> excludeMatchers = new ArrayList<>();
                 for (String pattern : config.getExcludePaths()) {
-                    excludeMatchers.add(FileSystems.getDefault().getPathMatcher("glob:" + pattern.trim()));
+                    excludeMatchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern.trim()));
                 }
                 Set<String> filtered = new LinkedHashSet<>();
                 for (String file : changedFiles) {
@@ -171,7 +176,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Check full build triggers
             for (String pattern : config.getFullBuildTriggers()) {
-                PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern.trim());
+                PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern.trim());
                 for (String changedFile : changedFiles) {
                     if (matcher.matches(Paths.get(changedFile))) {
                         logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
@@ -375,7 +380,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             } else if (config.isSkipTestsForUpstream()
                     && trimResult.getUpstreamOnly().contains(project)) {
                 // Skip tests on upstream-only modules if configured
-                project.getProperties().setProperty("maven.test.skip", "true");
+                project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
             } else {
                 // Downstream modules run tests by default
@@ -402,7 +407,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Skip tests on this project
-            project.getProperties().setProperty("maven.test.skip", "true");
+            project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
             skippedProjects.add(project);
         }
 
@@ -549,7 +554,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             project.getGroupId(),
                             project.getArtifactId(),
                             path,
-                            Collections.singletonList("UPSTREAM_DEPENDENCY"),
+                            Collections.singletonList(ScalpelReport.REASON_UPSTREAM_DEPENDENCY),
                             ScalpelReport.CATEGORY_UPSTREAM));
                 }
             }
@@ -560,7 +565,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             project.getGroupId(),
                             project.getArtifactId(),
                             path,
-                            Collections.singletonList("DOWNSTREAM_DEPENDENT"),
+                            Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
                             ScalpelReport.CATEGORY_DOWNSTREAM));
                 }
             }
@@ -590,6 +595,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 for (MavenProject project : trimResult.getUpstreamOnly()) {
                     project.getProperties().setProperty(parts[0], parts[1]);
                 }
+            } else {
+                logger.warn("Scalpel: Malformed upstreamArgs entry '{}', expected key=value format", arg);
             }
         }
         for (String arg : config.getDownstreamArgs()) {
@@ -598,13 +605,15 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 for (MavenProject project : trimResult.getDownstreamOnly()) {
                     project.getProperties().setProperty(parts[0], parts[1]);
                 }
+            } else {
+                logger.warn("Scalpel: Malformed downstreamArgs entry '{}', expected key=value format", arg);
             }
         }
     }
 
     private void skipTestsOnAll(List<MavenProject> projects) {
         for (MavenProject project : projects) {
-            project.getProperties().setProperty("maven.test.skip", "true");
+            project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
         }
     }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -452,7 +452,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private void writeImpactedLog(ScalpelConfiguration config, Path reactorRoot, Set<MavenProject> affectedModules)
             throws MavenExecutionException {
-        Path logPath = reactorRoot.resolve(config.getImpactedLog());
+        String impactedLog = config.getImpactedLog();
+        if (impactedLog == null || impactedLog.trim().isEmpty()) {
+            return;
+        }
+        Path logPath = reactorRoot.resolve(impactedLog);
         try {
             java.nio.file.Files.createDirectories(logPath.getParent());
             List<String> lines = new ArrayList<>();

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -85,6 +85,15 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             return;
         }
 
+        // Check if -pl is active and disableOnSelectedProjects is set
+        if (config.isDisableOnSelectedProjects()) {
+            List<String> selectedProjects = session.getRequest().getSelectedProjects();
+            if (selectedProjects != null && !selectedProjects.isEmpty()) {
+                logger.info("Scalpel {} disabled due to -pl project selection", Version.version());
+                return;
+            }
+        }
+
         logger.info("Scalpel {} activated (mode={})", Version.version(), config.getMode());
         logger.debug("Configuration: {}", config);
 
@@ -108,10 +117,57 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             Set<String> changedFiles = result.getChangedFiles();
             if (changedFiles.isEmpty()) {
+                if (config.isBuildAllIfNoChanges()) {
+                    logger.info("Scalpel: No changes detected, building all modules (buildAllIfNoChanges=true)");
+                }
                 return;
             }
 
             logger.info("Scalpel: {} changed files detected", changedFiles.size());
+
+            // Check disable triggers (bail out entirely if any changed file matches)
+            for (String pattern : config.getDisableTriggers()) {
+                PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern.trim());
+                for (String changedFile : changedFiles) {
+                    if (matcher.matches(Paths.get(changedFile))) {
+                        logger.info(
+                                "Scalpel: Disabled due to change in {} (matches disable trigger {})",
+                                changedFile,
+                                pattern);
+                        return;
+                    }
+                }
+            }
+
+            // Filter out excluded paths
+            if (!config.getExcludePaths().isEmpty()) {
+                List<PathMatcher> excludeMatchers = new ArrayList<>();
+                for (String pattern : config.getExcludePaths()) {
+                    excludeMatchers.add(FileSystems.getDefault().getPathMatcher("glob:" + pattern.trim()));
+                }
+                Set<String> filtered = new LinkedHashSet<>();
+                for (String file : changedFiles) {
+                    boolean excluded = false;
+                    for (PathMatcher matcher : excludeMatchers) {
+                        if (matcher.matches(Paths.get(file))) {
+                            excluded = true;
+                            break;
+                        }
+                    }
+                    if (!excluded) {
+                        filtered.add(file);
+                    }
+                }
+                int excludedCount = changedFiles.size() - filtered.size();
+                if (excludedCount > 0) {
+                    logger.info("Scalpel: {} files excluded by path filters", excludedCount);
+                }
+                changedFiles = filtered;
+                if (changedFiles.isEmpty()) {
+                    logger.info("Scalpel: All changed files excluded by path filters, building all modules");
+                    return;
+                }
+            }
 
             // Check full build triggers
             for (String pattern : config.getFullBuildTriggers()) {
@@ -179,6 +235,24 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             directlyAffected.addAll(affectedBySource);
             directlyAffected.addAll(affectedByPom);
 
+            // Force-include modules matching forceBuildModules patterns
+            Set<MavenProject> forceIncluded = new LinkedHashSet<>();
+            if (!config.getForceBuildModules().isEmpty()) {
+                for (MavenProject project : allProjects) {
+                    if (directlyAffected.contains(project)) {
+                        continue;
+                    }
+                    for (String pattern : config.getForceBuildModules()) {
+                        if (project.getArtifactId().matches(pattern.trim())) {
+                            directlyAffected.add(project);
+                            forceIncluded.add(project);
+                            logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
+                            break;
+                        }
+                    }
+                }
+            }
+
             if (directlyAffected.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
                 if (config.isModeReport()) {
@@ -192,7 +266,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             Collections.<MavenProject>emptySet(),
                             Collections.<MavenProject>emptySet(),
                             Collections.<MavenProject>emptySet(),
-                            Collections.<MavenProject, List<String>>emptyMap());
+                            Collections.<MavenProject>emptySet(),
+                            Collections.<MavenProject, List<String>>emptyMap(),
+                            null);
                 } else if (config.isModeSkipTests()) {
                     skipTestsOnAll(allProjects);
                 }
@@ -204,7 +280,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     directlyAffected.size(),
                     projectKeys(directlyAffected));
 
+            // Write impacted module log if configured
+            if (config.getImpactedLog() != null) {
+                writeImpactedLog(config, reactorRoot, directlyAffected);
+            }
+
             if (config.isModeReport()) {
+                // Compute upstream/downstream categorization for report enrichment
+                TrimResult trimResult =
+                        reactorTrimmer.computeBuildSet(directlyAffected, session.getProjectDependencyGraph(), config);
+
                 // Check remaining modules for transitive dependency/plugin impact
                 Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
                 if (!changedManagedDepGAs.isEmpty() || !changedManagedPluginGAs.isEmpty()) {
@@ -242,24 +327,28 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         directlyAffected,
                         affectedBySource,
                         affectedByPom,
-                        transitivelyAffected);
+                        forceIncluded,
+                        transitivelyAffected,
+                        trimResult);
                 return;
             }
 
             // Compute full build set with upstream/downstream
-            List<MavenProject> buildSet =
+            TrimResult trimResult =
                     reactorTrimmer.computeBuildSet(directlyAffected, session.getProjectDependencyGraph(), config);
 
             if (config.isModeSkipTests()) {
-                applySkipTests(session, allProjects, buildSet, changedManagedDepGAs, changedManagedPluginGAs);
+                applySkipTests(session, allProjects, trimResult, config, changedManagedDepGAs, changedManagedPluginGAs);
             } else {
                 // trim mode: remove unaffected projects from reactor
                 logger.info(
                         "Scalpel: Building {} of {} modules: {}",
-                        buildSet.size(),
+                        trimResult.getBuildSet().size(),
                         allProjects.size(),
-                        projectKeys(buildSet));
-                session.setProjects(buildSet);
+                        projectKeys(trimResult.getBuildSet()));
+                session.setProjects(trimResult.getBuildSet());
+                // Apply per-category args in trim mode
+                applyPerCategoryArgs(trimResult, config);
             }
 
         } catch (ScalpelException e) {
@@ -270,17 +359,33 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     private void applySkipTests(
             MavenSession session,
             List<MavenProject> allProjects,
-            List<MavenProject> buildSet,
+            TrimResult trimResult,
+            ScalpelConfiguration config,
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs) {
 
-        Set<MavenProject> buildSetLookup = new LinkedHashSet<>(buildSet);
-        List<MavenProject> testProjects = new ArrayList<>(buildSet);
+        Set<MavenProject> buildSetLookup = new LinkedHashSet<>(trimResult.getBuildSet());
+        List<MavenProject> testProjects = new ArrayList<>();
         List<MavenProject> skippedProjects = new ArrayList<>();
+
+        // Directly affected modules always run tests
+        for (MavenProject project : trimResult.getBuildSet()) {
+            if (trimResult.getDirectlyAffected().contains(project)) {
+                testProjects.add(project);
+            } else if (config.isSkipTestsForUpstream()
+                    && trimResult.getUpstreamOnly().contains(project)) {
+                // Skip tests on upstream-only modules if configured
+                project.getProperties().setProperty("maven.test.skip", "true");
+                skippedProjects.add(project);
+            } else {
+                // Downstream modules run tests by default
+                testProjects.add(project);
+            }
+        }
 
         for (MavenProject project : allProjects) {
             if (buildSetLookup.contains(project)) {
-                continue; // Already known to need tests
+                continue; // Already handled above
             }
 
             // Check effective build plugins against changed managed plugins
@@ -300,6 +405,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             project.getProperties().setProperty("maven.test.skip", "true");
             skippedProjects.add(project);
         }
+
+        // Apply per-category args
+        applyPerCategoryArgs(trimResult, config);
 
         logger.info(
                 "Scalpel: Testing {} of {} modules, skipping tests on {} modules: {}",
@@ -342,6 +450,22 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
+    private void writeImpactedLog(ScalpelConfiguration config, Path reactorRoot, Set<MavenProject> affectedModules)
+            throws MavenExecutionException {
+        Path logPath = reactorRoot.resolve(config.getImpactedLog());
+        try {
+            java.nio.file.Files.createDirectories(logPath.getParent());
+            List<String> lines = new ArrayList<>();
+            for (MavenProject project : affectedModules) {
+                lines.add(relativePath(reactorRoot, project));
+            }
+            java.nio.file.Files.write(logPath, lines, java.nio.charset.StandardCharsets.UTF_8);
+            logger.info("Scalpel: Impacted modules written to {}", config.getImpactedLog());
+        } catch (IOException e) {
+            throw new MavenExecutionException("Scalpel: Failed to write impacted log", e);
+        }
+    }
+
     private void writeFullBuildReport(
             ScalpelConfiguration config, Path reactorRoot, String triggerFile, Set<String> changedFiles)
             throws MavenExecutionException {
@@ -369,7 +493,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<MavenProject> directlyAffected,
             Set<MavenProject> affectedBySource,
             Set<MavenProject> affectedByPom,
-            Map<MavenProject, List<String>> transitivelyAffected)
+            Set<MavenProject> forceIncluded,
+            Map<MavenProject, List<String>> transitivelyAffected,
+            TrimResult trimResult)
             throws MavenExecutionException {
         ScalpelReport.Builder builder = ScalpelReport.builder()
                 .baseBranch(config.getBaseBranch())
@@ -388,15 +514,52 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (affectedByPom.contains(project)) {
                 reasons.add(ScalpelReport.REASON_POM_CHANGE);
             }
-            builder.addAffectedModule(
-                    new ScalpelReport.AffectedModule(project.getGroupId(), project.getArtifactId(), path, reasons));
+            if (forceIncluded.contains(project)) {
+                reasons.add(ScalpelReport.REASON_FORCE_BUILD);
+            }
+            builder.addAffectedModule(new ScalpelReport.AffectedModule(
+                    project.getGroupId(), project.getArtifactId(), path, reasons, ScalpelReport.CATEGORY_DIRECT));
         }
 
         for (Map.Entry<MavenProject, List<String>> entry : transitivelyAffected.entrySet()) {
             MavenProject project = entry.getKey();
             String path = relativePath(reactorRoot, project);
+            String category = null;
+            if (trimResult != null) {
+                if (trimResult.getUpstreamOnly().contains(project)) {
+                    category = ScalpelReport.CATEGORY_UPSTREAM;
+                } else if (trimResult.getDownstreamOnly().contains(project)) {
+                    category = ScalpelReport.CATEGORY_DOWNSTREAM;
+                }
+            }
             builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                    project.getGroupId(), project.getArtifactId(), path, entry.getValue()));
+                    project.getGroupId(), project.getArtifactId(), path, entry.getValue(), category));
+        }
+
+        // Add upstream/downstream modules from trimResult that aren't already covered
+        if (trimResult != null) {
+            for (MavenProject project : trimResult.getUpstreamOnly()) {
+                if (!directlyAffected.contains(project) && !transitivelyAffected.containsKey(project)) {
+                    String path = relativePath(reactorRoot, project);
+                    builder.addAffectedModule(new ScalpelReport.AffectedModule(
+                            project.getGroupId(),
+                            project.getArtifactId(),
+                            path,
+                            Collections.singletonList("UPSTREAM_DEPENDENCY"),
+                            ScalpelReport.CATEGORY_UPSTREAM));
+                }
+            }
+            for (MavenProject project : trimResult.getDownstreamOnly()) {
+                if (!directlyAffected.contains(project) && !transitivelyAffected.containsKey(project)) {
+                    String path = relativePath(reactorRoot, project);
+                    builder.addAffectedModule(new ScalpelReport.AffectedModule(
+                            project.getGroupId(),
+                            project.getArtifactId(),
+                            path,
+                            Collections.singletonList("DOWNSTREAM_DEPENDENT"),
+                            ScalpelReport.CATEGORY_DOWNSTREAM));
+                }
+            }
         }
 
         try {
@@ -414,6 +577,25 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .normalize()
                 .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
                 .toString();
+    }
+
+    private void applyPerCategoryArgs(TrimResult trimResult, ScalpelConfiguration config) {
+        for (String arg : config.getUpstreamArgs()) {
+            String[] parts = arg.trim().split("=", 2);
+            if (parts.length == 2) {
+                for (MavenProject project : trimResult.getUpstreamOnly()) {
+                    project.getProperties().setProperty(parts[0], parts[1]);
+                }
+            }
+        }
+        for (String arg : config.getDownstreamArgs()) {
+            String[] parts = arg.trim().split("=", 2);
+            if (parts.length == 2) {
+                for (MavenProject project : trimResult.getDownstreamOnly()) {
+                    project.getProperties().setProperty(parts[0], parts[1]);
+                }
+            }
+        }
     }
 
     private void skipTestsOnAll(List<MavenProject> projects) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Result of computing the build set, categorizing modules as directly affected,
+ * upstream-only (added via alsoMake), or downstream-only (added via alsoMakeDependents).
+ */
+final class TrimResult {
+
+    private final List<MavenProject> buildSet;
+    private final Set<MavenProject> directlyAffected;
+    private final Set<MavenProject> upstreamOnly;
+    private final Set<MavenProject> downstreamOnly;
+
+    TrimResult(
+            List<MavenProject> buildSet,
+            Set<MavenProject> directlyAffected,
+            Set<MavenProject> upstreamOnly,
+            Set<MavenProject> downstreamOnly) {
+        this.buildSet = buildSet;
+        this.directlyAffected = directlyAffected;
+        this.upstreamOnly = upstreamOnly;
+        this.downstreamOnly = downstreamOnly;
+    }
+
+    List<MavenProject> getBuildSet() {
+        return buildSet;
+    }
+
+    Set<MavenProject> getDirectlyAffected() {
+        return directlyAffected;
+    }
+
+    Set<MavenProject> getUpstreamOnly() {
+        return upstreamOnly;
+    }
+
+    Set<MavenProject> getDownstreamOnly() {
+        return downstreamOnly;
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +30,7 @@ import java.util.Properties;
 import java.util.Set;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
@@ -177,6 +179,11 @@ class ScalpelLifecycleParticipantTest {
         when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
 
         // Set report mode
         sysProps.setProperty("scalpel.mode", "report");
@@ -302,6 +309,11 @@ class ScalpelLifecycleParticipantTest {
         when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph2 = mock(ProjectDependencyGraph.class);
+        when(graph2.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph2.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph2.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph2);
 
         participant.afterProjectsRead(session);
 

--- a/it/extension3-its/pom.xml
+++ b/it/extension3-its/pom.xml
@@ -72,6 +72,9 @@
               <preBuildHookScript>setup</preBuildHookScript>
               <postBuildHookScript>verify</postBuildHookScript>
               <addTestClassPath>false</addTestClassPath>
+              <extraArtifacts>
+                <extraArtifact>eu.maveniverse.maven.scalpel:scalpel:${project.version}:pom</extraArtifact>
+              </extraArtifacts>
             </configuration>
             <executions>
               <execution>

--- a/it/extension3-its/src/it/branch-disable/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/branch-disable/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/branch-disable/invoker.properties
+++ b/it/extension3-its/src/it/branch-disable/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.disableOnBranch=main

--- a/it/extension3-its/src/it/branch-disable/module-a/pom.xml
+++ b/it/extension3-its/src/it/branch-disable/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.branchdisable</groupId>
+        <artifactId>branch-disable</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/branch-disable/module-b/pom.xml
+++ b/it/extension3-its/src/it/branch-disable/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.branchdisable</groupId>
+        <artifactId>branch-disable</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/branch-disable/pom.xml
+++ b/it/extension3-its/src/it/branch-disable/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.branchdisable</groupId>
+    <artifactId>branch-disable</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/branch-disable/setup.groovy
+++ b/it/extension3-its/src/it/branch-disable/setup.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo on 'main' branch (which matches the disableOnBranch pattern)
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init', '-b', 'main')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Add a source file change (would normally trigger trimming)
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension3-its/src/it/branch-disable/verify.groovy
+++ b/it/extension3-its/src/it/branch-disable/verify.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated but then disabled because we're on 'main'
+assert log.contains('Scalpel')
+assert log.contains("Disabled because current branch 'main' matches pattern") : \
+    "Expected Scalpel to be disabled due to branch matching, log: $log"
+
+// All modules should be built (no trimming happened)
+assert !log.contains('directly affected') : "Scalpel should not have computed affected modules"

--- a/it/extension3-its/src/it/disable-triggers/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/disable-triggers/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/disable-triggers/invoker.properties
+++ b/it/extension3-its/src/it/disable-triggers/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.disableTriggers=.github/**

--- a/it/extension3-its/src/it/disable-triggers/module-a/pom.xml
+++ b/it/extension3-its/src/it/disable-triggers/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.disabletriggers</groupId>
+        <artifactId>disable-triggers</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/disable-triggers/module-b/pom.xml
+++ b/it/extension3-its/src/it/disable-triggers/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.disabletriggers</groupId>
+        <artifactId>disable-triggers</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/disable-triggers/pom.xml
+++ b/it/extension3-its/src/it/disable-triggers/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.disabletriggers</groupId>
+    <artifactId>disable-triggers</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/disable-triggers/setup.groovy
+++ b/it/extension3-its/src/it/disable-triggers/setup.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, then change a .github file and a source file
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Add a .github/ci.yml file (should trigger disable)
+new File(dir, '.github/ci.yml').text = 'name: CI'
+// Also add a source file in module-b
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add CI config and source')

--- a/it/extension3-its/src/it/disable-triggers/setup.groovy
+++ b/it/extension3-its/src/it/disable-triggers/setup.groovy
@@ -27,6 +27,7 @@ exec('git', 'commit', '-m', 'initial')
 exec('git', 'branch', 'base')
 
 // Add a .github/ci.yml file (should trigger disable)
+new File(dir, '.github').mkdirs()
 new File(dir, '.github/ci.yml').text = 'name: CI'
 // Also add a source file in module-b
 new File(dir, 'module-b/src/main/java').mkdirs()

--- a/it/extension3-its/src/it/disable-triggers/verify.groovy
+++ b/it/extension3-its/src/it/disable-triggers/verify.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated but then disabled by the .github/** trigger
+assert log.contains('Scalpel')
+assert log.contains('Disabled due to change in') : "Expected Scalpel to be disabled by disable trigger"
+assert log.contains('.github/') : "Expected .github/ file to be mentioned as the trigger"
+
+// All modules should be built (no trimming happened)
+assert !log.contains('directly affected') : "Scalpel should not have computed affected modules"

--- a/it/extension3-its/src/it/exclude-paths/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/exclude-paths/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/exclude-paths/invoker.properties
+++ b/it/extension3-its/src/it/exclude-paths/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.excludePaths=*.md

--- a/it/extension3-its/src/it/exclude-paths/module-a/pom.xml
+++ b/it/extension3-its/src/it/exclude-paths/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.excludepaths</groupId>
+        <artifactId>exclude-paths</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/exclude-paths/module-b/pom.xml
+++ b/it/extension3-its/src/it/exclude-paths/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.excludepaths</groupId>
+        <artifactId>exclude-paths</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.excludepaths</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/exclude-paths/module-c/pom.xml
+++ b/it/extension3-its/src/it/exclude-paths/module-c/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.excludepaths</groupId>
+        <artifactId>exclude-paths</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/exclude-paths/pom.xml
+++ b/it/extension3-its/src/it/exclude-paths/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.excludepaths</groupId>
+    <artifactId>exclude-paths</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/exclude-paths/setup.groovy
+++ b/it/extension3-its/src/it/exclude-paths/setup.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, then add a README.md (excluded) and a source file in module-b
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Add a README.md at root (should be excluded by *.md pattern)
+new File(dir, 'README.md').text = '# Test Project'
+// Add a source file in module-b (should NOT be excluded)
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add README and source to module-b')

--- a/it/extension3-its/src/it/exclude-paths/verify.groovy
+++ b/it/extension3-its/src/it/exclude-paths/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated
+assert log.contains('Scalpel')
+
+// README.md should have been excluded by the *.md pattern
+assert log.contains('excluded by path filters') : "Expected files to be excluded by path filters"
+
+// module-b was changed (source) → it should be the only directly affected module
+assert log.contains('1 modules directly affected') : "Expected exactly 1 module directly affected"
+
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine != null : "Expected 'directly affected' log line"
+assert directlyAffectedLine.contains('module-b') : "module-b should be directly affected (source changed)"
+
+// module-c has no relationship to module-b → should NOT be in the build set
+def buildingLine = log.readLines().find { it.contains('Building') && it.contains('of 4 modules') }
+assert buildingLine != null : "Expected 'Building X of 4 modules' log line"
+assert buildingLine.contains('module-b') : "module-b should be in the build set"
+assert !buildingLine.contains('module-c') : "module-c should NOT be in the build set"

--- a/it/extension3-its/src/it/fetch-base-branch/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/fetch-base-branch/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/fetch-base-branch/invoker.properties
+++ b/it/extension3-its/src/it/fetch-base-branch/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=origin/base -Dscalpel.fetchBaseBranch=true

--- a/it/extension3-its/src/it/fetch-base-branch/module-a/pom.xml
+++ b/it/extension3-its/src/it/fetch-base-branch/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.fetchbasebranch</groupId>
+        <artifactId>fetch-base-branch</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/fetch-base-branch/module-b/pom.xml
+++ b/it/extension3-its/src/it/fetch-base-branch/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.fetchbasebranch</groupId>
+        <artifactId>fetch-base-branch</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/fetch-base-branch/pom.xml
+++ b/it/extension3-its/src/it/fetch-base-branch/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.fetchbasebranch</groupId>
+    <artifactId>fetch-base-branch</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/fetch-base-branch/setup.groovy
+++ b/it/extension3-its/src/it/fetch-base-branch/setup.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Create a bare remote repo and a working repo that uses it as origin.
+// Push initial state to origin, create a "base" branch on the remote,
+// then prune local tracking so origin/base doesn't exist locally.
+// With fetchBaseBranch=true, Scalpel should fetch it before change detection.
+def dir = basedir
+def remoteDir = new File(basedir.parentFile, 'fetch-base-branch-remote.git')
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+def execIn = { File workDir, String... args ->
+    def proc = args.execute(null, workDir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+// 1. Create a bare remote repo
+execIn(basedir.parentFile, 'git', 'init', '--bare', remoteDir.absolutePath)
+
+// 2. Initialize working repo
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'remote', 'add', 'origin', remoteDir.absolutePath)
+
+// 3. Commit initial state and push
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'push', 'origin', 'HEAD:refs/heads/main')
+
+// 4. Create "base" branch on remote (same commit as main)
+exec('git', 'push', 'origin', 'HEAD:refs/heads/base')
+
+// 5. Make sure origin/base does NOT exist locally
+// git push updates the remote tracking ref, so we must explicitly delete it
+exec('git', 'update-ref', '-d', 'refs/remotes/origin/base')
+
+// 6. Make a source change and commit on the working branch
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension3-its/src/it/fetch-base-branch/verify.groovy
+++ b/it/extension3-its/src/it/fetch-base-branch/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should be activated
+assert log.contains('Scalpel') : "Expected Scalpel to be activated"
+
+// Should have fetched the base branch
+assert log.contains('Fetching base from origin') : "Expected fetch log line, log: $log"
+
+// module-b should be directly affected (source changed)
+assert log.contains('directly affected') : "Expected directly affected modules"
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine.contains('module-b') : "module-b should be directly affected"

--- a/it/extension3-its/src/it/force-build/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/force-build/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/force-build/invoker.properties
+++ b/it/extension3-its/src/it/force-build/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.forceBuildModules=module-c

--- a/it/extension3-its/src/it/force-build/module-a/pom.xml
+++ b/it/extension3-its/src/it/force-build/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.forcebuild</groupId>
+        <artifactId>force-build</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/force-build/module-b/pom.xml
+++ b/it/extension3-its/src/it/force-build/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.forcebuild</groupId>
+        <artifactId>force-build</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/force-build/module-c/pom.xml
+++ b/it/extension3-its/src/it/force-build/module-c/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.forcebuild</groupId>
+        <artifactId>force-build</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/force-build/pom.xml
+++ b/it/extension3-its/src/it/force-build/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.forcebuild</groupId>
+    <artifactId>force-build</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/force-build/setup.groovy
+++ b/it/extension3-its/src/it/force-build/setup.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, modify source in module-a only
+// module-c has no changes but should be force-included via forceBuildModules
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Only change module-a source
+new File(dir, 'module-a/src/main/java').mkdirs()
+new File(dir, 'module-a/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-a')

--- a/it/extension3-its/src/it/force-build/verify.groovy
+++ b/it/extension3-its/src/it/force-build/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated
+assert log.contains('Scalpel')
+
+// module-a changed (source) + module-c force-included → 2 directly affected
+assert log.contains('2 modules directly affected') : "Expected 2 modules directly affected, log: $log"
+
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine.contains('module-a') : "module-a should be directly affected (source changed)"
+assert directlyAffectedLine.contains('module-c') : "module-c should be directly affected (force-included)"
+
+// module-c should be in the build set even though it has no changes
+def buildingLine = log.readLines().find { it.contains('Building') && it.contains('of 4 modules') }
+assert buildingLine != null : "Expected 'Building X of 4 modules' log line"
+assert buildingLine.contains('module-a') : "module-a should be in the build set"
+assert buildingLine.contains('module-c') : "module-c should be in the build set (force-included)"

--- a/it/extension3-its/src/it/impacted-log/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/impacted-log/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/impacted-log/invoker.properties
+++ b/it/extension3-its/src/it/impacted-log/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.impactedLog=target/scalpel-impacted.log

--- a/it/extension3-its/src/it/impacted-log/module-a/pom.xml
+++ b/it/extension3-its/src/it/impacted-log/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.impactedlog</groupId>
+        <artifactId>impacted-log</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/impacted-log/module-b/pom.xml
+++ b/it/extension3-its/src/it/impacted-log/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.impactedlog</groupId>
+        <artifactId>impacted-log</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.impactedlog</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/impacted-log/module-c/pom.xml
+++ b/it/extension3-its/src/it/impacted-log/module-c/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.impactedlog</groupId>
+        <artifactId>impacted-log</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/impacted-log/pom.xml
+++ b/it/extension3-its/src/it/impacted-log/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.impactedlog</groupId>
+    <artifactId>impacted-log</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/impacted-log/setup.groovy
+++ b/it/extension3-its/src/it/impacted-log/setup.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, modify source in module-b
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Create a source file in module-b
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension3-its/src/it/impacted-log/verify.groovy
+++ b/it/extension3-its/src/it/impacted-log/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated
+assert log.contains('Scalpel')
+assert log.contains('Impacted modules written to') : "Expected impacted log to be written"
+
+// Check the impacted log file
+File impactedLog = new File(basedir, 'target/scalpel-impacted.log')
+assert impactedLog.exists() : "Expected impacted log file at target/scalpel-impacted.log"
+
+List<String> lines = impactedLog.readLines()
+assert lines.contains('module-b') : "module-b should be in impacted log (source changed)"
+assert !lines.contains('module-a') : "module-a should NOT be in impacted log (not directly affected)"
+assert !lines.contains('module-c') : "module-c should NOT be in impacted log (not directly affected)"

--- a/it/extension3-its/src/it/pl-disable/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/pl-disable/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/pl-disable/invoker.properties
+++ b/it/extension3-its/src/it/pl-disable/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -pl module-b -Dscalpel.baseBranch=base -Dscalpel.disableOnSelectedProjects=true

--- a/it/extension3-its/src/it/pl-disable/module-a/pom.xml
+++ b/it/extension3-its/src/it/pl-disable/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.pldisable</groupId>
+        <artifactId>pl-disable</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/pl-disable/module-b/pom.xml
+++ b/it/extension3-its/src/it/pl-disable/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.pldisable</groupId>
+        <artifactId>pl-disable</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/pl-disable/pom.xml
+++ b/it/extension3-its/src/it/pl-disable/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.pldisable</groupId>
+    <artifactId>pl-disable</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/pl-disable/setup.groovy
+++ b/it/extension3-its/src/it/pl-disable/setup.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, modify source in module-a
+// Scalpel should be disabled because -pl is used with disableOnSelectedProjects=true
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Add a source file change
+new File(dir, 'module-a/src/main/java').mkdirs()
+new File(dir, 'module-a/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-a')

--- a/it/extension3-its/src/it/pl-disable/verify.groovy
+++ b/it/extension3-its/src/it/pl-disable/verify.groovy
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been disabled due to -pl selection
+assert log.contains('disabled due to -pl project selection') : \
+    "Expected Scalpel to be disabled due to -pl selection, log: $log"
+
+// Scalpel should NOT have computed affected modules
+assert !log.contains('directly affected') : "Scalpel should not have computed affected modules"

--- a/it/extension3-its/src/it/skip-tests-upstream/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/skip-tests-upstream/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/skip-tests-upstream/invoker.properties
+++ b/it/extension3-its/src/it/skip-tests-upstream/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=skip-tests -Dscalpel.skipTestsForUpstream=true

--- a/it/extension3-its/src/it/skip-tests-upstream/module-a/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-upstream/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skiptestsupstream</groupId>
+        <artifactId>skip-tests-upstream</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/skip-tests-upstream/module-b/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-upstream/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skiptestsupstream</groupId>
+        <artifactId>skip-tests-upstream</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.skiptestsupstream</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/skip-tests-upstream/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-upstream/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.skiptestsupstream</groupId>
+    <artifactId>skip-tests-upstream</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/skip-tests-upstream/setup.groovy
+++ b/it/extension3-its/src/it/skip-tests-upstream/setup.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// module-b depends on module-a.
+// Change source in module-b only. module-a is upstream (via alsoMake).
+// With skipTestsForUpstream=true, module-a should have tests skipped.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Only change module-b source
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Bar.java').text = 'public class Bar {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension3-its/src/it/skip-tests-upstream/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-upstream/verify.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should be activated in skip-tests mode
+assert log.contains('Scalpel') : "Expected Scalpel to be activated"
+assert log.contains('mode=skip-tests') : "Expected skip-tests mode"
+
+// module-b should be directly affected (source changed)
+assert log.contains('directly affected') : "Expected directly affected modules"
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine.contains('module-b') : "module-b should be directly affected"
+
+// In skip-tests mode, tests on upstream-only module-a should be skipped
+// The log should show that tests are skipped on some modules
+def skippingLine = log.readLines().find { it.contains('skipping tests on') }
+assert skippingLine != null : "Expected 'skipping tests on' log line"

--- a/it/extension3-its/src/it/skip-tests-upstream/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-upstream/verify.groovy
@@ -22,3 +22,4 @@ assert directlyAffectedLine.contains('module-b') : "module-b should be directly 
 // The log should show that tests are skipped on some modules
 def skippingLine = log.readLines().find { it.contains('skipping tests on') }
 assert skippingLine != null : "Expected 'skipping tests on' log line"
+assert skippingLine.contains('module-a') : "Expected module-a to have tests skipped, got: $skippingLine"

--- a/it/extension3-its/src/it/uncommitted/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/uncommitted/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/uncommitted/invoker.properties
+++ b/it/extension3-its/src/it/uncommitted/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.uncommitted=true

--- a/it/extension3-its/src/it/uncommitted/module-a/pom.xml
+++ b/it/extension3-its/src/it/uncommitted/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.uncommitted</groupId>
+        <artifactId>uncommitted</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/uncommitted/module-b/pom.xml
+++ b/it/extension3-its/src/it/uncommitted/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.uncommitted</groupId>
+        <artifactId>uncommitted</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/uncommitted/pom.xml
+++ b/it/extension3-its/src/it/uncommitted/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.uncommitted</groupId>
+    <artifactId>uncommitted</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/uncommitted/setup.groovy
+++ b/it/extension3-its/src/it/uncommitted/setup.groovy
@@ -31,6 +31,5 @@ exec('git', 'branch', 'base')
 // Create an uncommitted (but tracked) source file in module-b
 new File(dir, 'module-b/src/main/java').mkdirs()
 new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
-// Do NOT git add or commit - this is an untracked file, but we test uncommitted here
-// Let's stage it to make it "uncommitted" (added but not committed)
+// Stage the file to make it "uncommitted" (added but not committed)
 exec('git', 'add', 'module-b/src/main/java/Foo.java')

--- a/it/extension3-its/src/it/uncommitted/setup.groovy
+++ b/it/extension3-its/src/it/uncommitted/setup.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, commit everything as base.
+// Then modify a file in module-b WITHOUT committing.
+// With scalpel.uncommitted=true, module-b should be detected.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Create an uncommitted (but tracked) source file in module-b
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+// Do NOT git add or commit - this is an untracked file, but we test uncommitted here
+// Let's stage it to make it "uncommitted" (added but not committed)
+exec('git', 'add', 'module-b/src/main/java/Foo.java')

--- a/it/extension3-its/src/it/uncommitted/verify.groovy
+++ b/it/extension3-its/src/it/uncommitted/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should be activated
+assert log.contains('Scalpel') : "Expected Scalpel to be activated"
+
+// Should detect uncommitted files
+assert log.contains('uncommitted files detected') : "Expected uncommitted files to be detected, log: $log"
+
+// module-b should be directly affected
+assert log.contains('directly affected') : "Expected directly affected modules"
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine.contains('module-b') : "module-b should be directly affected (uncommitted source)"


### PR DESCRIPTION
## Summary

- Add 8 features (14 new properties) to match gitflow-incremental-builder capabilities for CI-heavy project adoption
- Enrich report mode with DIRECT/UPSTREAM/DOWNSTREAM module categorization and FORCE_BUILD reason
- Add GIB migration guide with property mapping table and before/after example

### New Properties

| Property | Type | Feature |
|----------|------|---------|
| `scalpel.disableOnBranch` | CSV regex | Branch-matching disable |
| `scalpel.disableOnBaseBranch` | CSV regex | Branch-matching disable |
| `scalpel.fetchBaseBranch` | boolean | Fetch base branch in CI shallow clones |
| `scalpel.disableOnSelectedProjects` | boolean | Disable when `-pl` is used |
| `scalpel.impactedLog` | String path | Flat file of impacted module paths |
| `scalpel.skipTestsForUpstream` | boolean | Skip tests on upstream-only modules |
| `scalpel.upstreamArgs` | CSV k=v | Inject properties on upstream modules |
| `scalpel.downstreamArgs` | CSV k=v | Inject properties on downstream modules |
| `scalpel.excludePaths` | CSV globs | Ignore matching changed files |
| `scalpel.disableTriggers` | CSV globs | Disable Scalpel if any file matches |
| `scalpel.uncommitted` | boolean | Include uncommitted changes |
| `scalpel.untracked` | boolean | Include untracked files |
| `scalpel.forceBuildModules` | CSV regex | Always include matching modules |
| `scalpel.buildAllIfNoChanges` | boolean | Full build when no changes detected |

## Test plan

- [x] All 16 integration tests pass (9 new + 7 existing)
- [x] Unit tests pass
- [x] Full build with `mvn clean verify -B -P run-its` succeeds
- [x] Each feature tested via Maven Invoker Plugin IT (setup.groovy + verify.groovy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch-based disabling (regex), base-branch fetching, and shallow-clone support
  * Path-based disable/exclude triggers, ordered filtering, and disable-on-selected-projects (-pl) behavior
  * Detect uncommitted/untracked changes, force-include modules, and build-all fallback
  * Build categorization (DIRECT / UPSTREAM / DOWNSTREAM), per-category args/skip-tests, and new FORCE_BUILD reason
  * Impacted-module line-delimited log emitted alongside JSON report; JSON now includes category per module

* **Documentation**
  * Expanded config reference, examples, migration guide, and local/CI usage sections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->