### PR TITLE
Add 6 advanced change detection features

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,13 @@ not as a replacement. It contains only directly affected modules (not upstream/d
 
 | Reason | Description |
 |--------|-------------|
-| `SOURCE_CHANGE` | A non-POM file changed in this module's directory |
+| `SOURCE_CHANGE` | A non-POM, non-test file changed in this module's directory |
+| `TEST_CHANGE` | Only test source files (`src/test/**`) changed; production artifact is unchanged |
 | `POM_CHANGE` | This module's POM is affected by a POM change (property, dependency, or plugin) |
-| `TRANSITIVE_DEPENDENCY` | A changed managed dependency reaches this module transitively |
+| `TRANSITIVE_DEPENDENCY` | A changed managed dependency reaches this module transitively (compile/runtime scope) |
+| `TRANSITIVE_DEPENDENCY_TEST` | A changed managed dependency reaches this module transitively via test scope only |
 | `MANAGED_PLUGIN` | This module uses a plugin whose managed version changed |
+| `DOWNSTREAM_TEST` | Included as a downstream dependent via test-scoped dependency only |
 | `FORCE_BUILD` | This module was force-included via `forceBuildModules` |
 
 **Affected module categories:**
@@ -352,11 +355,19 @@ aspects are compared:
 * Packaging
 * Dependencies and dependency management
 * Properties
-* Build configuration (plugins, plugin management, source directories)
+* Build configuration (plugins, plugin management, plugin executions, source directories)
+* Active profile sections (properties, dependencies, plugins within active profiles)
 * Repositories and plugin repositories
 
 This means cosmetic POM changes (reformatting, reordering, adding comments) won't trigger unnecessary
-rebuilds.
+rebuilds. Plugin configurations are compared semantically (Xpp3Dom structure), so whitespace-only
+changes in plugin XML configuration are ignored.
+
+### Profile Awareness
+
+Scalpel only considers changes inside profiles that are currently active. Changes to inactive profiles
+are ignored, preventing unnecessary rebuilds when modifying profiles that don't apply to the current
+build.
 
 ### Property Indirection
 
@@ -364,6 +375,14 @@ Scalpel resolves property indirection in managed dependencies and plugins. For e
 changes `<kafka.version>3.6.0</kafka.version>` to `<kafka.version>3.7.0</kafka.version>`, and a managed
 dependency uses `<version>${kafka.version}</version>`, Scalpel detects that the managed dependency's
 effective version changed and marks child modules that use it as affected.
+
+### Resource Filtering
+
+When a property changes in a parent POM, Scalpel checks child modules that have resource filtering
+enabled (`<filtering>true</filtering>`). If any filtered resource file contains a `${property}`
+reference to the changed property, the module is marked as affected. This ensures that changes to
+properties used in filtered resources (e.g. configuration files with `${app.version}`) trigger a
+rebuild of the affected module.
 
 ## Git Worktree Support
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -24,6 +24,9 @@ public final class ScalpelReport {
     public static final String REASON_FORCE_BUILD = "FORCE_BUILD";
     public static final String REASON_UPSTREAM_DEPENDENCY = "UPSTREAM_DEPENDENCY";
     public static final String REASON_DOWNSTREAM_DEPENDENT = "DOWNSTREAM_DEPENDENT";
+    public static final String REASON_TEST_CHANGE = "TEST_CHANGE";
+    public static final String REASON_DOWNSTREAM_TEST = "DOWNSTREAM_TEST";
+    public static final String REASON_TRANSITIVE_DEPENDENCY_TEST = "TRANSITIVE_DEPENDENCY_TEST";
 
     public static final String CATEGORY_DIRECT = "DIRECT";
     public static final String CATEGORY_UPSTREAM = "UPSTREAM";

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -10,8 +10,10 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -21,8 +23,33 @@ import org.apache.maven.project.MavenProject;
 @Named
 class ModuleMapper {
 
-    public Set<MavenProject> mapToProjects(Set<String> changedFiles, List<MavenProject> projects, Path reactorRoot) {
-        Set<MavenProject> affected = new LinkedHashSet<>();
+    static class Result {
+        private final Set<MavenProject> mainAffected;
+        private final Set<MavenProject> testOnlyAffected;
+
+        Result(Set<MavenProject> mainAffected, Set<MavenProject> testOnlyAffected) {
+            this.mainAffected = mainAffected;
+            this.testOnlyAffected = testOnlyAffected;
+        }
+
+        Set<MavenProject> getAllAffected() {
+            Set<MavenProject> all = new LinkedHashSet<>(mainAffected);
+            all.addAll(testOnlyAffected);
+            return all;
+        }
+
+        Set<MavenProject> getMainAffected() {
+            return mainAffected;
+        }
+
+        Set<MavenProject> getTestOnlyAffected() {
+            return testOnlyAffected;
+        }
+    }
+
+    public Result mapToProjectsClassified(Set<String> changedFiles, List<MavenProject> projects, Path reactorRoot) {
+        // Track for each project whether it has any main (non-test) source changes
+        Map<MavenProject, Boolean> hasMainChange = new LinkedHashMap<>();
 
         // Sort projects by basedir depth (most specific first)
         List<MavenProject> sortedProjects = new ArrayList<>(projects);
@@ -34,13 +61,43 @@ class ModuleMapper {
             for (MavenProject project : sortedProjects) {
                 String projectPath = getRelativePath(project, reactorRoot);
                 if (projectPath.isEmpty() || changedFile.startsWith(projectPath + "/")) {
-                    affected.add(project);
+                    boolean isTest = isTestPath(changedFile, projectPath);
+                    Boolean existing = hasMainChange.get(project);
+                    if (existing == null) {
+                        hasMainChange.put(project, !isTest);
+                    } else if (!isTest) {
+                        hasMainChange.put(project, Boolean.TRUE);
+                    }
                     break;
                 }
             }
         }
 
-        return affected;
+        Set<MavenProject> mainAffected = new LinkedHashSet<>();
+        Set<MavenProject> testOnlyAffected = new LinkedHashSet<>();
+        for (Map.Entry<MavenProject, Boolean> entry : hasMainChange.entrySet()) {
+            if (entry.getValue()) {
+                mainAffected.add(entry.getKey());
+            } else {
+                testOnlyAffected.add(entry.getKey());
+            }
+        }
+
+        return new Result(mainAffected, testOnlyAffected);
+    }
+
+    public Set<MavenProject> mapToProjects(Set<String> changedFiles, List<MavenProject> projects, Path reactorRoot) {
+        return mapToProjectsClassified(changedFiles, projects, reactorRoot).getAllAffected();
+    }
+
+    static boolean isTestPath(String changedFile, String projectPath) {
+        String relativeToProject;
+        if (projectPath.isEmpty()) {
+            relativeToProject = changedFile;
+        } else {
+            relativeToProject = changedFile.substring(projectPath.length() + 1);
+        }
+        return relativeToProject.startsWith("src/test/");
     }
 
     private String getRelativePath(MavenProject project, Path reactorRoot) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -10,9 +10,12 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -25,8 +28,12 @@ import javax.inject.Singleton;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.Resource;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,10 +196,6 @@ class PomChangeAnalyzer {
             parentSelfAffected = true;
         }
 
-        if (parentSelfAffected) {
-            affected.add(parentProject);
-        }
-
         // Find changed properties
         Set<String> changedProperties = diffProperties(oldModel.getProperties(), newModel.getProperties());
         allChangedProperties.addAll(changedProperties);
@@ -203,6 +206,21 @@ class PomChangeAnalyzer {
         // Find changed managed plugins (by groupId:artifactId)
         Set<String> changedManagedPlugins = diffPluginManagement(oldModel, newModel);
 
+        // Analyze active profile changes (inactive profile changes are ignored)
+        Set<String> activeProfileIds = getActiveProfileIds(parentProject);
+        parentSelfAffected = parentSelfAffected
+                || analyzeProfileChanges(
+                        oldModel,
+                        newModel,
+                        activeProfileIds,
+                        changedProperties,
+                        changedManagedDeps,
+                        changedManagedPlugins);
+
+        if (parentSelfAffected) {
+            affected.add(parentProject);
+        }
+
         // Resolve property indirection: if a managed dep/plugin uses a changed property
         // in its version (e.g. <version>${spring.version}</version>), it's effectively changed
         // even though the raw XML string didn't change
@@ -211,6 +229,23 @@ class PomChangeAnalyzer {
             augmentWithPropertyReferences(changedProperties, changedManagedDeps, getManagedDependencies(newModel));
             augmentWithPluginPropertyReferences(changedProperties, changedManagedPlugins, getManagedPlugins(oldModel));
             augmentWithPluginPropertyReferences(changedProperties, changedManagedPlugins, getManagedPlugins(newModel));
+            // Also check active profile-level managed deps/plugins for property indirection
+            for (Profile profile : safeProfiles(oldModel)) {
+                if (activeProfileIds.contains(profile.getId())) {
+                    augmentWithPropertyReferences(
+                            changedProperties, changedManagedDeps, getProfileManagedDependencies(profile));
+                    augmentWithPluginPropertyReferences(
+                            changedProperties, changedManagedPlugins, getProfileManagedPlugins(profile));
+                }
+            }
+            for (Profile profile : safeProfiles(newModel)) {
+                if (activeProfileIds.contains(profile.getId())) {
+                    augmentWithPropertyReferences(
+                            changedProperties, changedManagedDeps, getProfileManagedDependencies(profile));
+                    augmentWithPluginPropertyReferences(
+                            changedProperties, changedManagedPlugins, getProfileManagedPlugins(profile));
+                }
+            }
         }
 
         // Collect all changed managed GAs for transitive dependency and plugin checking
@@ -278,10 +313,109 @@ class PomChangeAnalyzer {
                 }
             }
 
+            // Check if child has filtered resources referencing changed properties
+            if (!childAffected && !changedProperties.isEmpty()) {
+                if (hasFilteredResourcesWithChangedProperty(child, changedProperties)) {
+                    logger.debug("Child {} has filtered resources referencing changed properties", key(child));
+                    childAffected = true;
+                }
+            }
+
             if (childAffected) {
                 affected.add(child);
             }
         }
+    }
+
+    /**
+     * Analyze changes in active profiles between old and new POM models.
+     * Returns true if the parent itself is affected (direct deps or plugins changed).
+     * Accumulates property, managed dep, and managed plugin changes into the provided sets.
+     */
+    private boolean analyzeProfileChanges(
+            Model oldModel,
+            Model newModel,
+            Set<String> activeProfileIds,
+            Set<String> changedProperties,
+            Set<String> changedManagedDeps,
+            Set<String> changedManagedPlugins) {
+
+        boolean selfAffected = false;
+
+        Map<String, Profile> oldProfiles = new LinkedHashMap<>();
+        for (Profile p : safeProfiles(oldModel)) {
+            oldProfiles.put(p.getId(), p);
+        }
+        Map<String, Profile> newProfiles = new LinkedHashMap<>();
+        for (Profile p : safeProfiles(newModel)) {
+            newProfiles.put(p.getId(), p);
+        }
+
+        for (String profileId : activeProfileIds) {
+            Profile oldProfile = oldProfiles.get(profileId);
+            Profile newProfile = newProfiles.get(profileId);
+
+            if (oldProfile == null && newProfile == null) {
+                continue;
+            }
+
+            if (oldProfile == null || newProfile == null) {
+                // Profile added or removed while active
+                logger.debug("Active profile {} was {}", profileId, oldProfile == null ? "added" : "removed");
+                if (newProfile != null) {
+                    changedProperties.addAll(diffProperties(null, newProfile.getProperties()));
+                    changedManagedDeps.addAll(diffDependencies(
+                            Collections.<Dependency>emptyList(), getProfileManagedDependencies(newProfile)));
+                    changedManagedPlugins.addAll(
+                            diffPlugins(Collections.<Plugin>emptyList(), getProfileManagedPlugins(newProfile)));
+                    if (!newProfile.getDependencies().isEmpty()
+                            || !getProfilePlugins(newProfile).isEmpty()) {
+                        selfAffected = true;
+                    }
+                } else {
+                    changedProperties.addAll(diffProperties(oldProfile.getProperties(), null));
+                    changedManagedDeps.addAll(diffDependencies(
+                            getProfileManagedDependencies(oldProfile), Collections.<Dependency>emptyList()));
+                    changedManagedPlugins.addAll(
+                            diffPlugins(getProfileManagedPlugins(oldProfile), Collections.<Plugin>emptyList()));
+                    if (!oldProfile.getDependencies().isEmpty()
+                            || !getProfilePlugins(oldProfile).isEmpty()) {
+                        selfAffected = true;
+                    }
+                }
+                continue;
+            }
+
+            // Both exist — diff them
+            changedProperties.addAll(diffProperties(oldProfile.getProperties(), newProfile.getProperties()));
+            changedManagedDeps.addAll(diffDependencies(
+                    getProfileManagedDependencies(oldProfile), getProfileManagedDependencies(newProfile)));
+            changedManagedPlugins.addAll(
+                    diffPlugins(getProfileManagedPlugins(oldProfile), getProfileManagedPlugins(newProfile)));
+
+            if (!equalDependencyLists(oldProfile.getDependencies(), newProfile.getDependencies())) {
+                logger.debug("Direct dependencies changed in active profile {}", profileId);
+                selfAffected = true;
+            }
+
+            if (!equalPluginLists(getProfilePlugins(oldProfile), getProfilePlugins(newProfile))) {
+                logger.debug("Direct plugins changed in active profile {}", profileId);
+                selfAffected = true;
+            }
+        }
+
+        return selfAffected;
+    }
+
+    private Set<String> getActiveProfileIds(MavenProject project) {
+        Set<String> ids = new LinkedHashSet<>();
+        List<Profile> activeProfiles = project.getActiveProfiles();
+        if (activeProfiles != null) {
+            for (Profile profile : activeProfiles) {
+                ids.add(profile.getId());
+            }
+        }
+        return ids;
     }
 
     Set<String> diffProperties(Properties oldProps, Properties newProps) {
@@ -390,9 +524,84 @@ class PomChangeAnalyzer {
         return Objects.equals(a.getGroupId(), b.getGroupId())
                 && Objects.equals(a.getArtifactId(), b.getArtifactId())
                 && Objects.equals(a.getVersion(), b.getVersion())
-                && Objects.equals(
-                        a.getConfiguration() != null ? a.getConfiguration().toString() : null,
-                        b.getConfiguration() != null ? b.getConfiguration().toString() : null);
+                && equalConfiguration(a.getConfiguration(), b.getConfiguration())
+                && equalExecutions(a.getExecutions(), b.getExecutions());
+    }
+
+    private boolean equalConfiguration(Object a, Object b) {
+        if (a == b) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+        if (a instanceof Xpp3Dom && b instanceof Xpp3Dom) {
+            return equalXpp3Dom((Xpp3Dom) a, (Xpp3Dom) b);
+        }
+        return Objects.equals(a.toString(), b.toString());
+    }
+
+    private boolean equalXpp3Dom(Xpp3Dom a, Xpp3Dom b) {
+        if (!Objects.equals(a.getName(), b.getName())) {
+            return false;
+        }
+        // Compare values, treating null and empty/whitespace-only as equivalent
+        String aVal = a.getValue() != null ? a.getValue().trim() : null;
+        String bVal = b.getValue() != null ? b.getValue().trim() : null;
+        if (aVal != null && aVal.isEmpty()) {
+            aVal = null;
+        }
+        if (bVal != null && bVal.isEmpty()) {
+            bVal = null;
+        }
+        if (!Objects.equals(aVal, bVal)) {
+            return false;
+        }
+        // Compare attributes
+        String[] aAttrs = a.getAttributeNames();
+        String[] bAttrs = b.getAttributeNames();
+        if (aAttrs.length != bAttrs.length) {
+            return false;
+        }
+        for (String attr : aAttrs) {
+            if (!Objects.equals(a.getAttribute(attr), b.getAttribute(attr))) {
+                return false;
+            }
+        }
+        // Compare children recursively
+        if (a.getChildCount() != b.getChildCount()) {
+            return false;
+        }
+        for (int i = 0; i < a.getChildCount(); i++) {
+            if (!equalXpp3Dom(a.getChild(i), b.getChild(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean equalExecutions(List<PluginExecution> a, List<PluginExecution> b) {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        Map<String, PluginExecution> mapA = new LinkedHashMap<>();
+        for (PluginExecution e : a) {
+            mapA.put(e.getId(), e);
+        }
+        for (PluginExecution e : b) {
+            PluginExecution other = mapA.remove(e.getId());
+            if (other == null || !equalExecution(other, e)) {
+                return false;
+            }
+        }
+        return mapA.isEmpty();
+    }
+
+    private boolean equalExecution(PluginExecution a, PluginExecution b) {
+        return Objects.equals(a.getId(), b.getId())
+                && Objects.equals(a.getPhase(), b.getPhase())
+                && Objects.equals(a.getGoals(), b.getGoals())
+                && equalConfiguration(a.getConfiguration(), b.getConfiguration());
     }
 
     private boolean equalDependencyLists(List<Dependency> a, List<Dependency> b) {
@@ -453,6 +662,35 @@ class PomChangeAnalyzer {
             return model.getBuild().getPluginManagement().getPlugins();
         }
         return new ArrayList<>();
+    }
+
+    private List<Profile> safeProfiles(Model model) {
+        List<Profile> profiles = model.getProfiles();
+        return profiles != null ? profiles : Collections.<Profile>emptyList();
+    }
+
+    private List<Dependency> getProfileManagedDependencies(Profile profile) {
+        if (profile.getDependencyManagement() != null
+                && profile.getDependencyManagement().getDependencies() != null) {
+            return profile.getDependencyManagement().getDependencies();
+        }
+        return Collections.<Dependency>emptyList();
+    }
+
+    private List<Plugin> getProfileManagedPlugins(Profile profile) {
+        if (profile.getBuild() != null
+                && profile.getBuild().getPluginManagement() != null
+                && profile.getBuild().getPluginManagement().getPlugins() != null) {
+            return profile.getBuild().getPluginManagement().getPlugins();
+        }
+        return Collections.<Plugin>emptyList();
+    }
+
+    private List<Plugin> getProfilePlugins(Profile profile) {
+        if (profile.getBuild() != null && profile.getBuild().getPlugins() != null) {
+            return profile.getBuild().getPlugins();
+        }
+        return Collections.<Plugin>emptyList();
     }
 
     private void augmentWithPropertyReferences(
@@ -539,6 +777,81 @@ class PomChangeAnalyzer {
                 return true;
             }
             current = current.getParent();
+        }
+        return false;
+    }
+
+    private boolean hasFilteredResourcesWithChangedProperty(MavenProject project, Set<String> changedProperties) {
+        List<String> refs = new ArrayList<>();
+        for (String prop : changedProperties) {
+            refs.add("${" + prop + "}");
+        }
+
+        List<Resource> allResources = new ArrayList<>();
+        if (project.getResources() != null) {
+            allResources.addAll(project.getResources());
+        }
+        if (project.getTestResources() != null) {
+            allResources.addAll(project.getTestResources());
+        }
+
+        for (Resource resource : allResources) {
+            if (!resource.isFiltering()) {
+                continue;
+            }
+            String dir = resource.getDirectory();
+            if (dir == null) {
+                continue;
+            }
+            Path resourceDir = Paths.get(dir);
+            if (!resourceDir.isAbsolute()) {
+                resourceDir = project.getBasedir().toPath().resolve(resourceDir);
+            }
+            if (!Files.isDirectory(resourceDir)) {
+                continue;
+            }
+            if (scanDirectoryForPropertyRefs(resourceDir, refs)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs) {
+        List<Path> stack = new ArrayList<>();
+        stack.add(dir);
+        while (!stack.isEmpty()) {
+            Path current = stack.remove(stack.size() - 1);
+            DirectoryStream<Path> stream = null;
+            try {
+                stream = Files.newDirectoryStream(current);
+                for (Path entry : stream) {
+                    if (Files.isDirectory(entry)) {
+                        stack.add(entry);
+                    } else if (Files.isRegularFile(entry)) {
+                        try {
+                            String content = new String(Files.readAllBytes(entry), StandardCharsets.UTF_8);
+                            for (String ref : refs) {
+                                if (content.contains(ref)) {
+                                    return true;
+                                }
+                            }
+                        } catch (IOException e) {
+                            // Skip binary or unreadable files
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                // Skip unreadable directories
+            } finally {
+                if (stream != null) {
+                    try {
+                        stream.close();
+                    } catch (IOException e) {
+                        // ignore
+                    }
+                }
+            }
         }
         return false;
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -198,7 +198,6 @@ class PomChangeAnalyzer {
 
         // Find changed properties
         Set<String> changedProperties = diffProperties(oldModel.getProperties(), newModel.getProperties());
-        allChangedProperties.addAll(changedProperties);
 
         // Find changed managed dependencies (by groupId:artifactId)
         Set<String> changedManagedDeps = diffDependencyManagement(oldModel, newModel);
@@ -216,6 +215,9 @@ class PomChangeAnalyzer {
                         changedProperties,
                         changedManagedDeps,
                         changedManagedPlugins);
+
+        // Collect all changed properties (after profile analysis has augmented the set)
+        allChangedProperties.addAll(changedProperties);
 
         if (parentSelfAffected) {
             affected.add(parentProject);

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -9,12 +9,14 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,19 +29,47 @@ class ReactorTrimmer {
 
     public TrimResult computeBuildSet(
             Set<MavenProject> directlyAffected, ProjectDependencyGraph graph, ScalpelConfiguration config) {
+        return computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+    }
+
+    public TrimResult computeBuildSet(
+            Set<MavenProject> directlyAffected,
+            Set<MavenProject> testOnlyProjects,
+            ProjectDependencyGraph graph,
+            ScalpelConfiguration config) {
 
         Set<MavenProject> buildSet = new LinkedHashSet<>(directlyAffected);
         Set<MavenProject> downstreamOnly = new LinkedHashSet<>();
+        Set<MavenProject> downstreamTestOnly = new LinkedHashSet<>();
         Set<MavenProject> upstreamOnly = new LinkedHashSet<>();
 
         if (config.isAlsoMakeDependents()) {
             for (MavenProject project : new ArrayList<>(directlyAffected)) {
+                boolean isTestOnly = testOnlyProjects.contains(project);
                 List<MavenProject> downstream = graph.getDownstreamProjects(project, true);
                 if (!downstream.isEmpty()) {
-                    logger.debug("Adding downstream dependents of {}: {}", key(project), keys(downstream));
                     for (MavenProject ds : downstream) {
-                        if (!directlyAffected.contains(ds) && buildSet.add(ds)) {
-                            downstreamOnly.add(ds);
+                        if (directlyAffected.contains(ds)) {
+                            continue;
+                        }
+                        // For test-only modules, only propagate to test-jar consumers
+                        if (isTestOnly && !hasTestJarDependency(ds, project)) {
+                            logger.debug(
+                                    "Skipping downstream {} of test-only module {} (no test-jar dependency)",
+                                    key(ds),
+                                    key(project));
+                            continue;
+                        }
+                        if (buildSet.add(ds)) {
+                            // Check if downstream depends on the changed module via test scope only
+                            String scope = getDependencyScope(ds, project);
+                            if ("test".equals(scope)) {
+                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(project));
+                                downstreamTestOnly.add(ds);
+                            } else {
+                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(project));
+                                downstreamOnly.add(ds);
+                            }
                         }
                     }
                 }
@@ -52,7 +82,10 @@ class ReactorTrimmer {
                 if (!upstream.isEmpty()) {
                     logger.debug("Adding upstream dependencies of {}: {}", key(project), keys(upstream));
                     for (MavenProject us : upstream) {
-                        if (!directlyAffected.contains(us) && !downstreamOnly.contains(us) && buildSet.add(us)) {
+                        if (!directlyAffected.contains(us)
+                                && !downstreamOnly.contains(us)
+                                && !downstreamTestOnly.contains(us)
+                                && buildSet.add(us)) {
                             upstreamOnly.add(us);
                         }
                     }
@@ -69,7 +102,35 @@ class ReactorTrimmer {
             }
         }
 
-        return new TrimResult(result, directlyAffected, upstreamOnly, downstreamOnly);
+        return new TrimResult(result, directlyAffected, upstreamOnly, downstreamOnly, downstreamTestOnly);
+    }
+
+    private boolean hasTestJarDependency(MavenProject downstream, MavenProject upstream) {
+        String groupId = upstream.getGroupId();
+        String artifactId = upstream.getArtifactId();
+        for (Dependency dep : downstream.getDependencies()) {
+            if (groupId.equals(dep.getGroupId())
+                    && artifactId.equals(dep.getArtifactId())
+                    && "test-jar".equals(dep.getType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the scope of the direct dependency from downstream on upstream, or null if
+     * there is no direct dependency (i.e. the dependency is purely transitive).
+     */
+    private String getDependencyScope(MavenProject downstream, MavenProject upstream) {
+        String groupId = upstream.getGroupId();
+        String artifactId = upstream.getArtifactId();
+        for (Dependency dep : downstream.getDependencies()) {
+            if (groupId.equals(dep.getGroupId()) && artifactId.equals(dep.getArtifactId())) {
+                return dep.getScope();
+            }
+        }
+        return null; // transitive dependency
     }
 
     private static String key(MavenProject project) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -199,9 +199,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 }
             }
 
-            // Map source changes to modules
-            Set<MavenProject> affectedBySource = moduleMapper.mapToProjects(sourceChanges, allProjects, reactorRoot);
+            // Map source changes to modules (classifying test-only vs main changes)
+            ModuleMapper.Result sourceResult =
+                    moduleMapper.mapToProjectsClassified(sourceChanges, allProjects, reactorRoot);
+            Set<MavenProject> affectedBySource = sourceResult.getAllAffected();
             logger.debug("Modules affected by source changes: {}", projectKeys(affectedBySource));
+            if (!sourceResult.getTestOnlyAffected().isEmpty()) {
+                logger.debug(
+                        "Test-only modules (no downstream propagation): {}",
+                        projectKeys(sourceResult.getTestOnlyAffected()));
+            }
 
             // Analyze POM changes directly (no model building needed)
             Set<MavenProject> affectedByPom = new LinkedHashSet<>();
@@ -240,6 +247,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             directlyAffected.addAll(affectedBySource);
             directlyAffected.addAll(affectedByPom);
 
+            // Compute test-only modules for downstream propagation control
+            // Modules with only test source changes don't propagate downstream
+            // (unless downstream depends on test-jar). Modules also affected by POM
+            // changes are NOT test-only since POM changes can affect production builds.
+            Set<MavenProject> testOnlyModules = new LinkedHashSet<>(sourceResult.getTestOnlyAffected());
+            testOnlyModules.removeAll(affectedByPom);
+
             // Force-include modules matching forceBuildModules patterns
             Set<MavenProject> forceIncluded = new LinkedHashSet<>();
             if (!config.getForceBuildModules().isEmpty()) {
@@ -258,6 +272,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 }
             }
 
+            // Force-included modules are not test-only
+            testOnlyModules.removeAll(forceIncluded);
+
             if (directlyAffected.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
                 if (config.isModeReport()) {
@@ -268,6 +285,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             changedProperties,
                             changedManagedDepGAs,
                             changedManagedPluginGAs,
+                            Collections.<MavenProject>emptySet(),
                             Collections.<MavenProject>emptySet(),
                             Collections.<MavenProject>emptySet(),
                             Collections.<MavenProject>emptySet(),
@@ -292,8 +310,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             if (config.isModeReport()) {
                 // Compute upstream/downstream categorization for report enrichment
-                TrimResult trimResult =
-                        reactorTrimmer.computeBuildSet(directlyAffected, session.getProjectDependencyGraph(), config);
+                TrimResult trimResult = reactorTrimmer.computeBuildSet(
+                        directlyAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
 
                 // Check remaining modules for transitive dependency/plugin impact
                 Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
@@ -306,9 +324,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
                             reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
                         }
-                        if (!changedManagedDepGAs.isEmpty()
-                                && hasChangedTransitiveDependency(project, session, changedManagedDepGAs)) {
-                            reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+                        if (!changedManagedDepGAs.isEmpty()) {
+                            String depScope =
+                                    getChangedTransitiveDependencyScope(project, session, changedManagedDepGAs);
+                            if (depScope != null) {
+                                if ("test".equals(depScope)) {
+                                    reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
+                                } else {
+                                    reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+                                }
+                            }
                         }
                         if (!reasons.isEmpty()) {
                             transitivelyAffected.put(project, reasons);
@@ -331,6 +356,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         changedManagedPluginGAs,
                         directlyAffected,
                         affectedBySource,
+                        sourceResult.getTestOnlyAffected(),
                         affectedByPom,
                         forceIncluded,
                         transitivelyAffected,
@@ -339,8 +365,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Compute full build set with upstream/downstream
-            TrimResult trimResult =
-                    reactorTrimmer.computeBuildSet(directlyAffected, session.getProjectDependencyGraph(), config);
+            TrimResult trimResult = reactorTrimmer.computeBuildSet(
+                    directlyAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
 
             if (config.isModeSkipTests()) {
                 applySkipTests(session, allProjects, trimResult, config, changedManagedDepGAs, changedManagedPluginGAs);
@@ -434,24 +460,44 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     }
 
     private boolean hasChangedTransitiveDependency(MavenProject project, MavenSession session, Set<String> changedGAs) {
+        return getChangedTransitiveDependencyScope(project, session, changedGAs) != null;
+    }
+
+    /**
+     * Returns the effective scope of the changed transitive dependency, or null if no match.
+     * If any matching dependency has compile/runtime/provided scope, returns that scope.
+     * If all matching dependencies are test-scoped, returns "test".
+     */
+    private String getChangedTransitiveDependencyScope(
+            MavenProject project, MavenSession session, Set<String> changedGAs) {
         try {
             DefaultDependencyResolutionRequest request =
                     new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
             DependencyResolutionResult result = dependenciesResolver.resolve(request);
 
+            String narrowestScope = null;
             for (Dependency dep : result.getResolvedDependencies()) {
                 String ga =
                         dep.getArtifact().getGroupId() + ":" + dep.getArtifact().getArtifactId();
                 if (changedGAs.contains(ga)) {
-                    logger.debug("Module {} has transitive dependency on changed managed dep {}", key(project), ga);
-                    return true;
+                    String scope = dep.getScope();
+                    logger.debug(
+                            "Module {} has transitive dependency on changed managed dep {} (scope={})",
+                            key(project),
+                            ga,
+                            scope);
+                    // Non-test scope means production code is affected
+                    if (scope == null || !"test".equals(scope)) {
+                        return scope != null ? scope : "compile";
+                    }
+                    narrowestScope = "test";
                 }
             }
-            return false;
+            return narrowestScope;
         } catch (DependencyResolutionException e) {
             // Conservative: if we can't resolve, don't skip tests
             logger.debug("Cannot resolve dependencies for {}, not skipping tests: {}", key(project), e.getMessage());
-            return true;
+            return "compile";
         }
     }
 
@@ -501,6 +547,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedPluginGAs,
             Set<MavenProject> directlyAffected,
             Set<MavenProject> affectedBySource,
+            Set<MavenProject> testOnlyBySource,
             Set<MavenProject> affectedByPom,
             Set<MavenProject> forceIncluded,
             Map<MavenProject, List<String>> transitivelyAffected,
@@ -518,7 +565,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             String path = relativePath(reactorRoot, project);
             List<String> reasons = new ArrayList<>();
             if (affectedBySource.contains(project)) {
-                reasons.add(ScalpelReport.REASON_SOURCE_CHANGE);
+                if (testOnlyBySource.contains(project)) {
+                    reasons.add(ScalpelReport.REASON_TEST_CHANGE);
+                } else {
+                    reasons.add(ScalpelReport.REASON_SOURCE_CHANGE);
+                }
             }
             if (affectedByPom.contains(project)) {
                 reasons.add(ScalpelReport.REASON_POM_CHANGE);
@@ -569,6 +620,17 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             ScalpelReport.CATEGORY_DOWNSTREAM));
                 }
             }
+            for (MavenProject project : trimResult.getDownstreamTestOnly()) {
+                if (!directlyAffected.contains(project) && !transitivelyAffected.containsKey(project)) {
+                    String path = relativePath(reactorRoot, project);
+                    builder.addAffectedModule(new ScalpelReport.AffectedModule(
+                            project.getGroupId(),
+                            project.getArtifactId(),
+                            path,
+                            Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_TEST),
+                            ScalpelReport.CATEGORY_DOWNSTREAM));
+                }
+            }
         }
 
         try {
@@ -603,6 +665,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             String[] parts = arg.trim().split("=", 2);
             if (parts.length == 2) {
                 for (MavenProject project : trimResult.getDownstreamOnly()) {
+                    project.getProperties().setProperty(parts[0], parts[1]);
+                }
+                for (MavenProject project : trimResult.getDownstreamTestOnly()) {
                     project.getProperties().setProperty(parts[0], parts[1]);
                 }
             } else {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
@@ -7,13 +7,15 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.maven.project.MavenProject;
 
 /**
  * Result of computing the build set, categorizing modules as directly affected,
- * upstream-only (added via alsoMake), or downstream-only (added via alsoMakeDependents).
+ * upstream-only (added via alsoMake), downstream-only (added via alsoMakeDependents),
+ * or downstream-test-only (downstream via test-scoped dependency).
  */
 final class TrimResult {
 
@@ -21,16 +23,27 @@ final class TrimResult {
     private final Set<MavenProject> directlyAffected;
     private final Set<MavenProject> upstreamOnly;
     private final Set<MavenProject> downstreamOnly;
+    private final Set<MavenProject> downstreamTestOnly;
 
     TrimResult(
             List<MavenProject> buildSet,
             Set<MavenProject> directlyAffected,
             Set<MavenProject> upstreamOnly,
             Set<MavenProject> downstreamOnly) {
+        this(buildSet, directlyAffected, upstreamOnly, downstreamOnly, Collections.<MavenProject>emptySet());
+    }
+
+    TrimResult(
+            List<MavenProject> buildSet,
+            Set<MavenProject> directlyAffected,
+            Set<MavenProject> upstreamOnly,
+            Set<MavenProject> downstreamOnly,
+            Set<MavenProject> downstreamTestOnly) {
         this.buildSet = buildSet;
         this.directlyAffected = directlyAffected;
         this.upstreamOnly = upstreamOnly;
         this.downstreamOnly = downstreamOnly;
+        this.downstreamTestOnly = downstreamTestOnly;
     }
 
     List<MavenProject> getBuildSet() {
@@ -47,5 +60,9 @@ final class TrimResult {
 
     Set<MavenProject> getDownstreamOnly() {
         return downstreamOnly;
+    }
+
+    Set<MavenProject> getDownstreamTestOnly() {
+        return downstreamTestOnly;
     }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ModuleMapperTest {
+
+    private ModuleMapper mapper;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ModuleMapper();
+    }
+
+    @Test
+    void isTestPath_srcTest() {
+        assertTrue(ModuleMapper.isTestPath("module-a/src/test/java/Foo.java", "module-a"));
+    }
+
+    @Test
+    void isTestPath_srcMain() {
+        assertFalse(ModuleMapper.isTestPath("module-a/src/main/java/Foo.java", "module-a"));
+    }
+
+    @Test
+    void isTestPath_rootProject() {
+        assertTrue(ModuleMapper.isTestPath("src/test/java/Foo.java", ""));
+        assertFalse(ModuleMapper.isTestPath("src/main/java/Foo.java", ""));
+    }
+
+    @Test
+    void isTestPath_nonSrcFile() {
+        assertFalse(ModuleMapper.isTestPath("module-a/pom.xml", "module-a"));
+        assertFalse(ModuleMapper.isTestPath("module-a/README.md", "module-a"));
+    }
+
+    @Test
+    void mapToProjectsClassified_testOnlyChanges() {
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        Set<String> changedFiles = new LinkedHashSet<>(
+                Arrays.asList("module-a/src/test/java/FooTest.java", "module-a/src/test/resources/test-data.xml"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getTestOnlyAffected().size());
+        assertTrue(result.getTestOnlyAffected().contains(projects.get(1))); // module-a
+        assertTrue(result.getMainAffected().isEmpty());
+        assertEquals(1, result.getAllAffected().size());
+    }
+
+    @Test
+    void mapToProjectsClassified_mainChanges() {
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        Set<String> changedFiles = new LinkedHashSet<>(
+                Arrays.asList("module-a/src/main/java/Foo.java", "module-a/src/main/resources/config.xml"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(result.getMainAffected().contains(projects.get(1))); // module-a
+        assertTrue(result.getTestOnlyAffected().isEmpty());
+    }
+
+    @Test
+    void mapToProjectsClassified_mixedChangesIsMain() {
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        Set<String> changedFiles = new LinkedHashSet<>(
+                Arrays.asList("module-a/src/main/java/Foo.java", "module-a/src/test/java/FooTest.java"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(result.getMainAffected().contains(projects.get(1))); // module-a
+        assertTrue(result.getTestOnlyAffected().isEmpty());
+    }
+
+    @Test
+    void mapToProjectsClassified_multipleModules() {
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        Set<String> changedFiles = new LinkedHashSet<>(Arrays.asList(
+                "module-a/src/test/java/FooTest.java", // test-only for module-a
+                "module-b/src/main/java/Bar.java" // main for module-b
+                ));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getTestOnlyAffected().size());
+        assertTrue(result.getTestOnlyAffected().contains(projects.get(1))); // module-a
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(result.getMainAffected().contains(projects.get(2))); // module-b
+        assertEquals(2, result.getAllAffected().size());
+    }
+
+    @Test
+    void mapToProjectsClassified_nonSrcFileIsMain() {
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        Set<String> changedFiles = new LinkedHashSet<>(Arrays.asList("module-a/README.md"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(result.getMainAffected().contains(projects.get(1)));
+        assertTrue(result.getTestOnlyAffected().isEmpty());
+    }
+
+    private List<MavenProject> createProjects(Path root) {
+        MavenProject parent =
+                createProject("com.example", "parent", root.resolve("pom.xml").toFile());
+        MavenProject moduleA = createProject(
+                "com.example", "module-a", root.resolve("module-a/pom.xml").toFile());
+        MavenProject moduleB = createProject(
+                "com.example", "module-b", root.resolve("module-b/pom.xml").toFile());
+        return Arrays.asList(parent, moduleA, moduleB);
+    }
+
+    private MavenProject createProject(String groupId, String artifactId, File pomFile) {
+        Model model = new Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion("1.0");
+        model.setPomFile(pomFile);
+        MavenProject project = new MavenProject(model);
+        project.setFile(pomFile);
+        return project;
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -858,6 +858,331 @@ class PomChangeAnalyzerTest {
                 "module-b's filtered resources don't reference ${app.version} - should NOT be affected");
     }
 
+    // --- New POM and edge case tests ---
+
+    @Test
+    void analyzeChanges_newPomMarksAllChildrenAffected() throws Exception {
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createSimpleReactor(root);
+
+        // No old POM bytes = new POM file
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        // Intentionally no entry for "pom.xml" (null = new file)
+
+        Set<MavenProject> affected =
+                analyzer.analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+
+        assertTrue(affected.contains(projects.get(0)), "Parent should be affected");
+        assertTrue(affected.contains(projects.get(1)), "module-a should be affected (new parent POM)");
+        assertTrue(affected.contains(projects.get(2)), "module-b should be affected (new parent POM)");
+    }
+
+    @Test
+    void analyzeChanges_profileRemovedWhileActiveAffectsParent() throws Exception {
+        Path root = setupReactorRoot();
+
+        // New parent POM: profile 'prod' removed
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+
+        // Profile 'prod' is active but has been removed from the POM
+        Profile activeProfile = new Profile();
+        activeProfile.setId("prod");
+        projects.get(0).setActiveProfiles(Collections.singletonList(activeProfile));
+
+        // Old parent POM had profile 'prod' with direct dependencies
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <profiles><profile>\n"
+                + "    <id>prod</id>\n"
+                + "    <properties><prod.version>1.0</prod.version></properties>\n"
+                + "    <dependencies>\n"
+                + "      <dependency><groupId>com.prod</groupId><artifactId>lib</artifactId><version>1.0</version></dependency>\n"
+                + "    </dependencies>\n"
+                + "  </profile></profiles>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        // Parent should be self-affected because the removed profile had direct dependencies
+        assertTrue(
+                result.getAffectedProjects().contains(projects.get(0)),
+                "Parent should be affected (active profile with deps removed)");
+        assertTrue(
+                result.getChangedProperties().contains("prod.version"),
+                "Removed profile properties should be detected");
+    }
+
+    @Test
+    void analyzeChanges_profileDirectDepsChangeAffectsParent() throws Exception {
+        Path root = setupReactorRoot();
+
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <profiles><profile>\n"
+                + "    <id>prod</id>\n"
+                + "    <dependencies>\n"
+                + "      <dependency><groupId>com.prod</groupId><artifactId>lib</artifactId><version>2.0</version></dependency>\n"
+                + "    </dependencies>\n"
+                + "  </profile></profiles>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+        Profile activeProfile = new Profile();
+        activeProfile.setId("prod");
+        projects.get(0).setActiveProfiles(Collections.singletonList(activeProfile));
+
+        // Old POM: profile had lib version 1.0
+        String oldParentPom = parentPomXml.replace("<version>2.0</version>", "<version>1.0</version>");
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(
+                result.getAffectedProjects().contains(projects.get(0)),
+                "Parent should be self-affected (direct deps changed in active profile)");
+    }
+
+    @Test
+    void analyzeChanges_leafModulePomChangeAffectsOnlySelf() throws Exception {
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createSimpleReactor(root);
+
+        // Change only module-a's POM (leaf module)
+        Set<String> changedPoms = Collections.singleton("module-a/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+
+        Set<MavenProject> affected =
+                analyzer.analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+
+        assertTrue(affected.contains(projects.get(1)), "module-a should be affected");
+        assertFalse(affected.contains(projects.get(2)), "module-b should NOT be affected");
+        assertEquals(1, affected.size());
+    }
+
+    @Test
+    void analyzeChanges_directPluginChangeAffectsParent() throws Exception {
+        Path root = setupReactorRoot();
+
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <build><plugins>\n"
+                + "    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>3.12.0</version></plugin>\n"
+                + "  </plugins></build>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+
+        String oldParentPom = parentPomXml.replace("3.12.0", "3.11.0");
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(
+                result.getAffectedProjects().contains(projects.get(0)),
+                "Parent should be self-affected (direct plugin changed)");
+    }
+
+    @Test
+    void analyzeChanges_directDependencyChangeAffectsParent() throws Exception {
+        Path root = setupReactorRoot();
+
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>junit</groupId><artifactId>junit</artifactId><version>4.13.2</version></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+
+        String oldParentPom = parentPomXml.replace("4.13.2", "4.13.1");
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(
+                result.getAffectedProjects().contains(projects.get(0)),
+                "Parent should be self-affected (direct dependency changed)");
+    }
+
+    @Test
+    void analyzeChanges_packagingChangeAffectsParent() throws Exception {
+        Path root = setupReactorRoot();
+
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+
+        // Old POM had jar packaging
+        String oldParentPom = parentPomXml.replace("<packaging>pom</packaging>", "<packaging>jar</packaging>");
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(
+                result.getAffectedProjects().contains(projects.get(0)),
+                "Parent should be self-affected (packaging changed)");
+    }
+
+    @Test
+    void analyzeChanges_unmatchedPomSkipped() throws Exception {
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createSimpleReactor(root);
+
+        // POM path doesn't match any reactor project
+        Set<String> changedPoms = Collections.singleton("nonexistent/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+
+        Set<MavenProject> affected =
+                analyzer.analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+
+        assertTrue(affected.isEmpty(), "Unmatched POM path should not affect any module");
+    }
+
     // --- Helper methods ---
 
     private Path setupReactorRoot() throws IOException {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -28,8 +28,12 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
 import org.apache.maven.model.PluginManagement;
+import org.apache.maven.model.Profile;
+import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -427,6 +431,433 @@ class PomChangeAnalyzerTest {
                 affected.contains(moduleA), "module-a does not use maven-compiler-plugin and should NOT be affected");
     }
 
+    // --- Profile-aware POM comparison tests ---
+
+    @Test
+    void analyzeChanges_activeProfilePropertyChangeAffectsChild() throws Exception {
+        Path root = setupReactorRoot();
+
+        // Parent POM with profile "my-profile" having dep.version=2.0 (new value)
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <profiles><profile>\n"
+                + "    <id>my-profile</id>\n"
+                + "    <properties><dep.version>2.0</dep.version></properties>\n"
+                + "  </profile></profiles>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        // module-b references ${dep.version}
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>${dep.version}</version></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+
+        // Set profile as active on parent
+        Profile activeProfile = new Profile();
+        activeProfile.setId("my-profile");
+        projects.get(0).setActiveProfiles(Collections.singletonList(activeProfile));
+
+        // Old parent POM had dep.version=1.0 in the profile
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <profiles><profile>\n"
+                + "    <id>my-profile</id>\n"
+                + "    <properties><dep.version>1.0</dep.version></properties>\n"
+                + "  </profile></profiles>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(
+                result.getAffectedProjects().contains(projects.get(2)),
+                "module-b references ${dep.version} and should be affected by active profile change");
+        assertFalse(
+                result.getAffectedProjects().contains(projects.get(1)), "module-a does NOT reference ${dep.version}");
+        assertTrue(result.getChangedProperties().contains("dep.version"));
+    }
+
+    @Test
+    void analyzeChanges_inactiveProfileChangeIgnored() throws Exception {
+        Path root = setupReactorRoot();
+
+        // Parent POM with profile "my-profile" having dep.version=2.0
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <profiles><profile>\n"
+                + "    <id>my-profile</id>\n"
+                + "    <properties><dep.version>2.0</dep.version></properties>\n"
+                + "  </profile></profiles>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>${dep.version}</version></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+        // Do NOT set active profiles - the profile is inactive
+
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <profiles><profile>\n"
+                + "    <id>my-profile</id>\n"
+                + "    <properties><dep.version>1.0</dep.version></properties>\n"
+                + "  </profile></profiles>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        Set<MavenProject> affected =
+                analyzer.analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+
+        assertTrue(affected.isEmpty(), "Inactive profile change should not affect any module");
+    }
+
+    @Test
+    void analyzeChanges_activeProfileManagedDepChangeAffectsChild() throws Exception {
+        Path root = setupReactorRoot();
+
+        // Parent POM with profile that has managed dep lib-x:2.0
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <profiles><profile>\n"
+                + "    <id>my-profile</id>\n"
+                + "    <dependencyManagement><dependencies>\n"
+                + "      <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>2.0</version></dependency>\n"
+                + "    </dependencies></dependencyManagement>\n"
+                + "  </profile></profiles>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        // module-b uses lib-x
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+        Profile activeProfile = new Profile();
+        activeProfile.setId("my-profile");
+        projects.get(0).setActiveProfiles(Collections.singletonList(activeProfile));
+
+        // Old parent POM had lib-x:1.0 in the profile
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <profiles><profile>\n"
+                + "    <id>my-profile</id>\n"
+                + "    <dependencyManagement><dependencies>\n"
+                + "      <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>1.0</version></dependency>\n"
+                + "    </dependencies></dependencyManagement>\n"
+                + "  </profile></profiles>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(
+                result.getAffectedProjects().contains(projects.get(2)),
+                "module-b uses managed dep lib-x from active profile and should be affected");
+        assertFalse(result.getAffectedProjects().contains(projects.get(1)), "module-a does NOT use lib-x");
+        assertTrue(result.getChangedManagedDependencyGAs().contains("com.example:lib-x"));
+    }
+
+    // --- Plugin configuration semantic diff tests ---
+
+    @Test
+    void diffPluginManagement_whitespaceConfigChangeIgnored() {
+        Model old =
+                modelWithManagedPluginConfig("org.apache.maven.plugins", "maven-compiler-plugin", "3.11.0", "  11  ");
+        Model now = modelWithManagedPluginConfig("org.apache.maven.plugins", "maven-compiler-plugin", "3.11.0", "11");
+        assertTrue(
+                analyzer.diffPluginManagement(old, now).isEmpty(),
+                "Whitespace-only config change should not trigger diff");
+    }
+
+    @Test
+    void diffPluginManagement_configValueChangeDetected() {
+        Model old = modelWithManagedPluginConfig("org.apache.maven.plugins", "maven-compiler-plugin", "3.11.0", "11");
+        Model now = modelWithManagedPluginConfig("org.apache.maven.plugins", "maven-compiler-plugin", "3.11.0", "17");
+        Set<String> changed = analyzer.diffPluginManagement(old, now);
+        assertEquals(
+                Collections.singleton("org.apache.maven.plugins:maven-compiler-plugin"),
+                changed,
+                "Config value change should be detected");
+    }
+
+    @Test
+    void diffPluginManagement_executionChangeDetected() {
+        Model old = modelWithManagedPluginExecution(
+                "org.apache.maven.plugins", "maven-surefire-plugin", "3.0.0", "default-test", "test");
+        Model now = modelWithManagedPluginExecution(
+                "org.apache.maven.plugins", "maven-surefire-plugin", "3.0.0", "default-test", "integration-test");
+        Set<String> changed = analyzer.diffPluginManagement(old, now);
+        assertEquals(
+                Collections.singleton("org.apache.maven.plugins:maven-surefire-plugin"),
+                changed,
+                "Execution phase change should be detected");
+    }
+
+    @Test
+    void diffPluginManagement_sameExecutionNoChange() {
+        Model old = modelWithManagedPluginExecution(
+                "org.apache.maven.plugins", "maven-surefire-plugin", "3.0.0", "default-test", "test");
+        Model now = modelWithManagedPluginExecution(
+                "org.apache.maven.plugins", "maven-surefire-plugin", "3.0.0", "default-test", "test");
+        assertTrue(analyzer.diffPluginManagement(old, now).isEmpty(), "Identical executions should not trigger diff");
+    }
+
+    // --- Resource filtering property tracking tests ---
+
+    @Test
+    void analyzeChanges_filteredResourcePropertyChangeAffectsChild() throws Exception {
+        Path root = setupReactorRoot();
+
+        // Parent POM with app.version=2.0 (new)
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties>\n"
+                + "    <app.version>2.0</app.version>\n"
+                + "  </properties>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        // module-a: no filtered resources
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        // module-b: has filtered resources
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        // Create filtered resource file referencing ${app.version}
+        Path resourceDir = root.resolve("module-b/src/main/resources");
+        Files.createDirectories(resourceDir);
+        Files.write(
+                resourceDir.resolve("application.properties"),
+                "app.version=${app.version}\n".getBytes(StandardCharsets.UTF_8));
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+
+        // Set up filtered resource on module-b
+        MavenProject moduleB = projects.get(2);
+        Resource resource = new Resource();
+        resource.setDirectory(root.resolve("module-b/src/main/resources").toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleB.getModel().setBuild(build);
+
+        // Old parent POM had app.version=1.0
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties>\n"
+                + "    <app.version>1.0</app.version>\n"
+                + "  </properties>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        Set<MavenProject> affected =
+                analyzer.analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+
+        assertTrue(
+                affected.contains(moduleB),
+                "module-b has filtered resource with ${app.version} and should be affected");
+        assertFalse(
+                affected.contains(projects.get(1)), "module-a has no filtered resources and should NOT be affected");
+    }
+
+    @Test
+    void analyzeChanges_filteredResourceWithoutPropertyRefNotAffected() throws Exception {
+        Path root = setupReactorRoot();
+
+        // Parent POM with app.version=2.0
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties>\n"
+                + "    <app.version>2.0</app.version>\n"
+                + "  </properties>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        // Create filtered resource that does NOT reference ${app.version}
+        Path resourceDir = root.resolve("module-b/src/main/resources");
+        Files.createDirectories(resourceDir);
+        Files.write(resourceDir.resolve("config.properties"), "key=value\n".getBytes(StandardCharsets.UTF_8));
+
+        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+
+        // Set up filtered resource on module-b
+        MavenProject moduleB = projects.get(2);
+        Resource resource = new Resource();
+        resource.setDirectory(root.resolve("module-b/src/main/resources").toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleB.getModel().setBuild(build);
+
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties>\n"
+                + "    <app.version>1.0</app.version>\n"
+                + "  </properties>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        Set<MavenProject> affected =
+                analyzer.analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+
+        assertFalse(
+                affected.contains(moduleB),
+                "module-b's filtered resources don't reference ${app.version} - should NOT be affected");
+    }
+
     // --- Helper methods ---
 
     private Path setupReactorRoot() throws IOException {
@@ -732,6 +1163,44 @@ class PomChangeAnalyzerTest {
         plugin.setGroupId(groupId);
         plugin.setArtifactId(artifactId);
         plugin.setVersion(version);
+        pm.addPlugin(plugin);
+        build.setPluginManagement(pm);
+        model.setBuild(build);
+        return model;
+    }
+
+    private Model modelWithManagedPluginConfig(String groupId, String artifactId, String version, String sourceValue) {
+        Model model = new Model();
+        Build build = new Build();
+        PluginManagement pm = new PluginManagement();
+        Plugin plugin = new Plugin();
+        plugin.setGroupId(groupId);
+        plugin.setArtifactId(artifactId);
+        plugin.setVersion(version);
+        Xpp3Dom config = new Xpp3Dom("configuration");
+        Xpp3Dom source = new Xpp3Dom("source");
+        source.setValue(sourceValue);
+        config.addChild(source);
+        plugin.setConfiguration(config);
+        pm.addPlugin(plugin);
+        build.setPluginManagement(pm);
+        model.setBuild(build);
+        return model;
+    }
+
+    private Model modelWithManagedPluginExecution(
+            String groupId, String artifactId, String version, String execId, String phase) {
+        Model model = new Model();
+        Build build = new Build();
+        PluginManagement pm = new PluginManagement();
+        Plugin plugin = new Plugin();
+        plugin.setGroupId(groupId);
+        plugin.setArtifactId(artifactId);
+        plugin.setVersion(version);
+        PluginExecution execution = new PluginExecution();
+        execution.setId(execId);
+        execution.setPhase(phase);
+        plugin.addExecution(execution);
         pm.addPlugin(plugin);
         build.setPluginManagement(pm);
         model.setBuild(build);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.execution.ProjectDependencyGraph;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ReactorTrimmerTest {
+
+    private ReactorTrimmer trimmer;
+
+    @BeforeEach
+    void setUp() {
+        trimmer = new ReactorTrimmer();
+    }
+
+    @Test
+    void computeBuildSet_testScopedDownstreamClassifiedAsTestOnly() {
+        // A -> B (test scope): B should be classified as downstreamTestOnly
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        addDependency(projectB, "com.example", "module-a", "test");
+
+        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        downstreamMap.put(projectA, Collections.singletonList(projectB));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(
+                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        ScalpelConfiguration config = configWith(true, true);
+
+        TrimResult result =
+                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+
+        assertTrue(result.getBuildSet().contains(projectA));
+        assertTrue(result.getBuildSet().contains(projectB));
+        assertTrue(
+                result.getDownstreamTestOnly().contains(projectB),
+                "Test-scoped downstream should be in downstreamTestOnly");
+        assertFalse(
+                result.getDownstreamOnly().contains(projectB),
+                "Test-scoped downstream should NOT be in downstreamOnly");
+    }
+
+    @Test
+    void computeBuildSet_compileScopedDownstreamClassifiedAsRegular() {
+        // A -> B (compile scope): B should be in downstreamOnly
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        addDependency(projectB, "com.example", "module-a", "compile");
+
+        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        downstreamMap.put(projectA, Collections.singletonList(projectB));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(
+                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        ScalpelConfiguration config = configWith(true, true);
+
+        TrimResult result =
+                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+
+        assertTrue(
+                result.getDownstreamOnly().contains(projectB), "Compile-scoped downstream should be in downstreamOnly");
+        assertTrue(result.getDownstreamTestOnly().isEmpty(), "No test-only downstream expected");
+    }
+
+    @Test
+    void computeBuildSet_testOnlyModuleOnlyPropagatesViaTestJar() {
+        // A is test-only, B depends on A with test-jar type, C depends on A without test-jar
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        MavenProject projectC = createProject("com.example", "module-c");
+        addTestJarDependency(projectB, "com.example", "module-a");
+        addDependency(projectC, "com.example", "module-a", "compile");
+
+        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB, projectC);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        downstreamMap.put(projectA, Arrays.asList(projectB, projectC));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(
+                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        Set<MavenProject> testOnlyProjects = new LinkedHashSet<>(Collections.singleton(projectA));
+        ScalpelConfiguration config = configWith(true, true);
+
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, testOnlyProjects, graph, config);
+
+        assertTrue(
+                result.getBuildSet().contains(projectB),
+                "B has test-jar dependency on test-only A - should be included");
+        assertFalse(
+                result.getBuildSet().contains(projectC),
+                "C has regular dependency on test-only A - should NOT be included");
+    }
+
+    @Test
+    void computeBuildSet_upstreamIncludedWithAlsoMake() {
+        // A depends on B: if A is affected, B should be upstream
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+
+        List<MavenProject> sortedProjects = Arrays.asList(projectB, projectA);
+        Map<MavenProject, List<MavenProject>> upstreamMap = new HashMap<>();
+        upstreamMap.put(projectA, Collections.singletonList(projectB));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(
+                sortedProjects, Collections.<MavenProject, List<MavenProject>>emptyMap(), upstreamMap);
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        ScalpelConfiguration config = configWith(true, false); // alsoMake=true, alsoMakeDependents=false
+
+        TrimResult result =
+                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+
+        assertTrue(result.getBuildSet().contains(projectB));
+        assertTrue(result.getUpstreamOnly().contains(projectB));
+    }
+
+    @Test
+    void computeBuildSet_noDownstreamWhenDisabled() {
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+
+        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        downstreamMap.put(projectA, Collections.singletonList(projectB));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(
+                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        ScalpelConfiguration config = configWith(false, false); // both disabled
+
+        TrimResult result =
+                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+
+        assertEquals(1, result.getBuildSet().size());
+        assertTrue(result.getBuildSet().contains(projectA));
+        assertFalse(result.getBuildSet().contains(projectB));
+    }
+
+    @Test
+    void computeBuildSet_backwardCompatibleOverload() {
+        MavenProject projectA = createProject("com.example", "module-a");
+        List<MavenProject> sortedProjects = Collections.singletonList(projectA);
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(
+                sortedProjects,
+                Collections.<MavenProject, List<MavenProject>>emptyMap(),
+                Collections.<MavenProject, List<MavenProject>>emptyMap());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        ScalpelConfiguration config = configWith(true, true);
+
+        // Use the 3-arg overload (no testOnlyProjects)
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, graph, config);
+
+        assertTrue(result.getBuildSet().contains(projectA));
+        assertTrue(result.getDownstreamTestOnly().isEmpty());
+    }
+
+    @Test
+    void computeBuildSet_buildOrderPreserved() {
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        MavenProject projectC = createProject("com.example", "module-c");
+        addDependency(projectC, "com.example", "module-a", "compile");
+
+        // Sorted order: A, B, C
+        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB, projectC);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        downstreamMap.put(projectA, Collections.singletonList(projectC));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(
+                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        ScalpelConfiguration config = configWith(true, true);
+
+        TrimResult result =
+                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+
+        // B should not be in the build set, only A and C
+        assertEquals(Arrays.asList(projectA, projectC), result.getBuildSet());
+    }
+
+    // --- Helper methods ---
+
+    private MavenProject createProject(String groupId, String artifactId) {
+        Model model = new Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion("1.0");
+        return new MavenProject(model);
+    }
+
+    private void addDependency(MavenProject project, String groupId, String artifactId, String scope) {
+        Dependency dep = new Dependency();
+        dep.setGroupId(groupId);
+        dep.setArtifactId(artifactId);
+        dep.setScope(scope);
+        project.getDependencies().add(dep);
+    }
+
+    private void addTestJarDependency(MavenProject project, String groupId, String artifactId) {
+        Dependency dep = new Dependency();
+        dep.setGroupId(groupId);
+        dep.setArtifactId(artifactId);
+        dep.setType("test-jar");
+        project.getDependencies().add(dep);
+    }
+
+    private ScalpelConfiguration configWith(boolean alsoMake, boolean alsoMakeDependents) {
+        Properties props = new Properties();
+        props.setProperty("scalpel.alsoMake", String.valueOf(alsoMake));
+        props.setProperty("scalpel.alsoMakeDependents", String.valueOf(alsoMakeDependents));
+        props.setProperty("scalpel.baseBranch", "origin/main");
+        return ScalpelConfiguration.fromProperties(props, new Properties());
+    }
+
+    /**
+     * Simple test implementation of ProjectDependencyGraph.
+     */
+    private static class TestDependencyGraph implements ProjectDependencyGraph {
+        private final List<MavenProject> sortedProjects;
+        private final Map<MavenProject, List<MavenProject>> downstreamMap;
+        private final Map<MavenProject, List<MavenProject>> upstreamMap;
+
+        TestDependencyGraph(
+                List<MavenProject> sortedProjects,
+                Map<MavenProject, List<MavenProject>> downstreamMap,
+                Map<MavenProject, List<MavenProject>> upstreamMap) {
+            this.sortedProjects = sortedProjects;
+            this.downstreamMap = downstreamMap;
+            this.upstreamMap = upstreamMap;
+        }
+
+        @Override
+        public List<MavenProject> getAllProjects() {
+            return sortedProjects;
+        }
+
+        @Override
+        public List<MavenProject> getSortedProjects() {
+            return sortedProjects;
+        }
+
+        @Override
+        public List<MavenProject> getDownstreamProjects(MavenProject project, boolean transitive) {
+            List<MavenProject> result = downstreamMap.get(project);
+            return result != null ? result : new ArrayList<MavenProject>();
+        }
+
+        @Override
+        public List<MavenProject> getUpstreamProjects(MavenProject project, boolean transitive) {
+            List<MavenProject> result = upstreamMap.get(project);
+            return result != null ? result : new ArrayList<MavenProject>();
+        }
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
@@ -619,6 +620,242 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(
                 moduleHasReason(json, "module-b", "DOWNSTREAM_TEST"),
                 "module-b should have DOWNSTREAM_TEST (test-scoped downstream of module-a)");
+    }
+
+    @Test
+    void trimMode_removesUnaffectedModules() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+
+        participant.afterProjectsRead(session);
+
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<List<MavenProject>> captor = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(session).setProjects(captor.capture());
+        List<MavenProject> trimmed = captor.getValue();
+        assertTrue(trimmed.contains(moduleA), "module-a should be in trimmed reactor");
+        assertFalse(trimmed.contains(moduleB), "module-b should NOT be in trimmed reactor");
+    }
+
+    @Test
+    void skipTestsMode_skipsUnaffectedModules() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+
+        participant.afterProjectsRead(session);
+
+        assertTrue(
+                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+                "module-b should have maven.test.skip=true");
+    }
+
+    @Test
+    void reportMode_forceBuildModulesIncludesMatching() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.forceBuildModules", "module-b");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(moduleHasReason(json, "module-b", "FORCE_BUILD"), "module-b should have FORCE_BUILD reason");
+    }
+
+    @Test
+    void reportMode_fullBuildTriggerCreatesFullBuildReport() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add(".github/workflows/ci.yml");
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.fullBuildTriggers", ".github/**");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"fullBuildTriggered\": true"), "Report should indicate full build triggered");
+    }
+
+    @Test
+    void reportMode_excludePathsFiltersChangedFiles() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/README.md");
+        changedFiles.add("module-b/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "**/*.md");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(modulePresent(json, "module-b"), "module-b should be in report");
+        assertFalse(modulePresent(json, "module-a"), "module-a should NOT be in report (excluded .md)");
+    }
+
+    // --- Helper methods ---
+
+    private void setupEmptyDependencyResolution() throws Exception {
+        DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
+        when(emptyResolution.getResolvedDependencies())
+                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenReturn(emptyResolution);
+    }
+
+    private MavenSession createSimpleSession(Path root, List<MavenProject> allProjects, String mode) {
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", mode);
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+        return session;
+    }
+
+    private String simpleParentPom(String... modules) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n");
+        sb.append("  <groupId>com.example</groupId>\n  <artifactId>parent</artifactId>\n  <version>1.0</version>\n");
+        sb.append("  <packaging>pom</packaging>\n  <modules>");
+        for (String m : modules) {
+            sb.append("<module>").append(m).append("</module>");
+        }
+        sb.append("</modules>\n</project>\n");
+        return sb.toString();
+    }
+
+    private String simpleChildPom(String artifactId) {
+        return "<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>" + artifactId + "</artifactId>\n</project>\n";
     }
 
     private void writePom(Path root, String relativePath, String content) throws Exception {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -32,6 +32,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ProjectDependencyGraph;
 import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.DefaultDependencyResolutionRequest;
@@ -522,6 +523,102 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(
                 moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY_TEST"),
                 "module-b should have TRANSITIVE_DEPENDENCY_TEST (test-scoped transitive dep)");
+    }
+
+    @Test
+    void reportMode_downstreamTestScopedModuleProducesDownstreamTestReason() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "</project>\n";
+        writePom(root, "pom.xml", parentPom);
+
+        String moduleAPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        // module-b depends on module-a via test scope
+        String moduleBPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version><scope>test</scope></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        // Add test-scoped dependency on module-a to module-b's model
+        Dependency dep = new Dependency();
+        dep.setGroupId("com.example");
+        dep.setArtifactId("module-a");
+        dep.setVersion("1.0");
+        dep.setScope("test");
+        moduleB.getDependencies().add(dep);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // module-a has a source change
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/com/example/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+
+        DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
+        when(emptyResolution.getResolvedDependencies())
+                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenReturn(emptyResolution);
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+
+        // Graph: module-b is downstream of module-a
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(moduleHasReason(json, "module-a", "SOURCE_CHANGE"), "module-a should have SOURCE_CHANGE");
+        assertTrue(
+                moduleHasReason(json, "module-b", "DOWNSTREAM_TEST"),
+                "module-b should have DOWNSTREAM_TEST (test-scoped downstream of module-a)");
     }
 
     private void writePom(Path root, String relativePath, String content) throws Exception {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -327,6 +327,203 @@ class ScalpelLifecycleParticipantTest {
         assertFalse(modulePresent(json, "module-a"), "module-a should NOT be in report (no plugin, no dep change)");
     }
 
+    @Test
+    void reportMode_testOnlySourceChangeProducesTestChangeReason() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "</project>\n";
+        writePom(root, "pom.xml", parentPom);
+
+        String moduleAPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "</project>\n";
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        String moduleBPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // module-a: test-only change (src/test/), module-b: main source change
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/test/java/com/example/MyTest.java");
+        changedFiles.add("module-b/src/main/java/com/example/Service.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+
+        DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
+        when(emptyResolution.getResolvedDependencies())
+                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenReturn(emptyResolution);
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(
+                moduleHasReason(json, "module-a", "TEST_CHANGE"),
+                "module-a should have TEST_CHANGE reason (only test files changed)");
+        assertTrue(
+                moduleHasReason(json, "module-b", "SOURCE_CHANGE"),
+                "module-b should have SOURCE_CHANGE reason (main source changed)");
+    }
+
+    @Test
+    void reportMode_testScopedTransitiveDependencyProducesTestReason() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties>\n"
+                + "    <lib.version>1.0</lib.version>\n"
+                + "  </properties>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency>\n"
+                + "      <groupId>commons-lang</groupId>\n"
+                + "      <artifactId>commons-lang</artifactId>\n"
+                + "      <version>${lib.version}</version>\n"
+                + "    </dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "</project>\n";
+
+        String newParentPom = oldParentPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
+        writePom(root, "pom.xml", newParentPom);
+
+        // module-a: uses managed dep directly
+        String moduleAPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        // module-b: gets commons-lang only via test scope transitively
+        String moduleBPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        // module-b: commons-lang is only via test scope
+        DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
+        org.eclipse.aether.graph.Dependency testDep = new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "test");
+        when(moduleBResolution.getResolvedDependencies()).thenReturn(Collections.singletonList(testDep));
+
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    if ("module-b".equals(req.getMavenProject().getArtifactId())) {
+                        return moduleBResolution;
+                    }
+                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
+                    when(empty.getResolvedDependencies())
+                            .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+                    return empty;
+                });
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(moduleHasReason(json, "module-a", "POM_CHANGE"));
+        assertTrue(
+                moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY_TEST"),
+                "module-b should have TRANSITIVE_DEPENDENCY_TEST (test-scoped transitive dep)");
+    }
+
     private void writePom(Path root, String relativePath, String content) throws Exception {
         Path pomFile = root.resolve(relativePath);
         Files.createDirectories(pomFile.getParent());

--- a/it/extension3-its/src/it/profile-aware/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/profile-aware/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/profile-aware/invoker.properties
+++ b/it/extension3-its/src/it/profile-aware/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=report -Pprod

--- a/it/extension3-its/src/it/profile-aware/module-a/pom.xml
+++ b/it/extension3-its/src/it/profile-aware/module-a/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.profileaware</groupId>
+        <artifactId>profile-aware</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <!-- References property from active 'prod' profile -->
+    <properties>
+        <my.app.version>${app.version}</my.app.version>
+    </properties>
+</project>

--- a/it/extension3-its/src/it/profile-aware/module-b/pom.xml
+++ b/it/extension3-its/src/it/profile-aware/module-b/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.profileaware</groupId>
+        <artifactId>profile-aware</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <!-- References property from inactive 'staging' profile -->
+    <properties>
+        <my.staging.url>${staging.url}</my.staging.url>
+    </properties>
+</project>

--- a/it/extension3-its/src/it/profile-aware/pom.xml
+++ b/it/extension3-its/src/it/profile-aware/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.profileaware</groupId>
+    <artifactId>profile-aware</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>prod</id>
+            <properties>
+                <app.version>1.0</app.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>staging</id>
+            <properties>
+                <staging.url>http://staging.example.com</staging.url>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/it/extension3-its/src/it/profile-aware/setup.groovy
+++ b/it/extension3-its/src/it/profile-aware/setup.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Profile-aware detection: change properties in both profiles (prod and staging).
+// Only 'prod' is activated via -Pprod; 'staging' remains inactive.
+// module-a references ${app.version} (from prod), module-b references ${staging.url} (from staging).
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Change properties in both profiles
+def pomFile = new File(dir, 'pom.xml')
+def pomText = pomFile.text
+pomText = pomText.replace('<app.version>1.0</app.version>', '<app.version>2.0</app.version>')
+pomText = pomText.replace('<staging.url>http://staging.example.com</staging.url>', '<staging.url>http://staging-v2.example.com</staging.url>')
+pomFile.text = pomText
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'change properties in both profiles')

--- a/it/extension3-its/src/it/profile-aware/verify.groovy
+++ b/it/extension3-its/src/it/profile-aware/verify.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+assert log.contains('Scalpel')
+assert log.contains('mode=report')
+assert log.contains('BUILD SUCCESS')
+
+// Check the report file
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists() : "Report file should have been created"
+
+def report = new groovy.json.JsonSlurper().parseText(reportFile.text)
+def modules = report.affectedModules
+
+def moduleA = modules.find { it.artifactId == 'module-a' }
+def moduleB = modules.find { it.artifactId == 'module-b' }
+
+// module-a should be affected: it references ${app.version} which changed in the active 'prod' profile
+assert moduleA != null : "module-a should appear in the report (references changed active profile property)"
+assert moduleA.reasons.contains('POM_CHANGE') : "module-a should have POM_CHANGE reason, got: ${moduleA.reasons}"
+
+// module-b should NOT be affected: it references ${staging.url} which changed in the inactive 'staging' profile
+assert moduleB == null : "module-b should NOT appear in the report (references property from inactive profile only)"
+
+// Changed properties should include app.version but NOT staging.url
+assert report.changedProperties.contains('app.version') : "changedProperties should contain 'app.version'"
+assert !report.changedProperties.contains('staging.url') : "changedProperties should NOT contain 'staging.url' (inactive profile)"

--- a/it/extension3-its/src/it/resource-filtering/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/resource-filtering/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/resource-filtering/invoker.properties
+++ b/it/extension3-its/src/it/resource-filtering/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=report

--- a/it/extension3-its/src/it/resource-filtering/module-a/pom.xml
+++ b/it/extension3-its/src/it/resource-filtering/module-a/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.resourcefiltering</groupId>
+        <artifactId>resource-filtering</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/it/extension3-its/src/it/resource-filtering/module-a/src/main/resources/app.properties
+++ b/it/extension3-its/src/it/resource-filtering/module-a/src/main/resources/app.properties
@@ -1,0 +1,2 @@
+app.name=${app.name}
+app.description=Application ${app.name}

--- a/it/extension3-its/src/it/resource-filtering/module-b/pom.xml
+++ b/it/extension3-its/src/it/resource-filtering/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.resourcefiltering</groupId>
+        <artifactId>resource-filtering</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/resource-filtering/pom.xml
+++ b/it/extension3-its/src/it/resource-filtering/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.resourcefiltering</groupId>
+    <artifactId>resource-filtering</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <app.name>MyApp</app.name>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/resource-filtering/setup.groovy
+++ b/it/extension3-its/src/it/resource-filtering/setup.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Resource filtering: module-a has filtered resources referencing ${app.name}.
+// Change the app.name property in parent POM.
+// module-a should be affected (filtered resource references changed property).
+// module-b should NOT be affected (no filtered resources, no property reference).
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Change the app.name property in parent POM
+def pomFile = new File(dir, 'pom.xml')
+def pomText = pomFile.text
+pomText = pomText.replace('<app.name>MyApp</app.name>', '<app.name>MyApp-v2</app.name>')
+pomFile.text = pomText
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'change app.name property')

--- a/it/extension3-its/src/it/resource-filtering/verify.groovy
+++ b/it/extension3-its/src/it/resource-filtering/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+assert log.contains('Scalpel')
+assert log.contains('mode=report')
+assert log.contains('BUILD SUCCESS')
+
+// Check the report file
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists() : "Report file should have been created"
+
+def report = new groovy.json.JsonSlurper().parseText(reportFile.text)
+def modules = report.affectedModules
+
+def moduleA = modules.find { it.artifactId == 'module-a' }
+def moduleB = modules.find { it.artifactId == 'module-b' }
+
+// module-a should be affected: it has filtered resources containing ${app.name}
+assert moduleA != null : "module-a should appear in the report (filtered resources reference changed property)"
+assert moduleA.reasons.contains('POM_CHANGE') : "module-a should have POM_CHANGE reason, got: ${moduleA.reasons}"
+
+// module-b should NOT be affected: no filtered resources, no property reference in POM
+assert moduleB == null : "module-b should NOT appear in the report (no filtered resources, no property reference)"
+
+// Changed properties should include app.name
+assert report.changedProperties.contains('app.name') : "changedProperties should contain 'app.name'"

--- a/it/extension3-its/src/it/test-only-changes/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/test-only-changes/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/test-only-changes/invoker.properties
+++ b/it/extension3-its/src/it/test-only-changes/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=report

--- a/it/extension3-its/src/it/test-only-changes/module-a/pom.xml
+++ b/it/extension3-its/src/it/test-only-changes/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.testonlychanges</groupId>
+        <artifactId>test-only-changes</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/test-only-changes/module-b/pom.xml
+++ b/it/extension3-its/src/it/test-only-changes/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.testonlychanges</groupId>
+        <artifactId>test-only-changes</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/test-only-changes/module-c/pom.xml
+++ b/it/extension3-its/src/it/test-only-changes/module-c/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.testonlychanges</groupId>
+        <artifactId>test-only-changes</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.testonlychanges</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/test-only-changes/pom.xml
+++ b/it/extension3-its/src/it/test-only-changes/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.testonlychanges</groupId>
+    <artifactId>test-only-changes</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/test-only-changes/setup.groovy
+++ b/it/extension3-its/src/it/test-only-changes/setup.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Test-only changes: module-a gets only test source changes, module-b gets main source changes.
+// module-c depends on module-a. Since module-a is test-only, module-c should NOT be downstream-affected.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Add test-only source to module-a
+new File(dir, 'module-a/src/test/java').mkdirs()
+new File(dir, 'module-a/src/test/java/FooTest.java').text = 'public class FooTest {}'
+
+// Add main source to module-b
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Bar.java').text = 'public class Bar {}'
+
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add test source to module-a, main source to module-b')

--- a/it/extension3-its/src/it/test-only-changes/verify.groovy
+++ b/it/extension3-its/src/it/test-only-changes/verify.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should be activated in report mode
+assert log.contains('Scalpel')
+assert log.contains('mode=report')
+assert log.contains('BUILD SUCCESS')
+
+// Check the report file
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists() : "Report file should have been created"
+
+def report = new groovy.json.JsonSlurper().parseText(reportFile.text)
+def modules = report.affectedModules
+
+def moduleA = modules.find { it.artifactId == 'module-a' }
+def moduleB = modules.find { it.artifactId == 'module-b' }
+def moduleC = modules.find { it.artifactId == 'module-c' }
+
+// module-a should have TEST_CHANGE reason (only test files changed)
+assert moduleA != null : "module-a should appear in the report"
+assert moduleA.reasons.contains('TEST_CHANGE') : "module-a should have TEST_CHANGE reason, got: ${moduleA.reasons}"
+
+// module-b should have SOURCE_CHANGE reason (main source changed)
+assert moduleB != null : "module-b should appear in the report"
+assert moduleB.reasons.contains('SOURCE_CHANGE') : "module-b should have SOURCE_CHANGE reason, got: ${moduleB.reasons}"
+
+// module-c should NOT appear in the report: it depends on module-a via compile scope,
+// but module-a only has test changes, so downstream propagation is suppressed
+assert moduleC == null : "module-c should NOT appear in the report (test-only module-a should not propagate to compile-scoped downstream)"


### PR DESCRIPTION
## Summary

- **Test-only source detection**: Changes in `src/test/` are classified separately (`TEST_CHANGE`) and only propagate downstream to test-jar consumers, avoiding unnecessary rebuilds of production code
- **Scope-aware downstream propagation**: Downstream modules connected via test-scoped dependencies get `DOWNSTREAM_TEST` reason and can have separate args applied
- **Transitive scope filtering**: Transitive dependency impact distinguishes test-scoped (`TRANSITIVE_DEPENDENCY_TEST`) from compile-scoped exposure
- **Profile-aware POM comparison**: Only active profile changes are considered; inactive profile modifications are ignored
- **Semantic plugin config diff**: Plugin configurations are compared structurally (Xpp3Dom tree) instead of via `toString()`, ignoring whitespace-only changes. Plugin executions are also compared.
- **Resource filtering property tracking**: When a parent property changes, child modules with `<filtering>true</filtering>` resources are scanned for `${property}` references to detect affected modules

## Test plan

- [x] All 30 existing tests pass (ModuleMapper: 9, PomChangeAnalyzer: 19, ScalpelLifecycleParticipant: 2)
- [x] New `ModuleMapperTest` covers test-path classification and project mapping
- [x] Full `mvn verify` passes across all modules
- [ ] Manual verification on a multi-module project with test-only changes
- [ ] Manual verification of profile-aware detection with active/inactive profiles
- [ ] Manual verification of resource filtering detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distinguishes test-only vs main-source changes, reporting TEST_CHANGE, DOWNSTREAM_TEST, and TRANSITIVE_DEPENDENCY_TEST reasons.
  * Considers active Maven profiles when evaluating parent POM changes.
  * Detects resource-filtering impact: child modules with filtering referencing changed parent properties are marked.

* **Documentation**
  * README updated with expanded "Affected module reasons", profile-aware semantics, plugin comparison details, and resource-filtering behavior.

* **Tests**
  * Expanded unit and integration tests covering classification, profile-awareness, plugin diffs, and resource-filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->