### PR TITLE
Detect managed dependency changes in import-scope BOM modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ for parent-inherited managed dependencies.
 
 For example, given this reactor layout:
 
-```
+```text
 parent/
 ├── bom/          (defines managed deps: commons-lang ${lib.version})
 ├── module-a/     (imports bom via <scope>import</scope>, uses commons-lang)

--- a/README.md
+++ b/README.md
@@ -371,6 +371,29 @@ Scalpel only considers changes inside profiles that are currently active. Change
 are ignored, preventing unnecessary rebuilds when modifying profiles that don't apply to the current
 build.
 
+### Import-Scope BOM Detection
+
+Scalpel detects managed dependency changes in reactor modules that are imported as BOMs via
+`<scope>import</scope>` in another module's `<dependencyManagement>`. When a BOM module's managed
+dependencies change, Scalpel propagates those changes to all importing modules — just as it does
+for parent-inherited managed dependencies.
+
+For example, given this reactor layout:
+
+```
+parent/
+├── bom/          (defines managed deps: commons-lang ${lib.version})
+├── module-a/     (imports bom via <scope>import</scope>, uses commons-lang)
+└── module-b/     (no BOM import)
+```
+
+If `bom/pom.xml` changes `lib.version` from `3.12` to `3.14`, Scalpel detects that:
+- `module-a` is directly affected (it imports the BOM and uses `commons-lang`)
+- `module-b` is not affected (it doesn't import the BOM or use the dependency)
+
+This works with all POM analysis features: property indirection, managed plugin changes,
+and transitive dependency checking.
+
 ### Property Indirection
 
 Scalpel resolves property indirection in managed dependencies and plugins. For example, if a parent POM

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -911,11 +911,8 @@ class PomChangeAnalyzer {
     }
 
     /**
-     * Find reactor modules that are imported as BOMs by other reactor modules.
-     * Scans each module's raw POM {@code <dependencyManagement>} for entries with
-     * {@code <type>pom</type><scope>import</scope>} that reference another reactor module.
-     *
-     * @return map of BOM module to the list of modules that import it
+     * Collect all modules that depend on the given project, combining reactor children
+     * (via parent inheritance) and BOM importers (via import-scope dependency management).
      */
     private List<MavenProject> collectDependents(
             MavenProject project,
@@ -937,6 +934,13 @@ class PomChangeAnalyzer {
         return dependents;
     }
 
+    /**
+     * Find reactor modules that are imported as BOMs by other reactor modules.
+     * Scans each module's raw POM {@code <dependencyManagement>} for entries with
+     * {@code <type>pom</type><scope>import</scope>} that reference another reactor module.
+     *
+     * @return map of BOM module to the list of modules that import it
+     */
     Map<MavenProject, List<MavenProject>> findBomImporters(List<MavenProject> allProjects) {
         Map<String, MavenProject> projectByGA = new LinkedHashMap<>();
         for (MavenProject project : allProjects) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -116,6 +116,9 @@ class PomChangeAnalyzer {
         // Build set of projects that have children in the reactor
         Set<MavenProject> parents = findParentProjects(allProjects);
 
+        // Build map of reactor modules imported as BOMs by other reactor modules
+        Map<MavenProject, List<MavenProject>> bomImporters = findBomImporters(allProjects);
+
         for (String changedPomPath : changedPomPaths) {
             MavenProject project = projectByPomPath.get(changedPomPath);
             if (project == null) {
@@ -123,20 +126,34 @@ class PomChangeAnalyzer {
                 continue;
             }
 
-            if (!parents.contains(project)) {
+            // Determine all dependent modules (children via parent inheritance + BOM importers)
+            List<MavenProject> dependents = new ArrayList<>();
+            if (parents.contains(project)) {
+                dependents.addAll(findChildren(project, allProjects));
+            }
+            List<MavenProject> importers = bomImporters.get(project);
+            if (importers != null) {
+                for (MavenProject importer : importers) {
+                    if (!dependents.contains(importer)) {
+                        dependents.add(importer);
+                    }
+                }
+            }
+
+            if (dependents.isEmpty()) {
                 // Leaf module: its own POM changed, mark it as affected
                 logger.debug("Leaf module POM changed: {}", key(project));
                 affected.add(project);
                 continue;
             }
 
-            // Parent/aggregator POM changed: analyze what actually changed
+            // Parent/BOM POM changed: analyze what actually changed
             byte[] oldPomBytes = oldPomContents.get(changedPomPath);
             if (oldPomBytes == null) {
-                // New POM (didn't exist in base), mark all children as affected
-                logger.debug("New parent POM: {}, marking all children as affected", key(project));
+                // New POM (didn't exist in base), mark all dependents as affected
+                logger.debug("New parent/BOM POM: {}, marking all dependents as affected", key(project));
                 affected.add(project);
-                affected.addAll(findChildren(project, allProjects));
+                affected.addAll(dependents);
                 continue;
             }
 
@@ -144,20 +161,20 @@ class PomChangeAnalyzer {
                 analyzeParentPomChange(
                         project,
                         oldPomBytes,
-                        allProjects,
+                        dependents,
                         reactorRoot,
                         affected,
                         allChangedManagedDepGAs,
                         allChangedManagedPluginGAs,
                         allChangedProperties);
             } catch (Exception e) {
-                // If we can't parse the old POM, be conservative and mark all children
+                // If we can't parse the old POM, be conservative and mark all dependents
                 logger.warn(
-                        "Cannot parse old POM for {}, marking all children as affected: {}",
+                        "Cannot parse old POM for {}, marking all dependents as affected: {}",
                         key(project),
                         e.getMessage());
                 affected.add(project);
-                affected.addAll(findChildren(project, allProjects));
+                affected.addAll(dependents);
             }
         }
 
@@ -167,7 +184,7 @@ class PomChangeAnalyzer {
     private void analyzeParentPomChange(
             MavenProject parentProject,
             byte[] oldPomBytes,
-            List<MavenProject> allProjects,
+            List<MavenProject> dependentProjects,
             Path reactorRoot,
             Set<MavenProject> affected,
             Set<String> allChangedManagedDepGAs,
@@ -293,9 +310,8 @@ class PomChangeAnalyzer {
                 changedManagedDeps,
                 changedManagedPlugins);
 
-        // Check each child to see if it's affected
-        List<MavenProject> children = findChildren(parentProject, allProjects);
-        for (MavenProject child : children) {
+        // Check each dependent (child or BOM importer) to see if it's affected
+        for (MavenProject child : dependentProjects) {
             if (affected.contains(child)) {
                 continue;
             }
@@ -901,6 +917,43 @@ class PomChangeAnalyzer {
             }
         }
         return parents;
+    }
+
+    /**
+     * Find reactor modules that are imported as BOMs by other reactor modules.
+     * Scans each module's raw POM {@code <dependencyManagement>} for entries with
+     * {@code <type>pom</type><scope>import</scope>} that reference another reactor module.
+     *
+     * @return map of BOM module to the list of modules that import it
+     */
+    Map<MavenProject, List<MavenProject>> findBomImporters(List<MavenProject> allProjects) {
+        Map<String, MavenProject> projectByGA = new LinkedHashMap<>();
+        for (MavenProject project : allProjects) {
+            projectByGA.put(project.getGroupId() + ":" + project.getArtifactId(), project);
+        }
+
+        Map<MavenProject, List<MavenProject>> result = new LinkedHashMap<>();
+
+        for (MavenProject project : allProjects) {
+            for (Dependency dep : getManagedDependencies(project.getOriginalModel())) {
+                if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
+                    String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+                    MavenProject bomProject = projectByGA.get(ga);
+                    if (bomProject != null && bomProject != project) {
+                        List<MavenProject> importers = result.get(bomProject);
+                        if (importers == null) {
+                            importers = new ArrayList<>();
+                            result.put(bomProject, importers);
+                        }
+                        if (!importers.contains(project)) {
+                            importers.add(project);
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
     }
 
     private List<MavenProject> findChildren(MavenProject parent, List<MavenProject> allProjects) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -127,18 +127,7 @@ class PomChangeAnalyzer {
             }
 
             // Determine all dependent modules (children via parent inheritance + BOM importers)
-            List<MavenProject> dependents = new ArrayList<>();
-            if (parents.contains(project)) {
-                dependents.addAll(findChildren(project, allProjects));
-            }
-            List<MavenProject> importers = bomImporters.get(project);
-            if (importers != null) {
-                for (MavenProject importer : importers) {
-                    if (!dependents.contains(importer)) {
-                        dependents.add(importer);
-                    }
-                }
-            }
+            List<MavenProject> dependents = collectDependents(project, parents, bomImporters, allProjects);
 
             if (dependents.isEmpty()) {
                 // Leaf module: its own POM changed, mark it as affected
@@ -151,7 +140,9 @@ class PomChangeAnalyzer {
             byte[] oldPomBytes = oldPomContents.get(changedPomPath);
             if (oldPomBytes == null) {
                 // New POM (didn't exist in base), mark all dependents as affected
-                logger.debug("New parent/BOM POM: {}, marking all dependents as affected", key(project));
+                if (logger.isDebugEnabled()) {
+                    logger.debug("New parent/BOM POM: {}, marking all dependents as affected", key(project));
+                }
                 affected.add(project);
                 affected.addAll(dependents);
                 continue;
@@ -926,6 +917,26 @@ class PomChangeAnalyzer {
      *
      * @return map of BOM module to the list of modules that import it
      */
+    private List<MavenProject> collectDependents(
+            MavenProject project,
+            Set<MavenProject> parents,
+            Map<MavenProject, List<MavenProject>> bomImporters,
+            List<MavenProject> allProjects) {
+        List<MavenProject> dependents = new ArrayList<>();
+        if (parents.contains(project)) {
+            dependents.addAll(findChildren(project, allProjects));
+        }
+        List<MavenProject> importers = bomImporters.get(project);
+        if (importers != null) {
+            for (MavenProject importer : importers) {
+                if (!dependents.contains(importer)) {
+                    dependents.add(importer);
+                }
+            }
+        }
+        return dependents;
+    }
+
     Map<MavenProject, List<MavenProject>> findBomImporters(List<MavenProject> allProjects) {
         Map<String, MavenProject> projectByGA = new LinkedHashMap<>();
         for (MavenProject project : allProjects) {
@@ -948,11 +959,7 @@ class PomChangeAnalyzer {
             String ga = dep.getGroupId() + ":" + dep.getArtifactId();
             MavenProject bomProject = projectByGA.get(ga);
             if (bomProject != null && bomProject != project) {
-                List<MavenProject> importers = result.get(bomProject);
-                if (importers == null) {
-                    importers = new ArrayList<>();
-                    result.put(bomProject, importers);
-                }
+                List<MavenProject> importers = result.computeIfAbsent(bomProject, k -> new ArrayList<>());
                 if (!importers.contains(project)) {
                     importers.add(project);
                 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -933,27 +933,35 @@ class PomChangeAnalyzer {
         }
 
         Map<MavenProject, List<MavenProject>> result = new LinkedHashMap<>();
-
         for (MavenProject project : allProjects) {
-            for (Dependency dep : getManagedDependencies(project.getOriginalModel())) {
-                if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
-                    String ga = dep.getGroupId() + ":" + dep.getArtifactId();
-                    MavenProject bomProject = projectByGA.get(ga);
-                    if (bomProject != null && bomProject != project) {
-                        List<MavenProject> importers = result.get(bomProject);
-                        if (importers == null) {
-                            importers = new ArrayList<>();
-                            result.put(bomProject, importers);
-                        }
-                        if (!importers.contains(project)) {
-                            importers.add(project);
-                        }
-                    }
+            collectBomImportsFrom(project, projectByGA, result);
+        }
+        return result;
+    }
+
+    private void collectBomImportsFrom(
+            MavenProject project, Map<String, MavenProject> projectByGA, Map<MavenProject, List<MavenProject>> result) {
+        for (Dependency dep : getManagedDependencies(project.getOriginalModel())) {
+            if (!isImportScopeBom(dep)) {
+                continue;
+            }
+            String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+            MavenProject bomProject = projectByGA.get(ga);
+            if (bomProject != null && bomProject != project) {
+                List<MavenProject> importers = result.get(bomProject);
+                if (importers == null) {
+                    importers = new ArrayList<>();
+                    result.put(bomProject, importers);
+                }
+                if (!importers.contains(project)) {
+                    importers.add(project);
                 }
             }
         }
+    }
 
-        return result;
+    private boolean isImportScopeBom(Dependency dep) {
+        return "pom".equals(dep.getType()) && "import".equals(dep.getScope());
     }
 
     private List<MavenProject> findChildren(MavenProject parent, List<MavenProject> allProjects) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -2209,7 +2209,310 @@ class PomChangeAnalyzerTest {
         assertTrue(affected.isEmpty(), "Unmatched POM path should not affect any module");
     }
 
+    // --- Import-scope BOM detection tests ---
+
+    @Test
+    void analyzeChanges_bomImportScopeManagedDepChangeAffectsImporter() throws Exception {
+        // BOM module defines managed dep lib-x. module-a imports the BOM and uses lib-x.
+        // When BOM's managed dep version changes, module-a should be affected.
+        Path root = setupReactorRootWithBom();
+        List<MavenProject> projects = createReactorWithBomImport(root);
+
+        // Old BOM POM had lib-x:1.0
+        String oldBomPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>bom</artifactId>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency>\n"
+                + "      <groupId>com.example</groupId>\n"
+                + "      <artifactId>lib-x</artifactId>\n"
+                + "      <version>1.0</version>\n"
+                + "    </dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("bom/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        MavenProject moduleA = projects.get(2);
+        MavenProject moduleB = projects.get(3);
+
+        assertTrue(
+                result.getAffectedProjects().contains(moduleA),
+                "module-a imports BOM and uses managed dep lib-x, should be affected");
+        assertFalse(
+                result.getAffectedProjects().contains(moduleB), "module-b does not import BOM, should NOT be affected");
+        assertTrue(
+                result.getChangedManagedDependencyGAs().contains("com.example:lib-x"),
+                "Changed managed dep GAs should include lib-x");
+    }
+
+    @Test
+    void analyzeChanges_bomImportScopeNoChangeNotAffected() throws Exception {
+        // BOM POM changed cosmetically (same managed deps), importers should not be affected
+        Path root = setupReactorRootWithBom();
+        List<MavenProject> projects = createReactorWithBomImport(root);
+
+        // Old BOM POM is identical to current (lib-x:2.0)
+        String oldBomPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>bom</artifactId>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency>\n"
+                + "      <groupId>com.example</groupId>\n"
+                + "      <artifactId>lib-x</artifactId>\n"
+                + "      <version>2.0</version>\n"
+                + "    </dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "</project>\n";
+
+        Set<String> changedPoms = Collections.singleton("bom/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(result.getAffectedProjects().isEmpty(), "Cosmetic BOM change should not affect any module");
+    }
+
+    @Test
+    void analyzeChanges_bomImportScopePropertyIndirection() throws Exception {
+        // BOM uses property for managed dep version. When property changes,
+        // importing module using that managed dep should be affected.
+        Path root = setupReactorRootWithBom();
+
+        // BOM with property-based version
+        String bomPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>bom</artifactId>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <properties>\n"
+                + "    <lib.version>2.0</lib.version>\n"
+                + "  </properties>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency>\n"
+                + "      <groupId>com.example</groupId>\n"
+                + "      <artifactId>lib-x</artifactId>\n"
+                + "      <version>${lib.version}</version>\n"
+                + "    </dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "</project>\n";
+        writePom(root.resolve("bom/pom.xml"), bomPomXml);
+
+        List<MavenProject> projects = createReactorWithBomImportCustomBom(root, bomPomXml);
+
+        // Old BOM POM had lib.version=1.0
+        String oldBomPom = bomPomXml.replace("<lib.version>2.0</lib.version>", "<lib.version>1.0</lib.version>");
+
+        Set<String> changedPoms = Collections.singleton("bom/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        MavenProject moduleA = projects.get(2);
+        assertTrue(
+                result.getAffectedProjects().contains(moduleA),
+                "module-a uses managed dep lib-x whose version comes from changed property in BOM");
+        assertTrue(
+                result.getChangedManagedDependencyGAs().contains("com.example:lib-x"),
+                "Changed managed dep GAs should include lib-x (via property indirection in BOM)");
+    }
+
+    @Test
+    void analyzeChanges_bomImportScopeNewBomMarksAllImporters() throws Exception {
+        // New BOM POM (no old bytes) should mark all importers as affected
+        Path root = setupReactorRootWithBom();
+        List<MavenProject> projects = createReactorWithBomImport(root);
+
+        Set<String> changedPoms = Collections.singleton("bom/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        // No entry for bom/pom.xml = new file
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        MavenProject bom = projects.get(1);
+        MavenProject moduleA = projects.get(2);
+
+        assertTrue(result.getAffectedProjects().contains(bom), "BOM should be affected");
+        assertTrue(result.getAffectedProjects().contains(moduleA), "module-a (BOM importer) should be affected");
+    }
+
+    @Test
+    void findBomImporters_detectsImportScopeEntries() {
+        // Verify findBomImporters correctly detects import-scope BOM entries
+        MavenProject parent = createProject(
+                "com.example", "parent", "1.0", tempDir.resolve("pom.xml").toFile());
+        parent.setOriginalModel(parseModel("<?xml version=\"1.0\"?>\n"
+                + "<project><modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "</project>"));
+
+        MavenProject bom = createProject(
+                "com.example", "bom", "1.0", tempDir.resolve("bom/pom.xml").toFile());
+        bom.setOriginalModel(parseModel("<?xml version=\"1.0\"?>\n"
+                + "<project><modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId><artifactId>bom</artifactId><version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "</project>"));
+
+        MavenProject moduleA = createProject(
+                "com.example",
+                "module-a",
+                "1.0",
+                tempDir.resolve("module-a/pom.xml").toFile());
+        moduleA.setOriginalModel(parseModel("<?xml version=\"1.0\"?>\n"
+                + "<project><modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>bom</artifactId>"
+                + "<version>1.0</version><type>pom</type><scope>import</scope></dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "</project>"));
+
+        MavenProject moduleB = createProject(
+                "com.example",
+                "module-b",
+                "1.0",
+                tempDir.resolve("module-b/pom.xml").toFile());
+        moduleB.setOriginalModel(parseModel("<?xml version=\"1.0\"?>\n"
+                + "<project><modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId><artifactId>module-b</artifactId><version>1.0</version>\n"
+                + "</project>"));
+
+        List<MavenProject> projects = new ArrayList<>();
+        projects.add(parent);
+        projects.add(bom);
+        projects.add(moduleA);
+        projects.add(moduleB);
+
+        Map<MavenProject, List<MavenProject>> result = analyzer.findBomImporters(projects);
+
+        assertTrue(result.containsKey(bom), "BOM should be detected as imported");
+        assertEquals(1, result.get(bom).size(), "BOM should have exactly one importer");
+        assertTrue(result.get(bom).contains(moduleA), "module-a should be an importer of BOM");
+        assertFalse(result.containsKey(parent), "parent should not be detected as a BOM");
+    }
+
     // --- Helper methods ---
+
+    private Path setupReactorRootWithBom() throws IOException {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+        Files.createDirectories(root.resolve("bom"));
+        Files.createDirectories(root.resolve("module-a"));
+        Files.createDirectories(root.resolve("module-b"));
+        return root;
+    }
+
+    private List<MavenProject> createReactorWithBomImport(Path root) throws IOException {
+        String bomPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>bom</artifactId>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency>\n"
+                + "      <groupId>com.example</groupId>\n"
+                + "      <artifactId>lib-x</artifactId>\n"
+                + "      <version>2.0</version>\n"
+                + "    </dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "</project>\n";
+        return createReactorWithBomImportCustomBom(root, bomPomXml);
+    }
+
+    private List<MavenProject> createReactorWithBomImportCustomBom(Path root, String bomPomXml) throws IOException {
+        String parentPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>bom</module><module>module-a</module><module>module-b</module></modules>\n"
+                + "</project>\n";
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        writePom(root.resolve("bom/pom.xml"), bomPomXml);
+
+        // module-a: imports BOM, uses lib-x
+        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency>\n"
+                + "      <groupId>com.example</groupId>\n"
+                + "      <artifactId>bom</artifactId>\n"
+                + "      <version>${project.version}</version>\n"
+                + "      <type>pom</type>\n"
+                + "      <scope>import</scope>\n"
+                + "    </dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        // module-b: no BOM import, no lib-x
+        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "</project>\n";
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        MavenProject parent = createProject(
+                "com.example", "parent", "1.0", root.resolve("pom.xml").toFile());
+        parent.setOriginalModel(parseModel(parentPomXml));
+        parent.getModel().setPackaging("pom");
+
+        MavenProject bom = createProject(
+                "com.example", "bom", "1.0", root.resolve("bom/pom.xml").toFile());
+        bom.setOriginalModel(parseModel(bomPomXml));
+        bom.getModel().setPackaging("pom");
+        bom.setParent(parent);
+
+        MavenProject moduleA = createProject(
+                "com.example",
+                "module-a",
+                "1.0",
+                root.resolve("module-a/pom.xml").toFile());
+        moduleA.setOriginalModel(parseModel(moduleAPomXml));
+        moduleA.setParent(parent);
+
+        MavenProject moduleB = createProject(
+                "com.example",
+                "module-b",
+                "1.0",
+                root.resolve("module-b/pom.xml").toFile());
+        moduleB.setOriginalModel(parseModel(moduleBPomXml));
+        moduleB.setParent(parent);
+
+        List<MavenProject> projects = new ArrayList<>();
+        projects.add(parent);
+        projects.add(bom);
+        projects.add(moduleA);
+        projects.add(moduleB);
+        return projects;
+    }
 
     private Path setupReactorRoot() throws IOException {
         Path root = tempDir.resolve("project");

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -810,6 +810,166 @@ class ScalpelLifecycleParticipantTest {
         assertFalse(modulePresent(json, "module-a"), "module-a should NOT be in report (excluded .md)");
     }
 
+    @Test
+    void reportMode_bomImportScopeDetected() throws Exception {
+        // BOM module defines managed dep commons-lang. module-a imports the BOM and uses it.
+        // module-b depends on module-a (gets commons-lang transitively).
+        // module-c has no relationship to the BOM.
+        // When BOM's managed dep version changes, module-a should be directly affected
+        // and module-b should be transitively affected.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // Parent POM (no managed deps — those are in the BOM)
+        String parentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>bom</module><module>module-a</module><module>module-b</module><module>module-c</module></modules>\n"
+                + "</project>\n";
+        writePom(root, "pom.xml", parentPom);
+
+        // Old BOM POM (before version change)
+        String oldBomPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>bom</artifactId>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <properties><lib.version>1.0</lib.version></properties>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId><version>${lib.version}</version></dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "</project>\n";
+
+        // New BOM POM (after version bump)
+        String newBomPom = oldBomPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
+        writePom(root, "bom/pom.xml", newBomPom);
+
+        // module-a: imports BOM, uses commons-lang
+        String moduleAPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "  <dependencyManagement><dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>bom</artifactId>"
+                + "<version>${project.version}</version><type>pom</type><scope>import</scope></dependency>\n"
+                + "  </dependencies></dependencyManagement>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        // module-b: depends on module-a (gets commons-lang transitively)
+        String moduleBPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "  <dependencies>\n"
+                + "    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version></dependency>\n"
+                + "  </dependencies>\n"
+                + "</project>\n";
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        // module-c: no dependencies
+        String moduleCPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-c</artifactId>\n"
+                + "</project>\n";
+        writePom(root, "module-c/pom.xml", moduleCPom);
+
+        // Build MavenProject objects
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject bomProject = createProject("com.example", "bom", "1.0", root, "bom/pom.xml", newBomPom);
+        bomProject.getModel().setPackaging("pom");
+        bomProject.setParent(parentProject);
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
+        moduleC.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, bomProject, moduleA, moduleB, moduleC);
+
+        // Mock ScalpelCore to return changed BOM POM
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("bom/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        // Mock dependency resolution: module-b has commons-lang transitively
+        DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
+        org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
+        when(moduleBResolution.getResolvedDependencies()).thenReturn(Collections.singletonList(commonsLangDep));
+
+        // Other modules: no matching deps
+        DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
+        when(emptyResolution.getResolvedDependencies())
+                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    if ("module-b".equals(req.getMavenProject().getArtifactId())) {
+                        return moduleBResolution;
+                    }
+                    return emptyResolution;
+                });
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // module-a should be directly affected (uses changed managed dep from imported BOM)
+        assertTrue(
+                moduleHasReason(json, "module-a", "POM_CHANGE"),
+                "module-a should have POM_CHANGE reason (imports BOM with changed managed dep)");
+
+        // module-b should be transitively affected (gets commons-lang through module-a)
+        assertTrue(
+                moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY"),
+                "module-b should have TRANSITIVE_DEPENDENCY reason");
+
+        // module-c should NOT be in the report
+        assertFalse(modulePresent(json, "module-c"), "module-c should NOT be in report");
+
+        // The report should show the changed managed dependency GA
+        assertTrue(json.contains("commons-lang:commons-lang"), "Report should include changed managed dep GA");
+    }
+
     // --- Helper methods ---
 
     private void setupEmptyDependencyResolution() throws Exception {

--- a/it/extension3-its/src/it/bom-import/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/bom-import/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/bom-import/bom/pom.xml
+++ b/it/extension3-its/src/it/bom-import/bom/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.bomimport</groupId>
+        <artifactId>bom-import</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bom</artifactId>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <commons-lang.version>2.5</commons-lang.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/it/extension3-its/src/it/bom-import/invoker.properties
+++ b/it/extension3-its/src/it/bom-import/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=report

--- a/it/extension3-its/src/it/bom-import/module-a/pom.xml
+++ b/it/extension3-its/src/it/bom-import/module-a/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.bomimport</groupId>
+        <artifactId>bom-import</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>eu.maveniverse.maven.scalpel.it.bomimport</groupId>
+                <artifactId>bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/bom-import/module-b/pom.xml
+++ b/it/extension3-its/src/it/bom-import/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.bomimport</groupId>
+        <artifactId>bom-import</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.bomimport</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/bom-import/module-c/pom.xml
+++ b/it/extension3-its/src/it/bom-import/module-c/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.bomimport</groupId>
+        <artifactId>bom-import</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/bom-import/pom.xml
+++ b/it/extension3-its/src/it/bom-import/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.bomimport</groupId>
+    <artifactId>bom-import</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>bom</module>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/bom-import/setup.groovy
+++ b/it/extension3-its/src/it/bom-import/setup.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, bump managed dependency version in BOM module
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Bump the managed dependency version in the BOM module POM
+def bomPom = new File(dir, 'bom/pom.xml')
+def bomText = bomPom.text
+bomText = bomText.replace('<commons-lang.version>2.5</commons-lang.version>', '<commons-lang.version>2.6</commons-lang.version>')
+bomPom.text = bomText
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'bump commons-lang version in BOM')

--- a/it/extension3-its/src/it/bom-import/verify.groovy
+++ b/it/extension3-its/src/it/bom-import/verify.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated in report mode
+assert log.contains('Scalpel')
+assert log.contains('mode=report')
+
+// Report should have been written
+assert log.contains('Report written to')
+
+// All modules should still be present in reactor (no trimming in report mode)
+assert log.contains('BUILD SUCCESS')
+
+// module-a should be directly affected (imports BOM with changed managed dependency)
+assert log.contains('directly affected')
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine != null : "Expected 'directly affected' log line"
+assert directlyAffectedLine.contains('module-a') : "module-a should be directly affected (imports BOM with changed managed dep)"
+
+// module-b should be transitively affected (gets commons-lang through module-a)
+assert log.contains('transitively affected')
+def transitivelyAffectedLine = log.readLines().find { it.contains('transitively affected') }
+assert transitivelyAffectedLine != null : "Expected 'transitively affected' log line"
+assert transitivelyAffectedLine.contains('module-b') : "module-b should be transitively affected"
+
+// Check the report file
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists() : "Report file should have been created"
+
+String json = reportFile.text
+def report = new groovy.json.JsonSlurper().parseText(json)
+
+assert report.version == '1' : "Report should have version 1"
+assert report.fullBuildTriggered == false : "fullBuildTriggered should be false"
+assert report.changedManagedDependencies.contains('commons-lang:commons-lang') : "changedManagedDependencies should contain commons-lang"
+
+def modules = report.affectedModules
+def moduleA = modules.find { it.artifactId == 'module-a' }
+def moduleB = modules.find { it.artifactId == 'module-b' }
+def moduleC = modules.find { it.artifactId == 'module-c' }
+
+// module-a should be affected with POM_CHANGE reason (imports BOM with changed managed dep)
+assert moduleA != null : "module-a should appear in the report"
+assert moduleA.reasons.contains('POM_CHANGE') : "module-a should have POM_CHANGE reason, got: ${moduleA.reasons}"
+
+// module-b should be affected with TRANSITIVE_DEPENDENCY reason (gets commons-lang through module-a)
+assert moduleB != null : "module-b should appear in the report"
+assert moduleB.reasons.contains('TRANSITIVE_DEPENDENCY') : "module-b should have TRANSITIVE_DEPENDENCY reason, got: ${moduleB.reasons}"
+
+// module-c should NOT appear in the report (no relationship to changed dependency)
+assert moduleC == null : "module-c should NOT appear in the report"

--- a/it/extension3-its/src/it/bom-import/verify.groovy
+++ b/it/extension3-its/src/it/bom-import/verify.groovy
@@ -21,15 +21,15 @@ assert log.contains('BUILD SUCCESS')
 
 // module-a should be directly affected (imports BOM with changed managed dependency)
 assert log.contains('directly affected')
-def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
-assert directlyAffectedLine != null : "Expected 'directly affected' log line"
-assert directlyAffectedLine.contains('module-a') : "module-a should be directly affected (imports BOM with changed managed dep)"
+def directlyAffectedLines = log.readLines().findAll { it.contains('directly affected') }
+assert !directlyAffectedLines.isEmpty() : "Expected 'directly affected' log line(s)"
+assert directlyAffectedLines.any { it.contains('module-a') } : "module-a should be directly affected (imports BOM with changed managed dep)"
 
 // module-b should be transitively affected (gets commons-lang through module-a)
 assert log.contains('transitively affected')
-def transitivelyAffectedLine = log.readLines().find { it.contains('transitively affected') }
-assert transitivelyAffectedLine != null : "Expected 'transitively affected' log line"
-assert transitivelyAffectedLine.contains('module-b') : "module-b should be transitively affected"
+def transitivelyAffectedLines = log.readLines().findAll { it.contains('transitively affected') }
+assert !transitivelyAffectedLines.isEmpty() : "Expected 'transitively affected' log line(s)"
+assert transitivelyAffectedLines.any { it.contains('module-b') } : "module-b should be transitively affected"
 
 // Check the report file
 File reportFile = new File(basedir, 'target/scalpel-report.json')


### PR DESCRIPTION
## Summary
- Detect managed dependency changes in reactor modules imported as BOMs via `<scope>import</scope>` in `<dependencyManagement>`
- When a BOM module's managed dependencies change, propagate those changes to all importing modules — just as Scalpel already does for parent-inherited managed dependencies
- Reuses all existing POM analysis logic (property indirection, managed dep/plugin diffing, profile awareness, resource filtering) for both parent-child and BOM-importer relationships

Closes #10

## Test plan
- [x] 5 new unit tests in `PomChangeAnalyzerTest` covering BOM import detection, no-change filtering, property indirection, and new BOM scenarios
- [x] 1 new end-to-end test in `ScalpelLifecycleParticipantTest` with parent/bom/module-a/module-b/module-c reactor
- [x] 1 new Maven Invoker IT (`bom-import`) verifying report output with real Maven build
- [x] All 68 existing tests pass
- [x] README updated with "Import-Scope BOM Detection" subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects BOM import-scope usage in multi-module reactors and treats managed-dependency changes in a BOM as affecting its importing modules, marking importers appropriately.

* **Documentation**
  * README: added "Import-Scope BOM Detection" describing propagation rules and interaction with existing POM analysis (property indirection, managed plugins, transitive checks).

* **Tests**
  * Added unit, integration and ITs validating import-scope detection, report contents, affected-module classifications, and changed managed-dependency reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->