### PR TITLE
Add sourceSet field to report and document source-set-aware propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,24 +119,26 @@ not as a replacement. It contains only directly affected modules (not upstream/d
   "baseBranch": "origin/main",
   "fullBuildTriggered": false,
   "triggerFile": null,
-  "changedFiles": ["parent/pom.xml"],
-  "changedProperties": ["kafka-version"],
-  "changedManagedDependencies": ["org.apache.kafka:kafka-clients"],
+  "changedFiles": ["module-a/src/main/java/Foo.java", "module-b/src/test/java/BarTest.java"],
+  "changedProperties": [],
+  "changedManagedDependencies": [],
   "changedManagedPlugins": [],
   "affectedModules": [
     {
       "groupId": "com.example",
       "artifactId": "module-a",
       "path": "module-a",
-      "reasons": ["POM_CHANGE"],
-      "category": "DIRECT"
+      "reasons": ["SOURCE_CHANGE"],
+      "category": "DIRECT",
+      "sourceSet": "main"
     },
     {
       "groupId": "com.example",
       "artifactId": "module-b",
       "path": "module-b",
-      "reasons": ["TRANSITIVE_DEPENDENCY"],
-      "category": "DOWNSTREAM"
+      "reasons": ["TEST_CHANGE"],
+      "category": "DIRECT",
+      "sourceSet": "test"
     }
   ]
 }
@@ -152,8 +154,17 @@ not as a replacement. It contains only directly affected modules (not upstream/d
 | `TRANSITIVE_DEPENDENCY` | A changed managed dependency reaches this module transitively (compile/runtime scope) |
 | `TRANSITIVE_DEPENDENCY_TEST` | A changed managed dependency reaches this module transitively via test scope only |
 | `MANAGED_PLUGIN` | This module uses a plugin whose managed version changed |
+| `UPSTREAM_DEPENDENCY` | Included as an upstream dependency (via `alsoMake`) |
+| `DOWNSTREAM_DEPENDENT` | Included as a downstream dependent (via `alsoMakeDependents`) |
 | `DOWNSTREAM_TEST` | Included as a downstream dependent via test-scoped dependency only |
 | `FORCE_BUILD` | This module was force-included via `forceBuildModules` |
+
+**Affected module source sets** (present on directly affected modules with source changes):
+
+| Source Set | Description |
+|------------|-------------|
+| `main` | Main source files (`src/main/**`) changed; all downstream dependents are affected |
+| `test` | Only test source files (`src/test/**`) changed; only test-jar dependents are affected |
 
 **Affected module categories:**
 
@@ -162,6 +173,38 @@ not as a replacement. It contains only directly affected modules (not upstream/d
 | `DIRECT` | Directly affected by a change |
 | `UPSTREAM` | Included as an upstream dependency (via `alsoMake`) |
 | `DOWNSTREAM` | Included as a downstream dependent (via `alsoMakeDependents`) |
+
+## Source-Set-Aware Downstream Propagation
+
+Scalpel distinguishes between main source changes (`src/main/`) and test-only changes (`src/test/`)
+when propagating changes to downstream modules:
+
+- **Test-only changes** (`src/test/` only): the module itself is built and tested (DIRECT), but
+  only downstream modules that declare a `<type>test-jar</type>` dependency on it are included.
+  Regular dependents are NOT affected, since the main artifact is unchanged.
+
+- **Main source changes** (`src/main/` with or without `src/test/`): all downstream dependents
+  (regular and test-jar) are included, as the main artifact may have changed.
+
+- **POM or resource changes**: treated like main source changes — all dependents are included.
+
+This dramatically reduces unnecessary builds. For example, in Apache Camel, `camel-core` has ~500
+regular dependents but only ~23 test-jar dependents. A change to a test base class in `camel-core`
+triggers testing of only those 23 modules instead of all 500+.
+
+Test-jar dependencies are declared in Maven as:
+
+```xml
+<dependency>
+    <groupId>org.apache.camel</groupId>
+    <artifactId>camel-core</artifactId>
+    <type>test-jar</type>
+    <scope>test</scope>
+</dependency>
+```
+
+In `report` mode, each directly affected module includes a `"sourceSet"` field (`"main"` or `"test"`)
+indicating which source set triggered the change.
 
 ## Configuration
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -83,6 +83,9 @@ public final class ScalpelReport {
                 List<String> reasons,
                 String category,
                 String sourceSet) {
+            if (sourceSet != null && !"main".equals(sourceSet) && !"test".equals(sourceSet)) {
+                throw new IllegalArgumentException("sourceSet must be 'main', 'test', or null");
+            }
             this.groupId = groupId;
             this.artifactId = artifactId;
             this.path = path;

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -66,17 +66,29 @@ public final class ScalpelReport {
         private final String path;
         private final List<String> reasons;
         private final String category;
+        private final String sourceSet;
 
         public AffectedModule(String groupId, String artifactId, String path, List<String> reasons) {
-            this(groupId, artifactId, path, reasons, null);
+            this(groupId, artifactId, path, reasons, null, null);
         }
 
         public AffectedModule(String groupId, String artifactId, String path, List<String> reasons, String category) {
+            this(groupId, artifactId, path, reasons, category, null);
+        }
+
+        public AffectedModule(
+                String groupId,
+                String artifactId,
+                String path,
+                List<String> reasons,
+                String category,
+                String sourceSet) {
             this.groupId = groupId;
             this.artifactId = artifactId;
             this.path = path;
             this.reasons = reasons;
             this.category = category;
+            this.sourceSet = sourceSet;
         }
 
         public String getGroupId() {
@@ -97,6 +109,10 @@ public final class ScalpelReport {
 
         public String getCategory() {
             return category;
+        }
+
+        public String getSourceSet() {
+            return sourceSet;
         }
     }
 
@@ -136,12 +152,13 @@ public final class ScalpelReport {
                 sb.append("      \"reasons\": ").append(jsonStringArray(m.reasons));
                 if (m.category != null) {
                     sb.append(",\n");
-                    sb.append("      \"category\": ")
-                            .append(jsonString(m.category))
-                            .append("\n");
-                } else {
-                    sb.append("\n");
+                    sb.append("      \"category\": ").append(jsonString(m.category));
                 }
+                if (m.sourceSet != null) {
+                    sb.append(",\n");
+                    sb.append("      \"sourceSet\": ").append(jsonString(m.sourceSet));
+                }
+                sb.append("\n");
                 sb.append("    }");
                 if (i < affectedModules.size() - 1) {
                     sb.append(",");

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -160,6 +160,65 @@ class ScalpelReportTest {
     }
 
     @Test
+    void toJson_sourceSetIncludedWhenPresent() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/test/java/FooTest.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-a",
+                        "module-a",
+                        Collections.singletonList(ScalpelReport.REASON_TEST_CHANGE),
+                        ScalpelReport.CATEGORY_DIRECT,
+                        "test"))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"sourceSet\": \"test\""));
+        assertTrue(json.contains("\"TEST_CHANGE\""));
+        assertTrue(json.contains("\"category\": \"DIRECT\""));
+    }
+
+    @Test
+    void toJson_sourceSetOmittedWhenNull() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/main/java/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-a",
+                        "module-a",
+                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        ScalpelReport.CATEGORY_DOWNSTREAM))
+                .build();
+
+        String json = report.toJson();
+        assertFalse(json.contains("\"sourceSet\""));
+    }
+
+    @Test
+    void toJson_sourceSetMainForMainChanges() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/main/java/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example",
+                        "module-a",
+                        "module-a",
+                        Collections.singletonList(ScalpelReport.REASON_SOURCE_CHANGE),
+                        ScalpelReport.CATEGORY_DIRECT,
+                        "main"))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"sourceSet\": \"main\""));
+        assertTrue(json.contains("\"SOURCE_CHANGE\""));
+    }
+
+    @Test
     void toJson_escapesSpecialCharacters() {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -564,11 +564,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         for (MavenProject project : directlyAffected) {
             String path = relativePath(reactorRoot, project);
             List<String> reasons = new ArrayList<>();
+            String sourceSet = null;
             if (affectedBySource.contains(project)) {
                 if (testOnlyBySource.contains(project)) {
                     reasons.add(ScalpelReport.REASON_TEST_CHANGE);
+                    sourceSet = "test";
                 } else {
                     reasons.add(ScalpelReport.REASON_SOURCE_CHANGE);
+                    sourceSet = "main";
                 }
             }
             if (affectedByPom.contains(project)) {
@@ -578,7 +581,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 reasons.add(ScalpelReport.REASON_FORCE_BUILD);
             }
             builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                    project.getGroupId(), project.getArtifactId(), path, reasons, ScalpelReport.CATEGORY_DIRECT));
+                    project.getGroupId(),
+                    project.getArtifactId(),
+                    path,
+                    reasons,
+                    ScalpelReport.CATEGORY_DIRECT,
+                    sourceSet));
         }
 
         for (Map.Entry<MavenProject, List<String>> entry : transitivelyAffected.entrySet()) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -410,8 +410,14 @@ class ScalpelLifecycleParticipantTest {
                 moduleHasReason(json, "module-a", "TEST_CHANGE"),
                 "module-a should have TEST_CHANGE reason (only test files changed)");
         assertTrue(
+                moduleHasSourceSet(json, "module-a", "test"),
+                "module-a should have sourceSet=test (only test files changed)");
+        assertTrue(
                 moduleHasReason(json, "module-b", "SOURCE_CHANGE"),
                 "module-b should have SOURCE_CHANGE reason (main source changed)");
+        assertTrue(
+                moduleHasSourceSet(json, "module-b", "main"),
+                "module-b should have sourceSet=main (main source changed)");
     }
 
     @Test
@@ -618,8 +624,17 @@ class ScalpelLifecycleParticipantTest {
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
         assertTrue(moduleHasReason(json, "module-a", "SOURCE_CHANGE"), "module-a should have SOURCE_CHANGE");
         assertTrue(
+                moduleHasSourceSet(json, "module-a", "main"),
+                "module-a should have sourceSet=main (main source changed)");
+        assertTrue(
                 moduleHasReason(json, "module-b", "DOWNSTREAM_TEST"),
                 "module-b should have DOWNSTREAM_TEST (test-scoped downstream of module-a)");
+        assertFalse(
+                moduleHasSourceSet(json, "module-b", "main"),
+                "module-b should NOT have sourceSet (downstream, not direct source change)");
+        assertFalse(
+                moduleHasSourceSet(json, "module-b", "test"),
+                "module-b should NOT have sourceSet (downstream, not direct source change)");
     }
 
     @Test
@@ -895,6 +910,21 @@ class ScalpelLifecycleParticipantTest {
         }
         String block = json.substring(start, end + 1);
         return block.contains("\"" + reason + "\"");
+    }
+
+    private boolean moduleHasSourceSet(String json, String artifactId, String sourceSet) {
+        String marker = "\"artifactId\": \"" + artifactId + "\"";
+        int idx = json.indexOf(marker);
+        if (idx < 0) {
+            return false;
+        }
+        int start = json.lastIndexOf("{", idx);
+        int end = json.indexOf("}", idx);
+        if (start < 0 || end < 0) {
+            return false;
+        }
+        String block = json.substring(start, end + 1);
+        return block.contains("\"sourceSet\": \"" + sourceSet + "\"");
     }
 
     private Model parseModel(String xml) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -630,10 +630,7 @@ class ScalpelLifecycleParticipantTest {
                 moduleHasReason(json, "module-b", "DOWNSTREAM_TEST"),
                 "module-b should have DOWNSTREAM_TEST (test-scoped downstream of module-a)");
         assertFalse(
-                moduleHasSourceSet(json, "module-b", "main"),
-                "module-b should NOT have sourceSet (downstream, not direct source change)");
-        assertFalse(
-                moduleHasSourceSet(json, "module-b", "test"),
+                moduleHasAnySourceSet(json, "module-b"),
                 "module-b should NOT have sourceSet (downstream, not direct source change)");
     }
 
@@ -910,6 +907,21 @@ class ScalpelLifecycleParticipantTest {
         }
         String block = json.substring(start, end + 1);
         return block.contains("\"" + reason + "\"");
+    }
+
+    private boolean moduleHasAnySourceSet(String json, String artifactId) {
+        String marker = "\"artifactId\": \"" + artifactId + "\"";
+        int idx = json.indexOf(marker);
+        if (idx < 0) {
+            return false;
+        }
+        int start = json.lastIndexOf("{", idx);
+        int end = json.indexOf("}", idx);
+        if (start < 0 || end < 0) {
+            return false;
+        }
+        String block = json.substring(start, end + 1);
+        return block.contains("\"sourceSet\":");
     }
 
     private boolean moduleHasSourceSet(String json, String artifactId, String sourceSet) {


### PR DESCRIPTION
## Summary

Closes #13

- Add a `sourceSet` field (`"main"` or `"test"`) to the JSON report for directly affected modules with source changes, making the source set that triggered the change visible in the report output
- Document the source-set-aware downstream propagation behavior in the README, including how test-only changes only propagate to test-jar dependents (not all 500+ regular dependents)
- Add `UPSTREAM_DEPENDENCY` and `DOWNSTREAM_DEPENDENT` reasons to the README documentation table (they existed in code but were missing from docs)

The core behavioral logic (test-only detection, test-jar filtering in downstream propagation) was already implemented in #8. This PR adds the missing report field requested in the issue and comprehensive documentation.

## Test plan

- [x] All 73 existing tests pass (11 in core, 62 in extension3)
- [x] New `ScalpelReportTest` tests verify `sourceSet` serialization: present when set, omitted when null, correct values for main/test
- [x] Updated `ScalpelLifecycleParticipantTest` verifies `sourceSet=test` for test-only changes, `sourceSet=main` for main changes, and no `sourceSet` on downstream modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report JSON now includes a sourceSet field for affected modules, distinguishing whether changes originate from test or main source directories for more granular change tracking.

* **Documentation**
  * Added sections on source-set-aware downstream propagation, describing how changes to test sources propagate differently than changes to main sources or resource/configuration files through the dependency tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->