### PR TITLE
Restore JDK 8 compatibility

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,6 +36,7 @@
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- JGit -->

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -181,6 +181,7 @@ public class ScalpelCore {
         File gitDir = builder.getGitDir();
 
         // Handle git worktrees: .git may be a file containing "gitdir: <path>"
+        // JGit 5.x does not support worktrees natively, so we handle it manually
         if (gitDir == null) {
             File dotGit = findDotGit(reactorRoot.toFile());
             if (dotGit != null && dotGit.isFile()) {


### PR DESCRIPTION
## Summary
- Made `org.eclipse.sisu:org.eclipse.sisu.inject` `provided` scope in `core/pom.xml` — it was `compile` scope, pulling in `org.ow2.asm:asm:9.9.1` (Java 9+ class file version 53) as a transitive dependency. Sisu is provided by Maven at runtime, so this doesn't affect functionality.
- Clarified that the manual worktree handling in `ScalpelCore` is needed because JGit 5.x does not support worktrees natively.

## Test plan
- [x] Full build passes with `mvn verify -DskipTests`
- [x] Dependency tree confirms ASM is now `provided` scope
- [ ] CI matrix runs against JDK 8 (already in parent workflow defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration.

* **Documentation**
  * Added clarification on Git worktree support handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->