### PR TITLE
Make parsed configuration lists truly immutable

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -198,7 +198,7 @@ public final class ScalpelConfiguration {
         if (value == null || value.isEmpty()) {
             return Collections.emptyList();
         }
-        return Arrays.asList(value.split(","));
+        return Collections.unmodifiableList(Arrays.asList(value.split(",")));
     }
 
     private static String detectBaseBranch(Properties system) {


### PR DESCRIPTION
## Summary
- Wrap `Arrays.asList()` results with `Collections.unmodifiableList()` in `ScalpelConfiguration.parseList()` to prevent callers from mutating configuration state via `set()`
- Empty lists already used `Collections.emptyList()` (immutable); this makes non-empty lists consistent

## Test plan
- [x] Verified project compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to configuration handling to enhance code robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->