### PR TITLE
Add skipTestsForDownstreamModules property (#14)

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -33,6 +33,7 @@ public final class ScalpelConfiguration {
     public static final String DISABLE_ON_SELECTED_PROJECTS = PREFIX + "disableOnSelectedProjects";
 
     public static final String SKIP_TESTS_FOR_UPSTREAM = PREFIX + "skipTestsForUpstream";
+    public static final String SKIP_TESTS_FOR_DOWNSTREAM_MODULES = PREFIX + "skipTestsForDownstreamModules";
     public static final String UPSTREAM_ARGS = PREFIX + "upstreamArgs";
     public static final String DOWNSTREAM_ARGS = PREFIX + "downstreamArgs";
 
@@ -66,6 +67,7 @@ public final class ScalpelConfiguration {
     private final boolean disableOnSelectedProjects;
     private final boolean fetchBaseBranch;
     private final boolean skipTestsForUpstream;
+    private final List<String> skipTestsForDownstreamModules;
     private final List<String> upstreamArgs;
     private final List<String> downstreamArgs;
     private final boolean uncommitted;
@@ -91,6 +93,7 @@ public final class ScalpelConfiguration {
             boolean disableOnSelectedProjects,
             boolean fetchBaseBranch,
             boolean skipTestsForUpstream,
+            List<String> skipTestsForDownstreamModules,
             List<String> upstreamArgs,
             List<String> downstreamArgs,
             boolean uncommitted,
@@ -114,6 +117,7 @@ public final class ScalpelConfiguration {
         this.disableOnSelectedProjects = disableOnSelectedProjects;
         this.fetchBaseBranch = fetchBaseBranch;
         this.skipTestsForUpstream = skipTestsForUpstream;
+        this.skipTestsForDownstreamModules = skipTestsForDownstreamModules;
         this.upstreamArgs = upstreamArgs;
         this.downstreamArgs = downstreamArgs;
         this.uncommitted = uncommitted;
@@ -145,6 +149,8 @@ public final class ScalpelConfiguration {
                 Boolean.parseBoolean(resolve(system, user, DISABLE_ON_SELECTED_PROJECTS, "false"));
         boolean fetchBaseBranch = Boolean.parseBoolean(resolve(system, user, FETCH_BASE_BRANCH, "false"));
         boolean skipTestsForUpstream = Boolean.parseBoolean(resolve(system, user, SKIP_TESTS_FOR_UPSTREAM, "false"));
+        List<String> skipTestsForDownstreamModules =
+                parseList(resolve(system, user, SKIP_TESTS_FOR_DOWNSTREAM_MODULES, null));
         List<String> upstreamArgs = parseList(resolve(system, user, UPSTREAM_ARGS, null));
         List<String> downstreamArgs = parseList(resolve(system, user, DOWNSTREAM_ARGS, null));
         boolean uncommitted = Boolean.parseBoolean(resolve(system, user, UNCOMMITTED, "false"));
@@ -170,6 +176,7 @@ public final class ScalpelConfiguration {
                 disableOnSelectedProjects,
                 fetchBaseBranch,
                 skipTestsForUpstream,
+                skipTestsForDownstreamModules,
                 upstreamArgs,
                 downstreamArgs,
                 uncommitted,
@@ -272,6 +279,10 @@ public final class ScalpelConfiguration {
         return skipTestsForUpstream;
     }
 
+    public List<String> getSkipTestsForDownstreamModules() {
+        return skipTestsForDownstreamModules;
+    }
+
     public List<String> getUpstreamArgs() {
         return upstreamArgs;
     }
@@ -341,6 +352,7 @@ public final class ScalpelConfiguration {
                 + ", disableOnSelectedProjects=" + disableOnSelectedProjects
                 + ", fetchBaseBranch=" + fetchBaseBranch
                 + ", skipTestsForUpstream=" + skipTestsForUpstream
+                + ", skipTestsForDownstreamModules=" + skipTestsForDownstreamModules
                 + ", upstreamArgs=" + upstreamArgs
                 + ", downstreamArgs=" + downstreamArgs
                 + ", uncommitted=" + uncommitted

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -163,28 +163,7 @@ public final class ScalpelReport {
         } else {
             sb.append("[\n");
             for (int i = 0; i < affectedModules.size(); i++) {
-                AffectedModule m = affectedModules.get(i);
-                sb.append("    {\n");
-                sb.append("      \"groupId\": ").append(jsonString(m.groupId)).append(",\n");
-                sb.append("      \"artifactId\": ")
-                        .append(jsonString(m.artifactId))
-                        .append(",\n");
-                sb.append("      \"path\": ").append(jsonString(m.path)).append(",\n");
-                sb.append("      \"reasons\": ").append(jsonStringArray(m.reasons));
-                if (m.category != null) {
-                    sb.append(",\n");
-                    sb.append("      \"category\": ").append(jsonString(m.category));
-                }
-                if (m.sourceSet != null) {
-                    sb.append(",\n");
-                    sb.append("      \"sourceSet\": ").append(jsonString(m.sourceSet));
-                }
-                if (m.testsSkippedReason != null) {
-                    sb.append(",\n");
-                    sb.append("      \"testsSkippedReason\": ").append(jsonString(m.testsSkippedReason));
-                }
-                sb.append("\n");
-                sb.append("    }");
+                appendModuleJson(sb, affectedModules.get(i));
                 if (i < affectedModules.size() - 1) {
                     sb.append(",");
                 }
@@ -194,6 +173,26 @@ public final class ScalpelReport {
         }
         sb.append("\n}\n");
         return sb.toString();
+    }
+
+    private static void appendModuleJson(StringBuilder sb, AffectedModule m) {
+        sb.append("    {\n");
+        sb.append("      \"groupId\": ").append(jsonString(m.groupId)).append(",\n");
+        sb.append("      \"artifactId\": ").append(jsonString(m.artifactId)).append(",\n");
+        sb.append("      \"path\": ").append(jsonString(m.path)).append(",\n");
+        sb.append("      \"reasons\": ").append(jsonStringArray(m.reasons));
+        appendOptionalField(sb, "category", m.category);
+        appendOptionalField(sb, "sourceSet", m.sourceSet);
+        appendOptionalField(sb, "testsSkippedReason", m.testsSkippedReason);
+        sb.append("\n");
+        sb.append("    }");
+    }
+
+    private static void appendOptionalField(StringBuilder sb, String name, String value) {
+        if (value != null) {
+            sb.append(",\n");
+            sb.append("      \"").append(name).append("\": ").append(jsonString(value));
+        }
     }
 
     public void writeToFile(Path reactorRoot, String reportFile) throws IOException {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -27,6 +27,7 @@ public final class ScalpelReport {
     public static final String REASON_TEST_CHANGE = "TEST_CHANGE";
     public static final String REASON_DOWNSTREAM_TEST = "DOWNSTREAM_TEST";
     public static final String REASON_TRANSITIVE_DEPENDENCY_TEST = "TRANSITIVE_DEPENDENCY_TEST";
+    public static final String REASON_EXCLUDED_DOWNSTREAM = "EXCLUDED_DOWNSTREAM";
 
     public static final String CATEGORY_DIRECT = "DIRECT";
     public static final String CATEGORY_UPSTREAM = "UPSTREAM";
@@ -67,13 +68,14 @@ public final class ScalpelReport {
         private final List<String> reasons;
         private final String category;
         private final String sourceSet;
+        private final String testsSkippedReason;
 
         public AffectedModule(String groupId, String artifactId, String path, List<String> reasons) {
-            this(groupId, artifactId, path, reasons, null, null);
+            this(groupId, artifactId, path, reasons, null, null, null);
         }
 
         public AffectedModule(String groupId, String artifactId, String path, List<String> reasons, String category) {
-            this(groupId, artifactId, path, reasons, category, null);
+            this(groupId, artifactId, path, reasons, category, null, null);
         }
 
         public AffectedModule(
@@ -83,6 +85,17 @@ public final class ScalpelReport {
                 List<String> reasons,
                 String category,
                 String sourceSet) {
+            this(groupId, artifactId, path, reasons, category, sourceSet, null);
+        }
+
+        public AffectedModule(
+                String groupId,
+                String artifactId,
+                String path,
+                List<String> reasons,
+                String category,
+                String sourceSet,
+                String testsSkippedReason) {
             if (sourceSet != null && !"main".equals(sourceSet) && !"test".equals(sourceSet)) {
                 throw new IllegalArgumentException("sourceSet must be 'main', 'test', or null");
             }
@@ -92,6 +105,7 @@ public final class ScalpelReport {
             this.reasons = reasons;
             this.category = category;
             this.sourceSet = sourceSet;
+            this.testsSkippedReason = testsSkippedReason;
         }
 
         public String getGroupId() {
@@ -116,6 +130,10 @@ public final class ScalpelReport {
 
         public String getSourceSet() {
             return sourceSet;
+        }
+
+        public String getTestsSkippedReason() {
+            return testsSkippedReason;
         }
     }
 
@@ -160,6 +178,10 @@ public final class ScalpelReport {
                 if (m.sourceSet != null) {
                     sb.append(",\n");
                     sb.append("      \"sourceSet\": ").append(jsonString(m.sourceSet));
+                }
+                if (m.testsSkippedReason != null) {
+                    sb.append(",\n");
+                    sb.append("      \"testsSkippedReason\": ").append(jsonString(m.testsSkippedReason));
                 }
                 sb.append("\n");
                 sb.append("    }");

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class ScalpelConfigurationTest {
+
+    @Test
+    void skipTestsForDownstreamModules_defaultIsEmpty() {
+        Properties system = new Properties();
+        system.setProperty("scalpel.baseBranch", "main");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(system, new Properties());
+        assertTrue(config.getSkipTestsForDownstreamModules().isEmpty());
+    }
+
+    @Test
+    void skipTestsForDownstreamModules_singleArtifactId() {
+        Properties system = new Properties();
+        system.setProperty("scalpel.baseBranch", "main");
+        system.setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(system, new Properties());
+        assertEquals(Arrays.asList("module-b"), config.getSkipTestsForDownstreamModules());
+    }
+
+    @Test
+    void skipTestsForDownstreamModules_multipleCommaSeparated() {
+        Properties system = new Properties();
+        system.setProperty("scalpel.baseBranch", "main");
+        system.setProperty("scalpel.skipTestsForDownstreamModules", "module-b,module-c");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(system, new Properties());
+        assertEquals(Arrays.asList("module-b", "module-c"), config.getSkipTestsForDownstreamModules());
+    }
+
+    @Test
+    void skipTestsForDownstreamModules_groupIdColonArtifactId() {
+        Properties system = new Properties();
+        system.setProperty("scalpel.baseBranch", "main");
+        system.setProperty("scalpel.skipTestsForDownstreamModules", "com.example:module-b");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(system, new Properties());
+        assertEquals(Arrays.asList("com.example:module-b"), config.getSkipTestsForDownstreamModules());
+    }
+
+    @Test
+    void skipTestsForDownstreamModules_fromUserProperties() {
+        Properties system = new Properties();
+        system.setProperty("scalpel.baseBranch", "main");
+        Properties user = new Properties();
+        user.setProperty("scalpel.skipTestsForDownstreamModules", "module-x");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(system, user);
+        assertEquals(Arrays.asList("module-x"), config.getSkipTestsForDownstreamModules());
+    }
+
+    @Test
+    void skipTestsForDownstreamModules_appearsInToString() {
+        Properties system = new Properties();
+        system.setProperty("scalpel.baseBranch", "main");
+        system.setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(system, new Properties());
+        assertTrue(config.toString().contains("skipTestsForDownstreamModules=[module-b]"));
+    }
+}

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -219,6 +219,86 @@ class ScalpelReportTest {
     }
 
     @Test
+    void toJson_testsSkippedReasonIncludedWhenSet() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-b",
+                        "module-b",
+                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        ScalpelReport.CATEGORY_DOWNSTREAM,
+                        null,
+                        ScalpelReport.REASON_EXCLUDED_DOWNSTREAM))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"testsSkippedReason\": \"EXCLUDED_DOWNSTREAM\""));
+        assertTrue(json.contains("\"category\": \"DOWNSTREAM\""));
+    }
+
+    @Test
+    void toJson_testsSkippedReasonOmittedWhenNull() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-b",
+                        "module-b",
+                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        ScalpelReport.CATEGORY_DOWNSTREAM))
+                .build();
+
+        String json = report.toJson();
+        assertFalse(json.contains("testsSkippedReason"));
+        assertTrue(json.contains("\"category\": \"DOWNSTREAM\""));
+    }
+
+    @Test
+    void toJson_testsSkippedReasonWithoutCategory() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-b",
+                        "module-b",
+                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        null,
+                        null,
+                        ScalpelReport.REASON_EXCLUDED_DOWNSTREAM))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"testsSkippedReason\": \"EXCLUDED_DOWNSTREAM\""));
+        assertFalse(json.contains("\"category\""));
+    }
+
+    @Test
+    void affectedModule_gettersReturnCorrectValues() {
+        ScalpelReport.AffectedModule module = new ScalpelReport.AffectedModule(
+                "com.example",
+                "module-a",
+                "module-a",
+                Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                ScalpelReport.CATEGORY_DOWNSTREAM,
+                null,
+                ScalpelReport.REASON_EXCLUDED_DOWNSTREAM);
+
+        assertEquals("com.example", module.getGroupId());
+        assertEquals("module-a", module.getArtifactId());
+        assertEquals("module-a", module.getPath());
+        assertEquals(Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT), module.getReasons());
+        assertEquals(ScalpelReport.CATEGORY_DOWNSTREAM, module.getCategory());
+        assertEquals(ScalpelReport.REASON_EXCLUDED_DOWNSTREAM, module.getTestsSkippedReason());
+    }
+
+    @Test
     void toJson_escapesSpecialCharacters() {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -299,6 +299,28 @@ class ScalpelReportTest {
     }
 
     @Test
+    void toJson_bothSourceSetAndTestsSkippedReason() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-b",
+                        "module-b",
+                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        ScalpelReport.CATEGORY_DOWNSTREAM,
+                        "main",
+                        ScalpelReport.REASON_EXCLUDED_DOWNSTREAM))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"sourceSet\": \"main\""));
+        assertTrue(json.contains("\"testsSkippedReason\": \"EXCLUDED_DOWNSTREAM\""));
+        assertTrue(json.contains("\"category\": \"DOWNSTREAM\""));
+    }
+
+    @Test
     void toJson_escapesSpecialCharacters() {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -408,17 +408,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 // Skip tests on upstream-only modules if configured
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
-            } else if (!config.getSkipTestsForDownstreamModules().isEmpty()
-                    && (trimResult.getDownstreamOnly().contains(project)
-                            || trimResult.getDownstreamTestOnly().contains(project))
-                    && matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
-                    && !(!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs))
-                    && !(!changedManagedDepGAs.isEmpty()
-                            && hasChangedTransitiveDependency(project, session, changedManagedDepGAs))) {
+            } else if (shouldSkipTestsForExcludedDownstream(
+                    project, trimResult, config, session, changedManagedPluginGAs, changedManagedDepGAs)) {
                 // Skip tests on excluded downstream modules (unless they also have plugin/dep changes)
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
-                logger.debug("Scalpel: Skipping tests on excluded downstream module {}", key(project));
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Scalpel: Skipping tests on excluded downstream module {}", key(project));
+                }
             } else {
                 // Downstream modules run tests by default
                 testProjects.add(project);
@@ -484,6 +481,33 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
         }
         return false;
+    }
+
+    private boolean shouldSkipTestsForExcludedDownstream(
+            MavenProject project,
+            TrimResult trimResult,
+            ScalpelConfiguration config,
+            MavenSession session,
+            Set<String> changedManagedPluginGAs,
+            Set<String> changedManagedDepGAs) {
+        if (config.getSkipTestsForDownstreamModules().isEmpty()) {
+            return false;
+        }
+        if (!trimResult.getDownstreamOnly().contains(project)
+                && !trimResult.getDownstreamTestOnly().contains(project)) {
+            return false;
+        }
+        if (!matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
+            return false;
+        }
+        // Safety guard: don't skip tests if the module also has changed managed plugins or deps
+        if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
+            return false;
+        }
+        if (!changedManagedDepGAs.isEmpty() && hasChangedTransitiveDependency(project, session, changedManagedDepGAs)) {
+            return false;
+        }
+        return true;
     }
 
     private boolean hasChangedTransitiveDependency(MavenProject project, MavenSession session, Set<String> changedGAs) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -411,8 +411,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             } else if (!config.getSkipTestsForDownstreamModules().isEmpty()
                     && (trimResult.getDownstreamOnly().contains(project)
                             || trimResult.getDownstreamTestOnly().contains(project))
-                    && matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
-                // Skip tests on excluded downstream modules
+                    && matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
+                    && !(!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs))
+                    && !(!changedManagedDepGAs.isEmpty()
+                            && hasChangedTransitiveDependency(project, session, changedManagedDepGAs))) {
+                // Skip tests on excluded downstream modules (unless they also have plugin/dep changes)
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
                 logger.debug("Scalpel: Skipping tests on excluded downstream module {}", key(project));
@@ -617,25 +620,18 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             MavenProject project = entry.getKey();
             String path = relativePath(reactorRoot, project);
             String category = null;
-            String testsSkippedReason = null;
             if (trimResult != null) {
                 if (trimResult.getUpstreamOnly().contains(project)) {
                     category = ScalpelReport.CATEGORY_UPSTREAM;
-                } else if (trimResult.getDownstreamOnly().contains(project)) {
+                } else if (trimResult.getDownstreamOnly().contains(project)
+                        || trimResult.getDownstreamTestOnly().contains(project)) {
                     category = ScalpelReport.CATEGORY_DOWNSTREAM;
-                    if (matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
-                        testsSkippedReason = ScalpelReport.REASON_EXCLUDED_DOWNSTREAM;
-                    }
                 }
             }
+            // Transitively affected modules have additional reasons (plugin/dep changes),
+            // so they are not "only DOWNSTREAM" — don't mark as excluded
             builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                    project.getGroupId(),
-                    project.getArtifactId(),
-                    path,
-                    entry.getValue(),
-                    category,
-                    null,
-                    testsSkippedReason));
+                    project.getGroupId(), project.getArtifactId(), path, entry.getValue(), category));
         }
 
         // Add upstream/downstream modules from trimResult that aren't already covered

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -408,6 +408,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 // Skip tests on upstream-only modules if configured
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
+            } else if (!config.getSkipTestsForDownstreamModules().isEmpty()
+                    && (trimResult.getDownstreamOnly().contains(project)
+                            || trimResult.getDownstreamTestOnly().contains(project))
+                    && matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
+                // Skip tests on excluded downstream modules
+                project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
+                skippedProjects.add(project);
+                logger.debug("Scalpel: Skipping tests on excluded downstream module {}", key(project));
             } else {
                 // Downstream modules run tests by default
                 testProjects.add(project);
@@ -454,6 +462,22 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (changedPluginGAs.contains(ga)) {
                 logger.debug("Module {} uses changed managed plugin {}", key(project), ga);
                 return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
+        for (String pattern : patterns) {
+            String trimmed = pattern.trim();
+            if (trimmed.contains(":")) {
+                if (key(project).equals(trimmed)) {
+                    return true;
+                }
+            } else {
+                if (project.getArtifactId().equals(trimmed)) {
+                    return true;
+                }
             }
         }
         return false;
@@ -593,15 +617,25 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             MavenProject project = entry.getKey();
             String path = relativePath(reactorRoot, project);
             String category = null;
+            String testsSkippedReason = null;
             if (trimResult != null) {
                 if (trimResult.getUpstreamOnly().contains(project)) {
                     category = ScalpelReport.CATEGORY_UPSTREAM;
                 } else if (trimResult.getDownstreamOnly().contains(project)) {
                     category = ScalpelReport.CATEGORY_DOWNSTREAM;
+                    if (matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
+                        testsSkippedReason = ScalpelReport.REASON_EXCLUDED_DOWNSTREAM;
+                    }
                 }
             }
             builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                    project.getGroupId(), project.getArtifactId(), path, entry.getValue(), category));
+                    project.getGroupId(),
+                    project.getArtifactId(),
+                    path,
+                    entry.getValue(),
+                    category,
+                    null,
+                    testsSkippedReason));
         }
 
         // Add upstream/downstream modules from trimResult that aren't already covered
@@ -620,23 +654,35 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             for (MavenProject project : trimResult.getDownstreamOnly()) {
                 if (!directlyAffected.contains(project) && !transitivelyAffected.containsKey(project)) {
                     String path = relativePath(reactorRoot, project);
+                    String testsSkippedReason =
+                            matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
+                                    ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
+                                    : null;
                     builder.addAffectedModule(new ScalpelReport.AffectedModule(
                             project.getGroupId(),
                             project.getArtifactId(),
                             path,
                             Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
-                            ScalpelReport.CATEGORY_DOWNSTREAM));
+                            ScalpelReport.CATEGORY_DOWNSTREAM,
+                            null,
+                            testsSkippedReason));
                 }
             }
             for (MavenProject project : trimResult.getDownstreamTestOnly()) {
                 if (!directlyAffected.contains(project) && !transitivelyAffected.containsKey(project)) {
                     String path = relativePath(reactorRoot, project);
+                    String testsSkippedReason =
+                            matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
+                                    ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
+                                    : null;
                     builder.addAffectedModule(new ScalpelReport.AffectedModule(
                             project.getGroupId(),
                             project.getArtifactId(),
                             path,
                             Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_TEST),
-                            ScalpelReport.CATEGORY_DOWNSTREAM));
+                            ScalpelReport.CATEGORY_DOWNSTREAM,
+                            null,
+                            testsSkippedReason));
                 }
             }
         }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1262,64 +1262,38 @@ class ScalpelLifecycleParticipantTest {
         return json.contains("\"artifactId\": \"" + artifactId + "\"");
     }
 
-    private boolean moduleHasReason(String json, String artifactId, String reason) {
+    private String extractModuleBlock(String json, String artifactId) {
         String marker = "\"artifactId\": \"" + artifactId + "\"";
         int idx = json.indexOf(marker);
         if (idx < 0) {
-            return false;
+            return null;
         }
         int start = json.lastIndexOf("{", idx);
         int end = json.indexOf("}", idx);
         if (start < 0 || end < 0) {
-            return false;
+            return null;
         }
-        String block = json.substring(start, end + 1);
-        return block.contains("\"" + reason + "\"");
+        return json.substring(start, end + 1);
+    }
+
+    private boolean moduleHasReason(String json, String artifactId, String reason) {
+        String block = extractModuleBlock(json, artifactId);
+        return block != null && block.contains("\"" + reason + "\"");
     }
 
     private boolean moduleHasAnySourceSet(String json, String artifactId) {
-        String marker = "\"artifactId\": \"" + artifactId + "\"";
-        int idx = json.indexOf(marker);
-        if (idx < 0) {
-            return false;
-        }
-        int start = json.lastIndexOf("{", idx);
-        int end = json.indexOf("}", idx);
-        if (start < 0 || end < 0) {
-            return false;
-        }
-        String block = json.substring(start, end + 1);
-        return block.contains("\"sourceSet\":");
+        String block = extractModuleBlock(json, artifactId);
+        return block != null && block.contains("\"sourceSet\":");
     }
 
     private boolean moduleHasSourceSet(String json, String artifactId, String sourceSet) {
-        String marker = "\"artifactId\": \"" + artifactId + "\"";
-        int idx = json.indexOf(marker);
-        if (idx < 0) {
-            return false;
-        }
-        int start = json.lastIndexOf("{", idx);
-        int end = json.indexOf("}", idx);
-        if (start < 0 || end < 0) {
-            return false;
-        }
-        String block = json.substring(start, end + 1);
-        return block.contains("\"sourceSet\": \"" + sourceSet + "\"");
+        String block = extractModuleBlock(json, artifactId);
+        return block != null && block.contains("\"sourceSet\": \"" + sourceSet + "\"");
     }
 
     private boolean moduleHasField(String json, String artifactId, String field, String value) {
-        String marker = "\"artifactId\": \"" + artifactId + "\"";
-        int idx = json.indexOf(marker);
-        if (idx < 0) {
-            return false;
-        }
-        int start = json.lastIndexOf("{", idx);
-        int end = json.indexOf("}", idx);
-        if (start < 0 || end < 0) {
-            return false;
-        }
-        String block = json.substring(start, end + 1);
-        return block.contains("\"" + field + "\": \"" + value + "\"");
+        String block = extractModuleBlock(json, artifactId);
+        return block != null && block.contains("\"" + field + "\": \"" + value + "\"");
     }
 
     private Model parseModel(String xml) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -7,7 +7,9 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -1031,12 +1033,14 @@ class ScalpelLifecycleParticipantTest {
         participant.afterProjectsRead(session);
 
         // module-b (excluded downstream) should have tests skipped
-        assertTrue(
-                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+        assertEquals(
+                "true",
+                moduleB.getProperties().getProperty("maven.test.skip"),
                 "module-b should have maven.test.skip=true (excluded downstream)");
         // module-c (downstream, not excluded) should NOT have tests skipped
-        assertFalse(
-                "true".equals(moduleC.getProperties().getProperty("maven.test.skip")),
+        assertNotEquals(
+                "true",
+                moduleC.getProperties().getProperty("maven.test.skip"),
                 "module-c should NOT have maven.test.skip=true (not excluded)");
     }
 
@@ -1082,8 +1086,9 @@ class ScalpelLifecycleParticipantTest {
         participant.afterProjectsRead(session);
 
         // module-a is DIRECT, so tests should NOT be skipped even though it's in exclusion list
-        assertFalse(
-                "true".equals(moduleA.getProperties().getProperty("maven.test.skip")),
+        assertNotEquals(
+                "true",
+                moduleA.getProperties().getProperty("maven.test.skip"),
                 "module-a should NOT have tests skipped (DIRECT overrides exclusion)");
     }
 
@@ -1128,8 +1133,9 @@ class ScalpelLifecycleParticipantTest {
 
         participant.afterProjectsRead(session);
 
-        assertTrue(
-                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+        assertEquals(
+                "true",
+                moduleB.getProperties().getProperty("maven.test.skip"),
                 "module-b should have tests skipped (matched by groupId:artifactId)");
     }
 
@@ -1320,8 +1326,9 @@ class ScalpelLifecycleParticipantTest {
 
         // module-b is excluded downstream BUT also uses a changed managed plugin
         // Safety guard: tests should NOT be skipped
-        assertFalse(
-                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+        assertNotEquals(
+                "true",
+                moduleB.getProperties().getProperty("maven.test.skip"),
                 "module-b should NOT have tests skipped (uses changed managed plugin, safety guard)");
     }
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -982,6 +982,206 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(json.contains("commons-lang:commons-lang"), "Report should include changed managed dep GA");
     }
 
+    @Test
+    void skipTestsMode_excludedDownstreamModulesHaveTestsSkipped() throws Exception {
+        // module-a is directly changed, module-b and module-c are downstream.
+        // module-b is in the exclusion list, module-c is not.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b", "module-c");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+        String moduleCPom = simpleChildPomWithDep("module-c", "module-a");
+        writePom(root, "module-c/pom.xml", moduleCPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
+        moduleC.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB, moduleC);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
+
+        // Graph: module-b and module-c are downstream of module-a
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Arrays.asList(moduleB, moduleC));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(moduleC, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        // module-b (excluded downstream) should have tests skipped
+        assertTrue(
+                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+                "module-b should have maven.test.skip=true (excluded downstream)");
+        // module-c (downstream, not excluded) should NOT have tests skipped
+        assertFalse(
+                "true".equals(moduleC.getProperties().getProperty("maven.test.skip")),
+                "module-c should NOT have maven.test.skip=true (not excluded)");
+    }
+
+    @Test
+    void skipTestsMode_directModuleOverridesDownstreamExclusion() throws Exception {
+        // module-a has source changes (DIRECT) and is also in the exclusion list.
+        // DIRECT should win — tests should still run.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        // module-a is in the exclusion list but also directly changed
+        session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-a");
+
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        // module-a is DIRECT, so tests should NOT be skipped even though it's in exclusion list
+        assertFalse(
+                "true".equals(moduleA.getProperties().getProperty("maven.test.skip")),
+                "module-a should NOT have tests skipped (DIRECT overrides exclusion)");
+    }
+
+    @Test
+    void skipTestsMode_groupIdColonArtifactIdExclusionPattern() throws Exception {
+        // Test that groupId:artifactId pattern matching works
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "com.example:module-b");
+
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        assertTrue(
+                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+                "module-b should have tests skipped (matched by groupId:artifactId)");
+    }
+
+    @Test
+    void reportMode_excludedDownstreamHasTestsSkippedReason() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
+
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(moduleHasReason(json, "module-a", "SOURCE_CHANGE"), "module-a should have SOURCE_CHANGE");
+        assertTrue(
+                moduleHasField(json, "module-b", "testsSkippedReason", "EXCLUDED_DOWNSTREAM"),
+                "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM in report");
+    }
+
     // --- Helper methods ---
 
     private void setupEmptyDependencyResolution() throws Exception {
@@ -1028,6 +1228,14 @@ class ScalpelLifecycleParticipantTest {
         return "<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n"
                 + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
                 + "  <artifactId>" + artifactId + "</artifactId>\n</project>\n";
+    }
+
+    private String simpleChildPomWithDep(String artifactId, String depArtifactId) {
+        return "<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>" + artifactId + "</artifactId>\n"
+                + "  <dependencies><dependency><groupId>com.example</groupId><artifactId>" + depArtifactId
+                + "</artifactId><version>1.0</version></dependency></dependencies>\n</project>\n";
     }
 
     private void writePom(Path root, String relativePath, String content) throws Exception {
@@ -1097,6 +1305,21 @@ class ScalpelLifecycleParticipantTest {
         }
         String block = json.substring(start, end + 1);
         return block.contains("\"sourceSet\": \"" + sourceSet + "\"");
+    }
+
+    private boolean moduleHasField(String json, String artifactId, String field, String value) {
+        String marker = "\"artifactId\": \"" + artifactId + "\"";
+        int idx = json.indexOf(marker);
+        if (idx < 0) {
+            return false;
+        }
+        int start = json.lastIndexOf("{", idx);
+        int end = json.indexOf("}", idx);
+        if (start < 0 || end < 0) {
+            return false;
+        }
+        String block = json.substring(start, end + 1);
+        return block.contains("\"" + field + "\": \"" + value + "\"");
     }
 
     private Model parseModel(String xml) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1182,6 +1182,149 @@ class ScalpelLifecycleParticipantTest {
                 "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM in report");
     }
 
+    @Test
+    void reportMode_downstreamTestOnlyExcludedHasTestsSkippedReason() throws Exception {
+        // module-b depends on module-a via test scope (downstream-test-only).
+        // module-b is in the exclusion list — should get testsSkippedReason.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = "<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-b</artifactId>\n"
+                + "  <dependencies><dependency><groupId>com.example</groupId><artifactId>module-a</artifactId>"
+                + "<version>1.0</version><scope>test</scope></dependency></dependencies>\n</project>\n";
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        Dependency dep = new Dependency();
+        dep.setGroupId("com.example");
+        dep.setArtifactId("module-a");
+        dep.setVersion("1.0");
+        dep.setScope("test");
+        moduleB.getDependencies().add(dep);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
+
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(
+                moduleHasReason(json, "module-b", "DOWNSTREAM_TEST"),
+                "module-b should have DOWNSTREAM_TEST reason (test-scoped downstream)");
+        assertTrue(
+                moduleHasField(json, "module-b", "testsSkippedReason", "EXCLUDED_DOWNSTREAM"),
+                "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM");
+    }
+
+    @Test
+    void skipTestsMode_excludedDownstreamWithChangedPluginStillRunsTests() throws Exception {
+        // module-b is downstream and in the exclusion list, but also uses a changed managed plugin.
+        // The safety guard should prevent test skipping.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties><compiler.version>3.11.0</compiler.version></properties>\n"
+                + "  <build><pluginManagement><plugins>\n"
+                + "    <plugin><groupId>org.apache.maven.plugins</groupId>"
+                + "<artifactId>maven-compiler-plugin</artifactId>"
+                + "<version>${compiler.version}</version></plugin>\n"
+                + "  </plugins></pluginManagement></build>\n"
+                + "</project>\n";
+
+        String newParentPom = oldParentPom.replace(
+                "<compiler.version>3.11.0</compiler.version>", "<compiler.version>3.12.0</compiler.version>");
+        writePom(root, "pom.xml", newParentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        Build parentBuild = new Build();
+        parentProject.getModel().setBuild(parentBuild);
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        // module-b uses the changed managed plugin
+        Build build = new Build();
+        Plugin compilerPlugin = new Plugin();
+        compilerPlugin.setGroupId("org.apache.maven.plugins");
+        compilerPlugin.setArtifactId("maven-compiler-plugin");
+        build.addPlugin(compilerPlugin);
+        moduleB.getModel().setBuild(build);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // Changed files: parent POM (property change) + module-a source
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
+
+        // module-b is downstream of module-a
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        // module-b is excluded downstream BUT also uses a changed managed plugin
+        // Safety guard: tests should NOT be skipped
+        assertFalse(
+                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+                "module-b should NOT have tests skipped (uses changed managed plugin, safety guard)");
+    }
+
     // --- Helper methods ---
 
     private void setupEmptyDependencyResolution() throws Exception {

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/invoker.properties
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=report -Dscalpel.skipTestsForDownstreamModules=module-b

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/module-a/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+        <artifactId>skip-tests-downstream-exclusion-report</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/module-b/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+        <artifactId>skip-tests-downstream-exclusion-report</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/module-c/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/module-c/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+        <artifactId>skip-tests-downstream-exclusion-report</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+    <artifactId>skip-tests-downstream-exclusion-report</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/setup.groovy
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/setup.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// module-b and module-c both depend on module-a.
+// Change source in module-a only. module-b and module-c are downstream.
+// With skipTestsForDownstreamModules=module-b, the report should mark module-b
+// with testsSkippedReason=EXCLUDED_DOWNSTREAM but not module-c.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Only change module-a source
+new File(dir, 'module-a/src/main/java').mkdirs()
+new File(dir, 'module-a/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-a')

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should be activated in report mode
+assert log.contains('Scalpel') : "Expected Scalpel to be activated"
+assert log.contains('mode=report') : "Expected report mode"
+
+// Report should have been written
+assert log.contains('Report written to') : "Expected report to be written"
+
+// All modules should still be present in reactor (no trimming in report mode)
+assert log.contains('BUILD SUCCESS')
+
+// Check the report file exists and has valid content
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists() : "Report file should have been created at target/scalpel-report.json"
+
+String json = reportFile.text
+assert json.contains('"version": "1"') : "Report should contain version field"
+assert json.contains('"fullBuildTriggered": false') : "fullBuildTriggered should be false"
+
+// module-a should be directly affected with SOURCE_CHANGE
+assert json.contains('"module-a"') : "module-a should appear in report"
+assert json.contains('"SOURCE_CHANGE"') : "module-a should have SOURCE_CHANGE reason"
+assert json.contains('"category": "DIRECT"') : "module-a should have DIRECT category"
+
+// module-b should be downstream with testsSkippedReason=EXCLUDED_DOWNSTREAM
+assert json.contains('"module-b"') : "module-b should appear in report"
+assert json.contains('"DOWNSTREAM_DEPENDENT"') : "module-b should have DOWNSTREAM_DEPENDENT reason"
+
+// Parse module-b block and verify testsSkippedReason
+def moduleBStart = json.indexOf('"module-b"')
+assert moduleBStart >= 0
+def moduleBBlock = json.substring(json.lastIndexOf('{', moduleBStart), json.indexOf('}', moduleBStart) + 1)
+assert moduleBBlock.contains('"testsSkippedReason": "EXCLUDED_DOWNSTREAM"') : \
+    "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM in report, got: $moduleBBlock"
+
+// module-c should be downstream but WITHOUT testsSkippedReason
+assert json.contains('"module-c"') : "module-c should appear in report"
+def moduleCStart = json.indexOf('"module-c"')
+assert moduleCStart >= 0
+def moduleCBlock = json.substring(json.lastIndexOf('{', moduleCStart), json.indexOf('}', moduleCStart) + 1)
+assert !moduleCBlock.contains('testsSkippedReason') : \
+    "module-c should NOT have testsSkippedReason in report, got: $moduleCBlock"

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/invoker.properties
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=skip-tests -Dscalpel.skipTestsForDownstreamModules=module-b
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=skip-tests -Dscalpel.skipTestsForDownstreamModules=eu.maveniverse.maven.scalpel.it.skiptestsdownstream:module-b

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/invoker.properties
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=skip-tests -Dscalpel.skipTestsForDownstreamModules=module-b

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/module-a/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+        <artifactId>skip-tests-downstream-exclusion</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/module-b/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+        <artifactId>skip-tests-downstream-exclusion</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/module-c/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/module-c/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+        <artifactId>skip-tests-downstream-exclusion</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.skiptestsdownstream</groupId>
+    <artifactId>skip-tests-downstream-exclusion</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/setup.groovy
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/setup.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// module-b and module-c both depend on module-a.
+// Change source in module-a only. module-b and module-c are downstream.
+// With skipTestsForDownstreamModules=module-b, module-b should have tests skipped
+// but module-c should still run tests.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Only change module-a source
+new File(dir, 'module-a/src/main/java').mkdirs()
+new File(dir, 'module-a/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-a')

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should be activated in skip-tests mode
+assert log.contains('Scalpel') : "Expected Scalpel to be activated"
+assert log.contains('mode=skip-tests') : "Expected skip-tests mode"
+
+// module-a should be directly affected (source changed)
+assert log.contains('directly affected') : "Expected directly affected modules"
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine.contains('module-a') : "module-a should be directly affected"
+
+// In skip-tests mode, the log should show skipping tests on some modules
+def skippingLine = log.readLines().find { it.contains('skipping tests on') }
+assert skippingLine != null : "Expected 'skipping tests on' log line"
+
+// module-b should have tests skipped (excluded downstream)
+assert skippingLine.contains('module-b') : "Expected module-b to have tests skipped (excluded downstream), got: $skippingLine"
+
+// module-c should NOT have tests skipped (downstream but not excluded)
+// module-c should be in the testing set, not in the skipped set
+assert !skippingLine.contains('module-c') : "module-c should NOT have tests skipped, got: $skippingLine"


### PR DESCRIPTION
## Summary

- Adds `scalpel.skipTestsForDownstreamModules` property (comma-separated list of artifactId or groupId:artifactId patterns) that skips tests on matching modules when they are only DOWNSTREAM dependents, while still testing them when DIRECT
- Annotates the JSON report with `testsSkippedReason: "EXCLUDED_DOWNSTREAM"` so PR comment generators can inform contributors
- Includes integration test validating excluded vs non-excluded downstream modules

Closes #14

## Example usage

```
-Dscalpel.skipTestsForDownstreamModules=camel-allcomponents,camel-catalog,camel-endpointdsl
```

## Behavior

| Scenario | Tests |
|----------|-------|
| Module is DOWNSTREAM + matches exclusion | Skipped |
| Module is DIRECT + matches exclusion | **Run** (DIRECT wins) |
| Module is DOWNSTREAM + no match | Run |

## Test plan

- [x] New `skip-tests-downstream-exclusion` integration test passes
- [x] Existing `skip-tests-upstream` test still passes (no regression)
- [x] Full integration test suite passes (20/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configuration to list downstream modules whose tests should be skipped in skip-tests mode (supports artifact or group:artifact patterns).
  * Reports now include a per-module reason when tests were skipped (e.g., excluded downstream), visible in generated report output.

* **Tests**
  * Add unit and integration tests covering exclusion matching, skip-tests behavior, report serialization, and logging to validate skipping and report fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->