### PR TITLE
Consolidate git status API, add safe regex matching, and improve report builder

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -151,6 +151,8 @@ public class GitChangeDetector {
             uncommitted.addAll(status.getChanged());
             uncommitted.addAll(status.getAdded());
             uncommitted.addAll(status.getRemoved());
+            uncommitted.addAll(status.getMissing());
+            uncommitted.addAll(status.getConflicting());
             untracked.addAll(status.getUntracked());
         } catch (GitAPIException e) {
             throw new IOException("Failed to get git status", e);

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -113,31 +113,46 @@ public class GitChangeDetector {
         }
     }
 
-    public Set<String> getUncommittedFiles(Repository repository) throws IOException {
-        Set<String> files = new LinkedHashSet<>();
-        try (org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repository)) {
-            org.eclipse.jgit.api.Status status = git.status().call();
-            files.addAll(status.getModified());
-            files.addAll(status.getChanged());
-            files.addAll(status.getAdded());
-            files.addAll(status.getRemoved());
-        } catch (org.eclipse.jgit.api.errors.GitAPIException e) {
-            throw new IOException("Failed to get uncommitted files", e);
+    /**
+     * Result of a git status query, containing both uncommitted and untracked files.
+     */
+    public static class StatusResult {
+        private final Set<String> uncommitted;
+        private final Set<String> untracked;
+
+        StatusResult(Set<String> uncommitted, Set<String> untracked) {
+            this.uncommitted = uncommitted;
+            this.untracked = untracked;
         }
-        logger.debug("Uncommitted files: {}", files);
-        return files;
+
+        public Set<String> getUncommitted() {
+            return uncommitted;
+        }
+
+        public Set<String> getUntracked() {
+            return untracked;
+        }
     }
 
-    public Set<String> getUntrackedFiles(Repository repository) throws IOException {
-        Set<String> files = new LinkedHashSet<>();
+    /**
+     * Computes git status once and returns both uncommitted and untracked files.
+     */
+    public StatusResult getStatusFiles(Repository repository) throws IOException {
+        Set<String> uncommitted = new LinkedHashSet<>();
+        Set<String> untracked = new LinkedHashSet<>();
         try (org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repository)) {
             org.eclipse.jgit.api.Status status = git.status().call();
-            files.addAll(status.getUntracked());
+            uncommitted.addAll(status.getModified());
+            uncommitted.addAll(status.getChanged());
+            uncommitted.addAll(status.getAdded());
+            uncommitted.addAll(status.getRemoved());
+            untracked.addAll(status.getUntracked());
         } catch (org.eclipse.jgit.api.errors.GitAPIException e) {
-            throw new IOException("Failed to get untracked files", e);
+            throw new IOException("Failed to get git status", e);
         }
-        logger.debug("Untracked files: {}", files);
-        return files;
+        logger.debug("Uncommitted files: {}", uncommitted);
+        logger.debug("Untracked files: {}", untracked);
+        return new StatusResult(uncommitted, untracked);
     }
 
     public void fetchBranch(Repository repository, String baseBranch) throws IOException {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -16,6 +16,9 @@ import java.util.Map;
 import java.util.Set;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.lib.ObjectId;
@@ -24,6 +27,7 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
+import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.eclipse.jgit.util.io.NullOutputStream;
 import org.slf4j.Logger;
@@ -122,16 +126,16 @@ public class GitChangeDetector {
         private final Set<String> untracked;
 
         StatusResult(Set<String> uncommitted, Set<String> untracked) {
-            this.uncommitted = uncommitted;
-            this.untracked = untracked;
+            this.uncommitted = Collections.unmodifiableSet(new LinkedHashSet<>(uncommitted));
+            this.untracked = Collections.unmodifiableSet(new LinkedHashSet<>(untracked));
         }
 
         public Set<String> getUncommitted() {
-            return Collections.unmodifiableSet(uncommitted);
+            return uncommitted;
         }
 
         public Set<String> getUntracked() {
-            return Collections.unmodifiableSet(untracked);
+            return untracked;
         }
     }
 
@@ -141,14 +145,14 @@ public class GitChangeDetector {
     public StatusResult getStatusFiles(Repository repository) throws IOException {
         Set<String> uncommitted = new LinkedHashSet<>();
         Set<String> untracked = new LinkedHashSet<>();
-        try (org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repository)) {
-            org.eclipse.jgit.api.Status status = git.status().call();
+        try (Git git = new Git(repository)) {
+            Status status = git.status().call();
             uncommitted.addAll(status.getModified());
             uncommitted.addAll(status.getChanged());
             uncommitted.addAll(status.getAdded());
             uncommitted.addAll(status.getRemoved());
             untracked.addAll(status.getUntracked());
-        } catch (org.eclipse.jgit.api.errors.GitAPIException e) {
+        } catch (GitAPIException e) {
             throw new IOException("Failed to get git status", e);
         }
         logger.debug("Uncommitted files: {}", uncommitted);
@@ -168,12 +172,9 @@ public class GitChangeDetector {
         String refspec = "+refs/heads/" + branch + ":refs/remotes/" + remote + "/" + branch;
 
         logger.info("Scalpel: Fetching {} from {}", branch, remote);
-        try (org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repository)) {
-            git.fetch()
-                    .setRemote(remote)
-                    .setRefSpecs(new org.eclipse.jgit.transport.RefSpec(refspec))
-                    .call();
-        } catch (org.eclipse.jgit.api.errors.GitAPIException e) {
+        try (Git git = new Git(repository)) {
+            git.fetch().setRemote(remote).setRefSpecs(new RefSpec(refspec)).call();
+        } catch (GitAPIException e) {
             throw new IOException("Failed to fetch " + baseBranch, e);
         }
     }

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.scalpel.core;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -126,11 +127,11 @@ public class GitChangeDetector {
         }
 
         public Set<String> getUncommitted() {
-            return uncommitted;
+            return Collections.unmodifiableSet(uncommitted);
         }
 
         public Set<String> getUntracked() {
-            return untracked;
+            return Collections.unmodifiableSet(untracked);
         }
     }
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -7,7 +7,7 @@
  */
 package eu.maveniverse.maven.scalpel.core;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -160,6 +160,10 @@ public final class ScalpelConfiguration {
         String impactedLog = resolve(system, user, IMPACTED_LOG, null);
         boolean failSafe = Boolean.parseBoolean(resolve(system, user, FAIL_SAFE, "true"));
         String mode = resolve(system, user, MODE, MODE_TRIM);
+        if (!MODE_TRIM.equals(mode) && !MODE_SKIP_TESTS.equals(mode) && !MODE_REPORT.equals(mode)) {
+            throw new IllegalArgumentException("Invalid scalpel.mode '" + mode + "', expected one of: " + MODE_TRIM
+                    + ", " + MODE_SKIP_TESTS + ", " + MODE_REPORT);
+        }
         String reportFile = resolve(system, user, REPORT_FILE, DEFAULT_REPORT_FILE);
 
         return new ScalpelConfiguration(
@@ -205,7 +209,12 @@ public final class ScalpelConfiguration {
         if (value == null || value.isEmpty()) {
             return Collections.emptyList();
         }
-        return Arrays.asList(value.split(","));
+        String[] parts = value.split(",");
+        List<String> result = new ArrayList<>(parts.length);
+        for (String part : parts) {
+            result.add(part.trim());
+        }
+        return Collections.unmodifiableList(result);
     }
 
     private static String detectBaseBranch(Properties system) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -17,8 +17,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -68,12 +70,19 @@ public class ScalpelCore {
                 String currentBranch = gitChangeDetector.getCurrentBranch(repository);
                 if (currentBranch != null) {
                     for (String pattern : config.getDisableOnBranch()) {
-                        if (currentBranch.matches(pattern.trim())) {
-                            logger.info(
-                                    "Scalpel: Disabled because current branch '{}' matches pattern '{}'",
-                                    currentBranch,
-                                    pattern);
-                            return null;
+                        try {
+                            if (currentBranch.matches(pattern)) {
+                                logger.info(
+                                        "Scalpel: Disabled because current branch '{}' matches pattern '{}'",
+                                        currentBranch,
+                                        pattern);
+                                return null;
+                            }
+                        } catch (PatternSyntaxException e) {
+                            logger.warn(
+                                    "Scalpel: Invalid regex pattern '{}' in disableOnBranch: {}",
+                                    pattern,
+                                    e.getMessage());
                         }
                     }
                 }
@@ -89,10 +98,19 @@ public class ScalpelCore {
                     baseBranchName = baseBranchName.substring(slashIndex + 1);
                 }
                 for (String pattern : config.getDisableOnBaseBranch()) {
-                    if (baseBranchName.matches(pattern.trim())) {
-                        logger.info(
-                                "Scalpel: Disabled because base branch '{}' matches pattern '{}'", baseBranch, pattern);
-                        return null;
+                    try {
+                        if (baseBranchName.matches(pattern)) {
+                            logger.info(
+                                    "Scalpel: Disabled because base branch '{}' matches pattern '{}'",
+                                    baseBranch,
+                                    pattern);
+                            return null;
+                        }
+                    } catch (PatternSyntaxException e) {
+                        logger.warn(
+                                "Scalpel: Invalid regex pattern '{}' in disableOnBaseBranch: {}",
+                                pattern,
+                                e.getMessage());
                     }
                 }
             }
@@ -137,21 +155,24 @@ public class ScalpelCore {
             }
 
             ObjectId headId = repository.resolve(head);
-            Set<String> changedFiles = gitChangeDetector.getChangedFiles(repository, mergeBase, headId);
+            // Copy the set to avoid mutating the return value of getChangedFiles()
+            Set<String> changedFiles =
+                    new LinkedHashSet<>(gitChangeDetector.getChangedFiles(repository, mergeBase, headId));
 
             // Merge in uncommitted/untracked files if configured
-            if (config.isUncommitted()) {
-                Set<String> uncommittedFiles = gitChangeDetector.getUncommittedFiles(repository);
-                if (!uncommittedFiles.isEmpty()) {
-                    logger.info("Scalpel: {} uncommitted files detected", uncommittedFiles.size());
-                    changedFiles.addAll(uncommittedFiles);
+            if (config.isUncommitted() || config.isUntracked()) {
+                GitChangeDetector.StatusResult statusResult = gitChangeDetector.getStatusFiles(repository);
+                if (config.isUncommitted() && !statusResult.getUncommitted().isEmpty()) {
+                    logger.info(
+                            "Scalpel: {} uncommitted files detected",
+                            statusResult.getUncommitted().size());
+                    changedFiles.addAll(statusResult.getUncommitted());
                 }
-            }
-            if (config.isUntracked()) {
-                Set<String> untrackedFiles = gitChangeDetector.getUntrackedFiles(repository);
-                if (!untrackedFiles.isEmpty()) {
-                    logger.info("Scalpel: {} untracked files detected", untrackedFiles.size());
-                    changedFiles.addAll(untrackedFiles);
+                if (config.isUntracked() && !statusResult.getUntracked().isEmpty()) {
+                    logger.info(
+                            "Scalpel: {} untracked files detected",
+                            statusResult.getUntracked().size());
+                    changedFiles.addAll(statusResult.getUntracked());
                 }
             }
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -70,19 +70,12 @@ public class ScalpelCore {
                 String currentBranch = gitChangeDetector.getCurrentBranch(repository);
                 if (currentBranch != null) {
                     for (String pattern : config.getDisableOnBranch()) {
-                        try {
-                            if (currentBranch.matches(pattern)) {
-                                logger.info(
-                                        "Scalpel: Disabled because current branch '{}' matches pattern '{}'",
-                                        currentBranch,
-                                        pattern);
-                                return null;
-                            }
-                        } catch (PatternSyntaxException e) {
-                            logger.warn(
-                                    "Scalpel: Invalid regex pattern '{}' in disableOnBranch: {}",
-                                    pattern,
-                                    e.getMessage());
+                        if (matchesSafely(currentBranch, pattern, "disableOnBranch")) {
+                            logger.info(
+                                    "Scalpel: Disabled because current branch '{}' matches pattern '{}'",
+                                    currentBranch,
+                                    pattern);
+                            return null;
                         }
                     }
                 }
@@ -98,19 +91,10 @@ public class ScalpelCore {
                     baseBranchName = baseBranchName.substring(slashIndex + 1);
                 }
                 for (String pattern : config.getDisableOnBaseBranch()) {
-                    try {
-                        if (baseBranchName.matches(pattern)) {
-                            logger.info(
-                                    "Scalpel: Disabled because base branch '{}' matches pattern '{}'",
-                                    baseBranch,
-                                    pattern);
-                            return null;
-                        }
-                    } catch (PatternSyntaxException e) {
-                        logger.warn(
-                                "Scalpel: Invalid regex pattern '{}' in disableOnBaseBranch: {}",
-                                pattern,
-                                e.getMessage());
+                    if (matchesSafely(baseBranchName, pattern, "disableOnBaseBranch")) {
+                        logger.info(
+                                "Scalpel: Disabled because base branch '{}' matches pattern '{}'", baseBranch, pattern);
+                        return null;
                     }
                 }
             }
@@ -192,6 +176,15 @@ public class ScalpelCore {
             return handleError(config, "Error during change detection", e);
         } finally {
             repository.close();
+        }
+    }
+
+    private boolean matchesSafely(String value, String pattern, String configKey) {
+        try {
+            return value.matches(pattern);
+        } catch (PatternSyntaxException e) {
+            logger.warn("Scalpel: Invalid regex pattern '{}' in {}: {}", pattern, configKey, e.getMessage());
+            return false;
         }
     }
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -135,6 +135,47 @@ public final class ScalpelReport {
         public String getTestsSkippedReason() {
             return testsSkippedReason;
         }
+
+        public static ModuleBuilder moduleBuilder(
+                String groupId, String artifactId, String path, List<String> reasons) {
+            return new ModuleBuilder(groupId, artifactId, path, reasons);
+        }
+
+        public static class ModuleBuilder {
+            private final String groupId;
+            private final String artifactId;
+            private final String path;
+            private final List<String> reasons;
+            private String category;
+            private String sourceSet;
+            private String testsSkippedReason;
+
+            ModuleBuilder(String groupId, String artifactId, String path, List<String> reasons) {
+                this.groupId = groupId;
+                this.artifactId = artifactId;
+                this.path = path;
+                this.reasons = reasons;
+            }
+
+            public ModuleBuilder category(String category) {
+                this.category = category;
+                return this;
+            }
+
+            public ModuleBuilder sourceSet(String sourceSet) {
+                this.sourceSet = sourceSet;
+                return this;
+            }
+
+            public ModuleBuilder testsSkippedReason(String testsSkippedReason) {
+                this.testsSkippedReason = testsSkippedReason;
+                return this;
+            }
+
+            public AffectedModule build() {
+                return new AffectedModule(groupId, artifactId, path, reasons, category, sourceSet, testsSkippedReason);
+            }
+        }
     }
 
     public String toJson() {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.scalpel.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -377,6 +378,31 @@ class ScalpelConfigurationTest {
         assertEquals("skip-tests", config.getMode());
         assertFalse(config.isFailSafe());
     }
+
+    // ---------------------------------------------------------------
+    // Mode validation
+    // ---------------------------------------------------------------
+
+    @Test
+    void invalidMode_throwsException() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.mode", "invalid");
+        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, new Properties()));
+    }
+
+    @Test
+    void validModes_accepted() {
+        for (String mode : new String[] {"trim", "skip-tests", "report"}) {
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.mode", mode);
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+            assertEquals(mode, config.getMode());
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Whitespace trimming
+    // ---------------------------------------------------------------
 
     @Test
     void listField_trimsWhitespaceInValues() {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -379,15 +379,14 @@ class ScalpelConfigurationTest {
     }
 
     @Test
-    void listField_preservesWhitespaceInValues() {
+    void listField_trimsWhitespaceInValues() {
         Properties sys = new Properties();
         sys.setProperty("scalpel.disableOnBranch", "main, release/.*,hotfix");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
         List<String> list = config.getDisableOnBranch();
         assertEquals(3, list.size());
         assertEquals("main", list.get(0));
-        // note: trimming happens in ScalpelLifecycleParticipant, not configuration
-        assertEquals(" release/.*", list.get(1));
+        assertEquals("release/.*", list.get(1));
         assertEquals("hotfix", list.get(2));
     }
 }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -387,7 +387,8 @@ class ScalpelConfigurationTest {
     void invalidMode_throwsException() {
         Properties sys = new Properties();
         sys.setProperty("scalpel.mode", "invalid");
-        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, new Properties()));
+        Properties user = new Properties();
+        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, user));
     }
 
     @Test

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.Set;
+import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ScalpelCoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void detectChanges_detectsNewFileOnBranch() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            // Initial commit on default branch
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+
+            // Create 'main' branch at this point
+            git.branchCreate().setName("main").call();
+
+            // Make a change on current branch
+            Files.write(tempDir.resolve("new-file.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new-file.txt").call();
+            git.commit().setMessage("add new file").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+
+            assertNotNull(result);
+            assertTrue(result.getChangedFiles().contains("new-file.txt"));
+        }
+    }
+
+    @Test
+    void detectChanges_withUncommittedFiles() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            // Create an uncommitted tracked change
+            Files.write(tempDir.resolve("file.txt"), "modified".getBytes(StandardCharsets.UTF_8));
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.uncommitted", "true");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+
+            assertNotNull(result);
+            assertTrue(result.getChangedFiles().contains("file.txt"), "uncommitted change should be detected");
+        }
+    }
+
+    @Test
+    void detectChanges_withUntrackedFiles() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            // Create an untracked file
+            Files.write(tempDir.resolve("untracked.txt"), "new".getBytes(StandardCharsets.UTF_8));
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.untracked", "true");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+
+            assertNotNull(result);
+            assertTrue(result.getChangedFiles().contains("untracked.txt"), "untracked file should be detected");
+        }
+    }
+
+    @Test
+    void detectChanges_invalidRegexInDisableOnBranch_doesNotCrash() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(tempDir.resolve("new.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new.txt").call();
+            git.commit().setMessage("change").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            // Invalid regex pattern should be handled gracefully
+            sys.setProperty("scalpel.disableOnBranch", "[unclosed");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            // Should not throw, just log a warning and continue
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+
+            assertNotNull(result);
+        }
+    }
+
+    @Test
+    void detectChanges_disableOnBranchMatchingPattern_returnsNull() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            // Current branch is "master" (default), disable on "master"
+            String currentBranch = git.getRepository().getBranch();
+            sys.setProperty("scalpel.disableOnBranch", currentBranch);
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+
+            assertNull(result, "Should return null when current branch matches disableOnBranch");
+        }
+    }
+
+    @Test
+    void detectChanges_notAGitRepo_returnsNull() throws Exception {
+        // A directory that is not a git repo
+        Path nonGitDir = tempDir.resolve("not-a-repo");
+        Files.createDirectories(nonGitDir);
+
+        ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.baseBranch", "main");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+        ChangeDetectionResult result = core.detectChanges(nonGitDir, config, Collections.<String>emptySet());
+
+        assertNull(result, "Should return null for non-git directory");
+    }
+
+    @Test
+    void detectChanges_readOldPomContent() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            // Create initial POM
+            String oldPom = "<project><version>1.0</version></project>";
+            Files.write(tempDir.resolve("pom.xml"), oldPom.getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            // Modify POM on current branch
+            String newPom = "<project><version>2.0</version></project>";
+            Files.write(tempDir.resolve("pom.xml"), newPom.getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("bump version").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            Set<String> pomPaths = Collections.singleton("pom.xml");
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, pomPaths);
+
+            assertNotNull(result);
+            assertTrue(result.getChangedFiles().contains("pom.xml"));
+            assertTrue(result.getOldPomContents().containsKey("pom.xml"));
+            String readOldPom = new String(result.getOldPomContents().get("pom.xml"), StandardCharsets.UTF_8);
+            assertTrue(readOldPom.contains("1.0"), "Old POM should contain original version");
+            assertFalse(readOldPom.contains("2.0"), "Old POM should not contain new version");
+        }
+    }
+}

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.scalpel.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -318,6 +319,82 @@ class ScalpelReportTest {
         assertTrue(json.contains("\"sourceSet\": \"main\""));
         assertTrue(json.contains("\"testsSkippedReason\": \"EXCLUDED_DOWNSTREAM\""));
         assertTrue(json.contains("\"category\": \"DOWNSTREAM\""));
+    }
+
+    // ---------------------------------------------------------------
+    // ModuleBuilder tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void moduleBuilder_minimalBuild() {
+        ScalpelReport.AffectedModule module = ScalpelReport.AffectedModule.moduleBuilder(
+                        "com.example", "module-a", "module-a", Collections.singletonList("SOURCE_CHANGE"))
+                .build();
+
+        assertEquals("com.example", module.getGroupId());
+        assertEquals("module-a", module.getArtifactId());
+        assertEquals("module-a", module.getPath());
+        assertEquals(Collections.singletonList("SOURCE_CHANGE"), module.getReasons());
+        assertNull(module.getCategory());
+        assertNull(module.getSourceSet());
+        assertNull(module.getTestsSkippedReason());
+    }
+
+    @Test
+    void moduleBuilder_allFieldsSet() {
+        ScalpelReport.AffectedModule module = ScalpelReport.AffectedModule.moduleBuilder(
+                        "com.example",
+                        "module-b",
+                        "path/module-b",
+                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT))
+                .category(ScalpelReport.CATEGORY_DOWNSTREAM)
+                .sourceSet("main")
+                .testsSkippedReason(ScalpelReport.REASON_EXCLUDED_DOWNSTREAM)
+                .build();
+
+        assertEquals("com.example", module.getGroupId());
+        assertEquals("module-b", module.getArtifactId());
+        assertEquals("path/module-b", module.getPath());
+        assertEquals(ScalpelReport.CATEGORY_DOWNSTREAM, module.getCategory());
+        assertEquals("main", module.getSourceSet());
+        assertEquals(ScalpelReport.REASON_EXCLUDED_DOWNSTREAM, module.getTestsSkippedReason());
+    }
+
+    @Test
+    void moduleBuilder_producesCorrectJson() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example",
+                                "module-a",
+                                "module-a",
+                                Collections.singletonList(ScalpelReport.REASON_SOURCE_CHANGE))
+                        .category(ScalpelReport.CATEGORY_DIRECT)
+                        .sourceSet("main")
+                        .build())
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"SOURCE_CHANGE\""));
+        assertTrue(json.contains("\"category\": \"DIRECT\""));
+        assertTrue(json.contains("\"sourceSet\": \"main\""));
+    }
+
+    @Test
+    void moduleBuilder_categoryOnly() {
+        ScalpelReport.AffectedModule module = ScalpelReport.AffectedModule.moduleBuilder(
+                        "com.example",
+                        "module-a",
+                        "module-a",
+                        Collections.singletonList(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY))
+                .category(ScalpelReport.CATEGORY_UPSTREAM)
+                .build();
+
+        assertEquals(ScalpelReport.CATEGORY_UPSTREAM, module.getCategory());
+        assertNull(module.getSourceSet());
+        assertNull(module.getTestsSkippedReason());
     }
 
     @Test

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Groups analysis results passed between stages of the Scalpel lifecycle processing.
+ */
+final class AnalysisContext {
+
+    final Set<String> changedFiles;
+    final Set<String> changedProperties;
+    final Set<String> changedManagedDepGAs;
+    final Set<String> changedManagedPluginGAs;
+    final Set<MavenProject> directlyAffected;
+    final Set<MavenProject> affectedBySource;
+    final Set<MavenProject> testOnlyBySource;
+    final Set<MavenProject> affectedByPom;
+    final Set<MavenProject> forceIncluded;
+    final Map<MavenProject, List<String>> transitivelyAffected;
+    final TrimResult trimResult;
+
+    AnalysisContext(
+            Set<String> changedFiles,
+            Set<String> changedProperties,
+            Set<String> changedManagedDepGAs,
+            Set<String> changedManagedPluginGAs,
+            Set<MavenProject> directlyAffected,
+            Set<MavenProject> affectedBySource,
+            Set<MavenProject> testOnlyBySource,
+            Set<MavenProject> affectedByPom,
+            Set<MavenProject> forceIncluded,
+            Map<MavenProject, List<String>> transitivelyAffected,
+            TrimResult trimResult) {
+        this.changedFiles = changedFiles;
+        this.changedProperties = changedProperties;
+        this.changedManagedDepGAs = changedManagedDepGAs;
+        this.changedManagedPluginGAs = changedManagedPluginGAs;
+        this.directlyAffected = directlyAffected;
+        this.affectedBySource = affectedBySource;
+        this.testOnlyBySource = testOnlyBySource;
+        this.affectedByPom = affectedByPom;
+        this.forceIncluded = forceIncluded;
+        this.transitivelyAffected = transitivelyAffected;
+        this.trimResult = trimResult;
+    }
+
+    static AnalysisContext empty(
+            Set<String> changedFiles,
+            Set<String> changedProperties,
+            Set<String> changedManagedDepGAs,
+            Set<String> changedManagedPluginGAs) {
+        return new AnalysisContext(
+                changedFiles,
+                changedProperties,
+                changedManagedDepGAs,
+                changedManagedPluginGAs,
+                Collections.<MavenProject>emptySet(),
+                Collections.<MavenProject>emptySet(),
+                Collections.<MavenProject>emptySet(),
+                Collections.<MavenProject>emptySet(),
+                Collections.<MavenProject>emptySet(),
+                Collections.<MavenProject, List<String>>emptyMap(),
+                null);
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
@@ -30,29 +30,31 @@ final class AnalysisContext {
     final Map<MavenProject, List<String>> transitivelyAffected;
     final TrimResult trimResult;
 
-    AnalysisContext(
+    private AnalysisContext(Builder builder) {
+        this.changedFiles = builder.changedFiles;
+        this.changedProperties = builder.changedProperties;
+        this.changedManagedDepGAs = builder.changedManagedDepGAs;
+        this.changedManagedPluginGAs = builder.changedManagedPluginGAs;
+        this.directlyAffected = builder.directlyAffected;
+        this.affectedBySource = builder.affectedBySource;
+        this.testOnlyBySource = builder.testOnlyBySource;
+        this.affectedByPom = builder.affectedByPom;
+        this.forceIncluded = builder.forceIncluded;
+        this.transitivelyAffected = builder.transitivelyAffected;
+        this.trimResult = builder.trimResult;
+    }
+
+    static Builder builder(
             Set<String> changedFiles,
             Set<String> changedProperties,
             Set<String> changedManagedDepGAs,
-            Set<String> changedManagedPluginGAs,
-            Set<MavenProject> directlyAffected,
-            Set<MavenProject> affectedBySource,
-            Set<MavenProject> testOnlyBySource,
-            Set<MavenProject> affectedByPom,
-            Set<MavenProject> forceIncluded,
-            Map<MavenProject, List<String>> transitivelyAffected,
-            TrimResult trimResult) {
-        this.changedFiles = changedFiles;
-        this.changedProperties = changedProperties;
-        this.changedManagedDepGAs = changedManagedDepGAs;
-        this.changedManagedPluginGAs = changedManagedPluginGAs;
-        this.directlyAffected = directlyAffected;
-        this.affectedBySource = affectedBySource;
-        this.testOnlyBySource = testOnlyBySource;
-        this.affectedByPom = affectedByPom;
-        this.forceIncluded = forceIncluded;
-        this.transitivelyAffected = transitivelyAffected;
-        this.trimResult = trimResult;
+            Set<String> changedManagedPluginGAs) {
+        Builder b = new Builder();
+        b.changedFiles = changedFiles;
+        b.changedProperties = changedProperties;
+        b.changedManagedDepGAs = changedManagedDepGAs;
+        b.changedManagedPluginGAs = changedManagedPluginGAs;
+        return b;
     }
 
     static AnalysisContext empty(
@@ -60,17 +62,63 @@ final class AnalysisContext {
             Set<String> changedProperties,
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs) {
-        return new AnalysisContext(
-                changedFiles,
-                changedProperties,
-                changedManagedDepGAs,
-                changedManagedPluginGAs,
-                Collections.<MavenProject>emptySet(),
-                Collections.<MavenProject>emptySet(),
-                Collections.<MavenProject>emptySet(),
-                Collections.<MavenProject>emptySet(),
-                Collections.<MavenProject>emptySet(),
-                Collections.<MavenProject, List<String>>emptyMap(),
-                null);
+        return builder(changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
+                .build();
+    }
+
+    static final class Builder {
+        private Set<String> changedFiles;
+        private Set<String> changedProperties;
+        private Set<String> changedManagedDepGAs;
+        private Set<String> changedManagedPluginGAs;
+        private Set<MavenProject> directlyAffected = Collections.<MavenProject>emptySet();
+        private Set<MavenProject> affectedBySource = Collections.<MavenProject>emptySet();
+        private Set<MavenProject> testOnlyBySource = Collections.<MavenProject>emptySet();
+        private Set<MavenProject> affectedByPom = Collections.<MavenProject>emptySet();
+        private Set<MavenProject> forceIncluded = Collections.<MavenProject>emptySet();
+        private Map<MavenProject, List<String>> transitivelyAffected =
+                Collections.<MavenProject, List<String>>emptyMap();
+        private TrimResult trimResult;
+
+        private Builder() {}
+
+        Builder directlyAffected(Set<MavenProject> directlyAffected) {
+            this.directlyAffected = directlyAffected;
+            return this;
+        }
+
+        Builder affectedBySource(Set<MavenProject> affectedBySource) {
+            this.affectedBySource = affectedBySource;
+            return this;
+        }
+
+        Builder testOnlyBySource(Set<MavenProject> testOnlyBySource) {
+            this.testOnlyBySource = testOnlyBySource;
+            return this;
+        }
+
+        Builder affectedByPom(Set<MavenProject> affectedByPom) {
+            this.affectedByPom = affectedByPom;
+            return this;
+        }
+
+        Builder forceIncluded(Set<MavenProject> forceIncluded) {
+            this.forceIncluded = forceIncluded;
+            return this;
+        }
+
+        Builder transitivelyAffected(Map<MavenProject, List<String>> transitivelyAffected) {
+            this.transitivelyAffected = transitivelyAffected;
+            return this;
+        }
+
+        Builder trimResult(TrimResult trimResult) {
+            this.trimResult = trimResult;
+            return this;
+        }
+
+        AnalysisContext build() {
+            return new AnalysisContext(this);
+        }
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -512,7 +512,9 @@ class PomChangeAnalyzer {
         for (Map.Entry<String, Dependency> e : oldMap.entrySet()) {
             Dependency newDep = newMap.get(e.getKey());
             if (newDep == null || !equalDependency(e.getValue(), newDep)) {
-                // Report the GA (not the full key) for downstream matching
+                // Report at GA level: downstream module matching resolves dependencies by GA,
+                // so any change to a managed GA (regardless of classifier/type variant) should
+                // flag all modules depending on that GA.
                 changed.add(e.getValue().getGroupId() + ":" + e.getValue().getArtifactId());
             }
         }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1048,7 +1048,7 @@ class PomChangeAnalyzer {
         return false;
     }
 
-    private static final long MAX_RESOURCE_FILE_SIZE = 1024 * 1024; // 1 MB
+    private static final long MAX_RESOURCE_FILE_SIZE = 1024L * 1024; // 1 MB
 
     private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs) {
         List<Path> stack = new ArrayList<>();

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -500,25 +502,39 @@ class PomChangeAnalyzer {
         Set<String> changed = new LinkedHashSet<>();
         Map<String, Dependency> oldMap = new LinkedHashMap<>();
         for (Dependency d : oldDeps) {
-            oldMap.put(d.getGroupId() + ":" + d.getArtifactId(), d);
+            oldMap.put(dependencyKey(d), d);
         }
         Map<String, Dependency> newMap = new LinkedHashMap<>();
         for (Dependency d : newDeps) {
-            newMap.put(d.getGroupId() + ":" + d.getArtifactId(), d);
+            newMap.put(dependencyKey(d), d);
         }
 
         for (Map.Entry<String, Dependency> e : oldMap.entrySet()) {
             Dependency newDep = newMap.get(e.getKey());
             if (newDep == null || !equalDependency(e.getValue(), newDep)) {
-                changed.add(e.getKey());
+                // Report the GA (not the full key) for downstream matching
+                changed.add(e.getValue().getGroupId() + ":" + e.getValue().getArtifactId());
             }
         }
-        for (String ga : newMap.keySet()) {
-            if (!oldMap.containsKey(ga)) {
-                changed.add(ga);
+        for (Map.Entry<String, Dependency> e : newMap.entrySet()) {
+            if (!oldMap.containsKey(e.getKey())) {
+                changed.add(e.getValue().getGroupId() + ":" + e.getValue().getArtifactId());
             }
         }
         return changed;
+    }
+
+    /**
+     * Returns a key that distinguishes dependencies with the same GA but different classifier/type.
+     */
+    private static String dependencyKey(Dependency d) {
+        String key = d.getGroupId() + ":" + d.getArtifactId();
+        String type = d.getType();
+        String classifier = d.getClassifier();
+        if ((type != null && !"jar".equals(type)) || classifier != null) {
+            key += ":" + (type != null ? type : "jar") + ":" + (classifier != null ? classifier : "");
+        }
+        return key;
     }
 
     private Set<String> diffPlugins(List<Plugin> oldPlugins, List<Plugin> newPlugins) {
@@ -646,11 +662,10 @@ class PomChangeAnalyzer {
         }
         Map<String, Dependency> mapA = new LinkedHashMap<>();
         for (Dependency dep : a) {
-            mapA.put(dep.getGroupId() + ":" + dep.getArtifactId(), dep);
+            mapA.put(dependencyKey(dep), dep);
         }
         for (Dependency dep : b) {
-            String key = dep.getGroupId() + ":" + dep.getArtifactId();
-            Dependency other = mapA.remove(key);
+            Dependency other = mapA.remove(dependencyKey(dep));
             if (other == null || !equalDependency(other, dep)) {
                 return false;
             }
@@ -900,10 +915,11 @@ class PomChangeAnalyzer {
     }
 
     private Set<MavenProject> findParentProjects(List<MavenProject> allProjects) {
+        Set<MavenProject> allProjectsSet = new HashSet<>(allProjects);
         Set<MavenProject> parents = new LinkedHashSet<>();
         for (MavenProject project : allProjects) {
             MavenProject parent = project.getParent();
-            if (parent != null && allProjects.contains(parent)) {
+            if (parent != null && allProjectsSet.contains(parent)) {
                 parents.add(parent);
             }
         }
@@ -1032,19 +1048,23 @@ class PomChangeAnalyzer {
         return false;
     }
 
+    private static final long MAX_RESOURCE_FILE_SIZE = 1024 * 1024; // 1 MB
+
     private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs) {
         List<Path> stack = new ArrayList<>();
         stack.add(dir);
         while (!stack.isEmpty()) {
             Path current = stack.remove(stack.size() - 1);
-            DirectoryStream<Path> stream = null;
-            try {
-                stream = Files.newDirectoryStream(current);
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(current)) {
                 for (Path entry : stream) {
                     if (Files.isDirectory(entry)) {
                         stack.add(entry);
                     } else if (Files.isRegularFile(entry)) {
                         try {
+                            long size = Files.size(entry);
+                            if (size > MAX_RESOURCE_FILE_SIZE) {
+                                continue; // Skip large files (likely binaries)
+                            }
                             String content = new String(Files.readAllBytes(entry), StandardCharsets.UTF_8);
                             for (String ref : refs) {
                                 if (content.contains(ref)) {
@@ -1058,14 +1078,6 @@ class PomChangeAnalyzer {
                 }
             } catch (IOException e) {
                 // Skip unreadable directories
-            } finally {
-                if (stream != null) {
-                    try {
-                        stream.close();
-                    } catch (IOException e) {
-                        // ignore
-                    }
-                }
             }
         }
         return false;
@@ -1078,9 +1090,5 @@ class PomChangeAnalyzer {
             logger.debug("Cannot read POM file for {}: {}", key(project), e.getMessage());
             return null;
         }
-    }
-
-    private static String key(MavenProject project) {
-        return project.getGroupId() + ":" + project.getArtifactId();
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1065,7 +1065,8 @@ class PomChangeAnalyzer {
                         try {
                             long size = Files.size(entry);
                             if (size > MAX_RESOURCE_FILE_SIZE) {
-                                continue; // Skip large files (likely binaries)
+                                // Conservative: treat oversized files as potentially affected
+                                return true;
                             }
                             String content = new String(Files.readAllBytes(entry), StandardCharsets.UTF_8);
                             for (String ref : refs) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/Projects.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/Projects.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.project.MavenProject;
+
+final class Projects {
+    private Projects() {}
+
+    static String key(MavenProject project) {
+        return project.getGroupId() + ":" + project.getArtifactId();
+    }
+
+    static List<String> keys(Iterable<MavenProject> projects) {
+        List<String> keys = new ArrayList<>();
+        for (MavenProject project : projects) {
+            keys.add(key(project));
+        }
+        return keys;
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -7,6 +7,9 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
+
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -131,17 +134,5 @@ class ReactorTrimmer {
             }
         }
         return null; // transitive dependency
-    }
-
-    private static String key(MavenProject project) {
-        return project.getGroupId() + ":" + project.getArtifactId();
-    }
-
-    private static List<String> keys(List<MavenProject> projects) {
-        List<String> keys = new ArrayList<>();
-        for (MavenProject project : projects) {
-            keys.add(key(project));
-        }
-        return keys;
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
 import static java.util.Objects.requireNonNull;
 
 import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
@@ -83,13 +85,6 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             return;
         }
 
-        if (!config.isModeTrim() && !config.isModeSkipTests() && !config.isModeReport()) {
-            logger.warn(
-                    "Scalpel: Unknown mode '{}', expected one of: trim, skip-tests, report. Scalpel will not activate.",
-                    config.getMode());
-            return;
-        }
-
         // Check if -pl is active and disableOnSelectedProjects is set
         if (config.isDisableOnSelectedProjects()) {
             List<String> selectedProjects = session.getRequest().getSelectedProjects();
@@ -131,61 +126,24 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             logger.info("Scalpel: {} changed files detected", changedFiles.size());
 
             // Check disable triggers (bail out entirely if any changed file matches)
-            for (String pattern : config.getDisableTriggers()) {
-                PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern.trim());
-                for (String changedFile : changedFiles) {
-                    if (matcher.matches(Paths.get(changedFile))) {
-                        logger.info(
-                                "Scalpel: Disabled due to change in {} (matches disable trigger {})",
-                                changedFile,
-                                pattern);
-                        return;
-                    }
-                }
+            if (matchesDisableTrigger(changedFiles, config)) {
+                return;
             }
 
             // Filter out excluded paths
-            if (!config.getExcludePaths().isEmpty()) {
-                List<PathMatcher> excludeMatchers = new ArrayList<>();
-                for (String pattern : config.getExcludePaths()) {
-                    excludeMatchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern.trim()));
-                }
-                Set<String> filtered = new LinkedHashSet<>();
-                for (String file : changedFiles) {
-                    boolean excluded = false;
-                    for (PathMatcher matcher : excludeMatchers) {
-                        if (matcher.matches(Paths.get(file))) {
-                            excluded = true;
-                            break;
-                        }
-                    }
-                    if (!excluded) {
-                        filtered.add(file);
-                    }
-                }
-                int excludedCount = changedFiles.size() - filtered.size();
-                if (excludedCount > 0) {
-                    logger.info("Scalpel: {} files excluded by path filters", excludedCount);
-                }
-                changedFiles = filtered;
-                if (changedFiles.isEmpty()) {
-                    logger.info("Scalpel: All changed files excluded by path filters, building all modules");
-                    return;
-                }
+            changedFiles = filterExcludedPaths(changedFiles, config);
+            if (changedFiles.isEmpty()) {
+                logger.info("Scalpel: All changed files excluded by path filters, building all modules");
+                return;
             }
 
             // Check full build triggers
-            for (String pattern : config.getFullBuildTriggers()) {
-                PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern.trim());
-                for (String changedFile : changedFiles) {
-                    if (matcher.matches(Paths.get(changedFile))) {
-                        logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
-                        if (config.isModeReport()) {
-                            writeFullBuildReport(config, reactorRoot, changedFile, changedFiles);
-                        }
-                        return;
-                    }
+            String triggerFile = findFullBuildTrigger(changedFiles, config);
+            if (triggerFile != null) {
+                if (config.isModeReport()) {
+                    writeFullBuildReport(config, reactorRoot, triggerFile, changedFiles);
                 }
+                return;
             }
 
             // Separate POM changes from source changes
@@ -203,11 +161,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             ModuleMapper.Result sourceResult =
                     moduleMapper.mapToProjectsClassified(sourceChanges, allProjects, reactorRoot);
             Set<MavenProject> affectedBySource = sourceResult.getAllAffected();
-            logger.debug("Modules affected by source changes: {}", projectKeys(affectedBySource));
+            logger.debug("Modules affected by source changes: {}", keys(affectedBySource));
             if (!sourceResult.getTestOnlyAffected().isEmpty()) {
                 logger.debug(
-                        "Test-only modules (no downstream propagation): {}",
-                        projectKeys(sourceResult.getTestOnlyAffected()));
+                        "Test-only modules (no downstream propagation): {}", keys(sourceResult.getTestOnlyAffected()));
             }
 
             // Analyze POM changes directly (no model building needed)
@@ -233,7 +190,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         throw new MavenExecutionException("Scalpel: Error analyzing POM changes", e);
                     }
                 }
-                logger.debug("Modules affected by POM changes: {}", projectKeys(affectedByPom));
+                logger.debug("Modules affected by POM changes: {}", keys(affectedByPom));
                 if (!changedManagedDepGAs.isEmpty()) {
                     logger.debug("Changed managed dependency GAs: {}", changedManagedDepGAs);
                 }
@@ -262,7 +219,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         continue;
                     }
                     for (String pattern : config.getForceBuildModules()) {
-                        if (project.getArtifactId().matches(pattern.trim())) {
+                        if (project.getArtifactId().matches(pattern)) {
                             directlyAffected.add(project);
                             forceIncluded.add(project);
                             logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
@@ -281,27 +238,15 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     writeReport(
                             config,
                             reactorRoot,
-                            changedFiles,
-                            changedProperties,
-                            changedManagedDepGAs,
-                            changedManagedPluginGAs,
-                            Collections.<MavenProject>emptySet(),
-                            Collections.<MavenProject>emptySet(),
-                            Collections.<MavenProject>emptySet(),
-                            Collections.<MavenProject>emptySet(),
-                            Collections.<MavenProject>emptySet(),
-                            Collections.<MavenProject, List<String>>emptyMap(),
-                            null);
+                            AnalysisContext.empty(
+                                    changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs));
                 } else if (config.isModeSkipTests()) {
                     skipTestsOnAll(allProjects);
                 }
                 return;
             }
 
-            logger.info(
-                    "Scalpel: {} modules directly affected: {}",
-                    directlyAffected.size(),
-                    projectKeys(directlyAffected));
+            logger.info("Scalpel: {} modules directly affected: {}", directlyAffected.size(), keys(directlyAffected));
 
             // Write impacted module log if configured
             if (config.getImpactedLog() != null) {
@@ -313,54 +258,24 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 TrimResult trimResult = reactorTrimmer.computeBuildSet(
                         directlyAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
 
-                // Check remaining modules for transitive dependency/plugin impact
-                Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
-                if (!changedManagedDepGAs.isEmpty() || !changedManagedPluginGAs.isEmpty()) {
-                    for (MavenProject project : allProjects) {
-                        if (directlyAffected.contains(project)) {
-                            continue;
-                        }
-                        List<String> reasons = new ArrayList<>();
-                        if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
-                            reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
-                        }
-                        if (!changedManagedDepGAs.isEmpty()) {
-                            String depScope =
-                                    getChangedTransitiveDependencyScope(project, session, changedManagedDepGAs);
-                            if (depScope != null) {
-                                if ("test".equals(depScope)) {
-                                    reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
-                                } else {
-                                    reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
-                                }
-                            }
-                        }
-                        if (!reasons.isEmpty()) {
-                            transitivelyAffected.put(project, reasons);
-                        }
-                    }
-                    if (!transitivelyAffected.isEmpty()) {
-                        logger.info(
-                                "Scalpel: {} modules transitively affected: {}",
-                                transitivelyAffected.size(),
-                                projectKeys(transitivelyAffected.keySet()));
-                    }
-                }
+                Map<MavenProject, List<String>> transitivelyAffected = computeTransitivelyAffected(
+                        allProjects, directlyAffected, changedManagedDepGAs, changedManagedPluginGAs, session);
 
                 writeReport(
                         config,
                         reactorRoot,
-                        changedFiles,
-                        changedProperties,
-                        changedManagedDepGAs,
-                        changedManagedPluginGAs,
-                        directlyAffected,
-                        affectedBySource,
-                        sourceResult.getTestOnlyAffected(),
-                        affectedByPom,
-                        forceIncluded,
-                        transitivelyAffected,
-                        trimResult);
+                        new AnalysisContext(
+                                changedFiles,
+                                changedProperties,
+                                changedManagedDepGAs,
+                                changedManagedPluginGAs,
+                                directlyAffected,
+                                affectedBySource,
+                                sourceResult.getTestOnlyAffected(),
+                                affectedByPom,
+                                forceIncluded,
+                                transitivelyAffected,
+                                trimResult));
                 return;
             }
 
@@ -376,7 +291,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         "Scalpel: Building {} of {} modules: {}",
                         trimResult.getBuildSet().size(),
                         allProjects.size(),
-                        projectKeys(trimResult.getBuildSet()));
+                        keys(trimResult.getBuildSet()));
                 session.setProjects(trimResult.getBuildSet());
                 // Apply per-category args in trim mode
                 applyPerCategoryArgs(trimResult, config);
@@ -385,6 +300,104 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         } catch (ScalpelException e) {
             throw new MavenExecutionException("Scalpel: " + e.getMessage(), e);
         }
+    }
+
+    private boolean matchesDisableTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
+        for (String pattern : config.getDisableTriggers()) {
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern);
+            for (String changedFile : changedFiles) {
+                if (matcher.matches(Paths.get(changedFile))) {
+                    logger.info(
+                            "Scalpel: Disabled due to change in {} (matches disable trigger {})", changedFile, pattern);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private Set<String> filterExcludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
+        if (config.getExcludePaths().isEmpty()) {
+            return changedFiles;
+        }
+        List<PathMatcher> excludeMatchers = new ArrayList<>();
+        for (String pattern : config.getExcludePaths()) {
+            excludeMatchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern));
+        }
+        Set<String> filtered = new LinkedHashSet<>();
+        for (String file : changedFiles) {
+            boolean excluded = false;
+            for (PathMatcher matcher : excludeMatchers) {
+                if (matcher.matches(Paths.get(file))) {
+                    excluded = true;
+                    break;
+                }
+            }
+            if (!excluded) {
+                filtered.add(file);
+            }
+        }
+        int excludedCount = changedFiles.size() - filtered.size();
+        if (excludedCount > 0) {
+            logger.info("Scalpel: {} files excluded by path filters", excludedCount);
+        }
+        return filtered;
+    }
+
+    private String findFullBuildTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
+        for (String pattern : config.getFullBuildTriggers()) {
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern);
+            for (String changedFile : changedFiles) {
+                if (matcher.matches(Paths.get(changedFile))) {
+                    logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
+                    return changedFile;
+                }
+            }
+        }
+        return null;
+    }
+
+    private Map<MavenProject, List<String>> computeTransitivelyAffected(
+            List<MavenProject> allProjects,
+            Set<MavenProject> directlyAffected,
+            Set<String> changedManagedDepGAs,
+            Set<String> changedManagedPluginGAs,
+            MavenSession session) {
+        Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
+        if (changedManagedDepGAs.isEmpty() && changedManagedPluginGAs.isEmpty()) {
+            return transitivelyAffected;
+        }
+        Map<MavenProject, DependencyResolutionResult> resolveCache = new LinkedHashMap<>();
+        for (MavenProject project : allProjects) {
+            if (directlyAffected.contains(project)) {
+                continue;
+            }
+            List<String> reasons = new ArrayList<>();
+            if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
+                reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
+            }
+            if (!changedManagedDepGAs.isEmpty()) {
+                String depScope =
+                        getChangedTransitiveDependencyScope(project, session, changedManagedDepGAs, resolveCache);
+                if (depScope != null) {
+                    if ("test".equals(depScope)) {
+                        reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
+                    } else {
+                        reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+                    }
+                }
+            }
+            if (!reasons.isEmpty()) {
+                transitivelyAffected.put(project, reasons);
+            }
+        }
+        if (!transitivelyAffected.isEmpty()) {
+            logger.info(
+                    "Scalpel: {} modules transitively affected: {}",
+                    transitivelyAffected.size(),
+                    keys(transitivelyAffected.keySet()));
+        }
+        return transitivelyAffected;
     }
 
     private void applySkipTests(
@@ -398,6 +411,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         Set<MavenProject> buildSetLookup = new LinkedHashSet<>(trimResult.getBuildSet());
         List<MavenProject> testProjects = new ArrayList<>();
         List<MavenProject> skippedProjects = new ArrayList<>();
+        Map<MavenProject, DependencyResolutionResult> resolveCache = new LinkedHashMap<>();
 
         // Directly affected modules always run tests
         for (MavenProject project : trimResult.getBuildSet()) {
@@ -409,7 +423,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
             } else if (shouldSkipTestsForExcludedDownstream(
-                    project, trimResult, config, session, changedManagedPluginGAs, changedManagedDepGAs)) {
+                    project,
+                    trimResult,
+                    config,
+                    session,
+                    changedManagedPluginGAs,
+                    changedManagedDepGAs,
+                    resolveCache)) {
                 // Skip tests on excluded downstream modules (unless they also have plugin/dep changes)
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
@@ -435,7 +455,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Check transitive dependencies if managed deps changed
             if (!changedManagedDepGAs.isEmpty()
-                    && hasChangedTransitiveDependency(project, session, changedManagedDepGAs)) {
+                    && hasChangedTransitiveDependency(project, session, changedManagedDepGAs, resolveCache)) {
                 testProjects.add(project);
                 continue;
             }
@@ -453,7 +473,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 testProjects.size(),
                 allProjects.size(),
                 skippedProjects.size(),
-                projectKeys(skippedProjects));
+                keys(skippedProjects));
     }
 
     private boolean usesChangedPlugin(MavenProject project, Set<String> changedPluginGAs) {
@@ -469,13 +489,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
         for (String pattern : patterns) {
-            String trimmed = pattern.trim();
-            if (trimmed.contains(":")) {
-                if (key(project).equals(trimmed)) {
+            if (pattern.contains(":")) {
+                if (key(project).equals(pattern)) {
                     return true;
                 }
             } else {
-                if (project.getArtifactId().equals(trimmed)) {
+                if (project.getArtifactId().equals(pattern)) {
                     return true;
                 }
             }
@@ -489,7 +508,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             ScalpelConfiguration config,
             MavenSession session,
             Set<String> changedManagedPluginGAs,
-            Set<String> changedManagedDepGAs) {
+            Set<String> changedManagedDepGAs,
+            Map<MavenProject, DependencyResolutionResult> resolveCache) {
         if (config.getSkipTestsForDownstreamModules().isEmpty()) {
             return false;
         }
@@ -504,14 +524,19 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
             return false;
         }
-        if (!changedManagedDepGAs.isEmpty() && hasChangedTransitiveDependency(project, session, changedManagedDepGAs)) {
+        if (!changedManagedDepGAs.isEmpty()
+                && hasChangedTransitiveDependency(project, session, changedManagedDepGAs, resolveCache)) {
             return false;
         }
         return true;
     }
 
-    private boolean hasChangedTransitiveDependency(MavenProject project, MavenSession session, Set<String> changedGAs) {
-        return getChangedTransitiveDependencyScope(project, session, changedGAs) != null;
+    private boolean hasChangedTransitiveDependency(
+            MavenProject project,
+            MavenSession session,
+            Set<String> changedGAs,
+            Map<MavenProject, DependencyResolutionResult> resolveCache) {
+        return getChangedTransitiveDependencyScope(project, session, changedGAs, resolveCache) != null;
     }
 
     /**
@@ -520,11 +545,18 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
      * If all matching dependencies are test-scoped, returns "test".
      */
     private String getChangedTransitiveDependencyScope(
-            MavenProject project, MavenSession session, Set<String> changedGAs) {
+            MavenProject project,
+            MavenSession session,
+            Set<String> changedGAs,
+            Map<MavenProject, DependencyResolutionResult> resolveCache) {
         try {
-            DefaultDependencyResolutionRequest request =
-                    new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
-            DependencyResolutionResult result = dependenciesResolver.resolve(request);
+            DependencyResolutionResult result = resolveCache.get(project);
+            if (result == null) {
+                DefaultDependencyResolutionRequest request =
+                        new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
+                result = dependenciesResolver.resolve(request);
+                resolveCache.put(project, result);
+            }
 
             String narrowestScope = null;
             for (Dependency dep : result.getResolvedDependencies()) {
@@ -589,35 +621,22 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private void writeReport(
-            ScalpelConfiguration config,
-            Path reactorRoot,
-            Set<String> changedFiles,
-            Set<String> changedProperties,
-            Set<String> changedManagedDepGAs,
-            Set<String> changedManagedPluginGAs,
-            Set<MavenProject> directlyAffected,
-            Set<MavenProject> affectedBySource,
-            Set<MavenProject> testOnlyBySource,
-            Set<MavenProject> affectedByPom,
-            Set<MavenProject> forceIncluded,
-            Map<MavenProject, List<String>> transitivelyAffected,
-            TrimResult trimResult)
+    private void writeReport(ScalpelConfiguration config, Path reactorRoot, AnalysisContext ctx)
             throws MavenExecutionException {
         ScalpelReport.Builder builder = ScalpelReport.builder()
                 .baseBranch(config.getBaseBranch())
                 .fullBuildTriggered(false)
-                .changedFiles(changedFiles)
-                .changedProperties(changedProperties)
-                .changedManagedDependencies(changedManagedDepGAs)
-                .changedManagedPlugins(changedManagedPluginGAs);
+                .changedFiles(ctx.changedFiles)
+                .changedProperties(ctx.changedProperties)
+                .changedManagedDependencies(ctx.changedManagedDepGAs)
+                .changedManagedPlugins(ctx.changedManagedPluginGAs);
 
-        for (MavenProject project : directlyAffected) {
+        for (MavenProject project : ctx.directlyAffected) {
             String path = relativePath(reactorRoot, project);
             List<String> reasons = new ArrayList<>();
             String sourceSet = null;
-            if (affectedBySource.contains(project)) {
-                if (testOnlyBySource.contains(project)) {
+            if (ctx.affectedBySource.contains(project)) {
+                if (ctx.testOnlyBySource.contains(project)) {
                     reasons.add(ScalpelReport.REASON_TEST_CHANGE);
                     sourceSet = "test";
                 } else {
@@ -625,84 +644,85 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     sourceSet = "main";
                 }
             }
-            if (affectedByPom.contains(project)) {
+            if (ctx.affectedByPom.contains(project)) {
                 reasons.add(ScalpelReport.REASON_POM_CHANGE);
             }
-            if (forceIncluded.contains(project)) {
+            if (ctx.forceIncluded.contains(project)) {
                 reasons.add(ScalpelReport.REASON_FORCE_BUILD);
             }
-            builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                    project.getGroupId(),
-                    project.getArtifactId(),
-                    path,
-                    reasons,
-                    ScalpelReport.CATEGORY_DIRECT,
-                    sourceSet));
+            builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                            project.getGroupId(), project.getArtifactId(), path, reasons)
+                    .category(ScalpelReport.CATEGORY_DIRECT)
+                    .sourceSet(sourceSet)
+                    .build());
         }
 
-        for (Map.Entry<MavenProject, List<String>> entry : transitivelyAffected.entrySet()) {
+        for (Map.Entry<MavenProject, List<String>> entry : ctx.transitivelyAffected.entrySet()) {
             MavenProject project = entry.getKey();
             String path = relativePath(reactorRoot, project);
             String category = null;
-            if (trimResult != null) {
-                if (trimResult.getUpstreamOnly().contains(project)) {
+            if (ctx.trimResult != null) {
+                if (ctx.trimResult.getUpstreamOnly().contains(project)) {
                     category = ScalpelReport.CATEGORY_UPSTREAM;
-                } else if (trimResult.getDownstreamOnly().contains(project)
-                        || trimResult.getDownstreamTestOnly().contains(project)) {
+                } else if (ctx.trimResult.getDownstreamOnly().contains(project)
+                        || ctx.trimResult.getDownstreamTestOnly().contains(project)) {
                     category = ScalpelReport.CATEGORY_DOWNSTREAM;
                 }
             }
             // Transitively affected modules have additional reasons (plugin/dep changes),
             // so they are not "only DOWNSTREAM" — don't mark as excluded
-            builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                    project.getGroupId(), project.getArtifactId(), path, entry.getValue(), category));
+            builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                            project.getGroupId(), project.getArtifactId(), path, entry.getValue())
+                    .category(category)
+                    .build());
         }
 
         // Add upstream/downstream modules from trimResult that aren't already covered
-        if (trimResult != null) {
-            for (MavenProject project : trimResult.getUpstreamOnly()) {
-                if (!directlyAffected.contains(project) && !transitivelyAffected.containsKey(project)) {
+        if (ctx.trimResult != null) {
+            for (MavenProject project : ctx.trimResult.getUpstreamOnly()) {
+                if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
                     String path = relativePath(reactorRoot, project);
-                    builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                            project.getGroupId(),
-                            project.getArtifactId(),
-                            path,
-                            Collections.singletonList(ScalpelReport.REASON_UPSTREAM_DEPENDENCY),
-                            ScalpelReport.CATEGORY_UPSTREAM));
+                    builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                    project.getGroupId(),
+                                    project.getArtifactId(),
+                                    path,
+                                    Collections.singletonList(ScalpelReport.REASON_UPSTREAM_DEPENDENCY))
+                            .category(ScalpelReport.CATEGORY_UPSTREAM)
+                            .build());
                 }
             }
-            for (MavenProject project : trimResult.getDownstreamOnly()) {
-                if (!directlyAffected.contains(project) && !transitivelyAffected.containsKey(project)) {
+            for (MavenProject project : ctx.trimResult.getDownstreamOnly()) {
+                if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
                     String path = relativePath(reactorRoot, project);
                     String testsSkippedReason =
                             matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
                                     ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
                                     : null;
-                    builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                            project.getGroupId(),
-                            project.getArtifactId(),
-                            path,
-                            Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
-                            ScalpelReport.CATEGORY_DOWNSTREAM,
-                            null,
-                            testsSkippedReason));
+                    builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                    project.getGroupId(),
+                                    project.getArtifactId(),
+                                    path,
+                                    Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT))
+                            .category(ScalpelReport.CATEGORY_DOWNSTREAM)
+                            .testsSkippedReason(testsSkippedReason)
+                            .build());
                 }
             }
-            for (MavenProject project : trimResult.getDownstreamTestOnly()) {
-                if (!directlyAffected.contains(project) && !transitivelyAffected.containsKey(project)) {
+            for (MavenProject project : ctx.trimResult.getDownstreamTestOnly()) {
+                if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
                     String path = relativePath(reactorRoot, project);
                     String testsSkippedReason =
                             matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
                                     ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
                                     : null;
-                    builder.addAffectedModule(new ScalpelReport.AffectedModule(
-                            project.getGroupId(),
-                            project.getArtifactId(),
-                            path,
-                            Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_TEST),
-                            ScalpelReport.CATEGORY_DOWNSTREAM,
-                            null,
-                            testsSkippedReason));
+                    builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                    project.getGroupId(),
+                                    project.getArtifactId(),
+                                    path,
+                                    Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_TEST))
+                            .category(ScalpelReport.CATEGORY_DOWNSTREAM)
+                            .testsSkippedReason(testsSkippedReason)
+                            .build());
                 }
             }
         }
@@ -726,7 +746,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private void applyPerCategoryArgs(TrimResult trimResult, ScalpelConfiguration config) {
         for (String arg : config.getUpstreamArgs()) {
-            String[] parts = arg.trim().split("=", 2);
+            String[] parts = arg.split("=", 2);
             if (parts.length == 2) {
                 for (MavenProject project : trimResult.getUpstreamOnly()) {
                     project.getProperties().setProperty(parts[0], parts[1]);
@@ -736,7 +756,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
         }
         for (String arg : config.getDownstreamArgs()) {
-            String[] parts = arg.trim().split("=", 2);
+            String[] parts = arg.split("=", 2);
             if (parts.length == 2) {
                 for (MavenProject project : trimResult.getDownstreamOnly()) {
                     project.getProperties().setProperty(parts[0], parts[1]);
@@ -754,17 +774,5 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         for (MavenProject project : projects) {
             project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
         }
-    }
-
-    private static String key(MavenProject project) {
-        return project.getGroupId() + ":" + project.getArtifactId();
-    }
-
-    private static List<String> projectKeys(Iterable<MavenProject> projects) {
-        List<String> keys = new ArrayList<>();
-        for (MavenProject project : projects) {
-            keys.add(key(project));
-        }
-        return keys;
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -524,11 +524,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
             return false;
         }
-        if (!changedManagedDepGAs.isEmpty()
-                && hasChangedTransitiveDependency(project, session, changedManagedDepGAs, resolveCache)) {
-            return false;
-        }
-        return true;
+        return changedManagedDepGAs.isEmpty()
+                || !hasChangedTransitiveDependency(project, session, changedManagedDepGAs, resolveCache);
     }
 
     private boolean hasChangedTransitiveDependency(
@@ -631,6 +628,20 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .changedManagedDependencies(ctx.changedManagedDepGAs)
                 .changedManagedPlugins(ctx.changedManagedPluginGAs);
 
+        addDirectlyAffectedModules(builder, ctx, reactorRoot);
+        addTransitivelyAffectedModules(builder, ctx, reactorRoot);
+        addTrimResultModules(builder, ctx, config, reactorRoot);
+
+        try {
+            ScalpelReport report = builder.build();
+            report.writeToFile(reactorRoot, config.getReportFile());
+            logger.info("Scalpel: Report written to {}", config.getReportFile());
+        } catch (IOException e) {
+            throw new MavenExecutionException("Scalpel: Failed to write report", e);
+        }
+    }
+
+    private void addDirectlyAffectedModules(ScalpelReport.Builder builder, AnalysisContext ctx, Path reactorRoot) {
         for (MavenProject project : ctx.directlyAffected) {
             String path = relativePath(reactorRoot, project);
             List<String> reasons = new ArrayList<>();
@@ -656,7 +667,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     .sourceSet(sourceSet)
                     .build());
         }
+    }
 
+    private void addTransitivelyAffectedModules(ScalpelReport.Builder builder, AnalysisContext ctx, Path reactorRoot) {
         for (Map.Entry<MavenProject, List<String>> entry : ctx.transitivelyAffected.entrySet()) {
             MavenProject project = entry.getKey();
             String path = relativePath(reactorRoot, project);
@@ -669,70 +682,66 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     category = ScalpelReport.CATEGORY_DOWNSTREAM;
                 }
             }
-            // Transitively affected modules have additional reasons (plugin/dep changes),
-            // so they are not "only DOWNSTREAM" — don't mark as excluded
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, entry.getValue())
                     .category(category)
                     .build());
         }
+    }
 
-        // Add upstream/downstream modules from trimResult that aren't already covered
-        if (ctx.trimResult != null) {
-            for (MavenProject project : ctx.trimResult.getUpstreamOnly()) {
-                if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
-                    String path = relativePath(reactorRoot, project);
-                    builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                                    project.getGroupId(),
-                                    project.getArtifactId(),
-                                    path,
-                                    Collections.singletonList(ScalpelReport.REASON_UPSTREAM_DEPENDENCY))
-                            .category(ScalpelReport.CATEGORY_UPSTREAM)
-                            .build());
-                }
-            }
-            for (MavenProject project : ctx.trimResult.getDownstreamOnly()) {
-                if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
-                    String path = relativePath(reactorRoot, project);
-                    String testsSkippedReason =
-                            matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
-                                    ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
-                                    : null;
-                    builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                                    project.getGroupId(),
-                                    project.getArtifactId(),
-                                    path,
-                                    Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT))
-                            .category(ScalpelReport.CATEGORY_DOWNSTREAM)
-                            .testsSkippedReason(testsSkippedReason)
-                            .build());
-                }
-            }
-            for (MavenProject project : ctx.trimResult.getDownstreamTestOnly()) {
-                if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
-                    String path = relativePath(reactorRoot, project);
-                    String testsSkippedReason =
-                            matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
-                                    ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
-                                    : null;
-                    builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                                    project.getGroupId(),
-                                    project.getArtifactId(),
-                                    path,
-                                    Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_TEST))
-                            .category(ScalpelReport.CATEGORY_DOWNSTREAM)
-                            .testsSkippedReason(testsSkippedReason)
-                            .build());
-                }
+    private void addTrimResultModules(
+            ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
+        if (ctx.trimResult == null) {
+            return;
+        }
+        for (MavenProject project : ctx.trimResult.getUpstreamOnly()) {
+            if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
+                String path = relativePath(reactorRoot, project);
+                builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                project.getGroupId(),
+                                project.getArtifactId(),
+                                path,
+                                Collections.singletonList(ScalpelReport.REASON_UPSTREAM_DEPENDENCY))
+                        .category(ScalpelReport.CATEGORY_UPSTREAM)
+                        .build());
             }
         }
+        addDownstreamModules(
+                builder,
+                ctx,
+                config,
+                reactorRoot,
+                ctx.trimResult.getDownstreamOnly(),
+                ScalpelReport.REASON_DOWNSTREAM_DEPENDENT);
+        addDownstreamModules(
+                builder,
+                ctx,
+                config,
+                reactorRoot,
+                ctx.trimResult.getDownstreamTestOnly(),
+                ScalpelReport.REASON_DOWNSTREAM_TEST);
+    }
 
-        try {
-            ScalpelReport report = builder.build();
-            report.writeToFile(reactorRoot, config.getReportFile());
-            logger.info("Scalpel: Report written to {}", config.getReportFile());
-        } catch (IOException e) {
-            throw new MavenExecutionException("Scalpel: Failed to write report", e);
+    private void addDownstreamModules(
+            ScalpelReport.Builder builder,
+            AnalysisContext ctx,
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            Set<MavenProject> downstreamProjects,
+            String reason) {
+        for (MavenProject project : downstreamProjects) {
+            if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
+                String path = relativePath(reactorRoot, project);
+                String testsSkippedReason =
+                        matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
+                                ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
+                                : null;
+                builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                project.getGroupId(), project.getArtifactId(), path, Collections.singletonList(reason))
+                        .category(ScalpelReport.CATEGORY_DOWNSTREAM)
+                        .testsSkippedReason(testsSkippedReason)
+                        .build());
+            }
         }
     }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -219,11 +220,18 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         continue;
                     }
                     for (String pattern : config.getForceBuildModules()) {
-                        if (project.getArtifactId().matches(pattern)) {
-                            directlyAffected.add(project);
-                            forceIncluded.add(project);
-                            logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
-                            break;
+                        try {
+                            if (project.getArtifactId().matches(pattern)) {
+                                directlyAffected.add(project);
+                                forceIncluded.add(project);
+                                logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
+                                break;
+                            }
+                        } catch (PatternSyntaxException e) {
+                            logger.warn(
+                                    "Scalpel: Invalid regex pattern '{}' in forceBuildModules: {}",
+                                    pattern,
+                                    e.getMessage());
                         }
                     }
                 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -18,7 +18,9 @@ import eu.maveniverse.maven.scalpel.core.ScalpelException;
 import eu.maveniverse.maven.scalpel.core.ScalpelReport;
 import eu.maveniverse.maven.scalpel.core.Version;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
@@ -597,12 +599,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
         Path logPath = reactorRoot.resolve(impactedLog);
         try {
-            java.nio.file.Files.createDirectories(logPath.getParent());
+            Files.createDirectories(logPath.getParent());
             List<String> lines = new ArrayList<>();
             for (MavenProject project : affectedModules) {
                 lines.add(relativePath(reactorRoot, project));
             }
-            java.nio.file.Files.write(logPath, lines, java.nio.charset.StandardCharsets.UTF_8);
+            Files.write(logPath, lines, StandardCharsets.UTF_8);
             logger.info("Scalpel: Impacted modules written to {}", config.getImpactedLog());
         } catch (IOException e) {
             throw new MavenExecutionException("Scalpel: Failed to write impacted log", e);

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -221,20 +221,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     if (directlyAffected.contains(project)) {
                         continue;
                     }
-                    for (String pattern : config.getForceBuildModules()) {
-                        try {
-                            if (project.getArtifactId().matches(pattern)) {
-                                directlyAffected.add(project);
-                                forceIncluded.add(project);
-                                logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
-                                break;
-                            }
-                        } catch (PatternSyntaxException e) {
-                            logger.warn(
-                                    "Scalpel: Invalid regex pattern '{}' in forceBuildModules: {}",
-                                    pattern,
-                                    e.getMessage());
-                        }
+                    if (matchesForceBuild(project, config.getForceBuildModules())) {
+                        directlyAffected.add(project);
+                        forceIncluded.add(project);
                     }
                 }
             }
@@ -274,18 +263,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 writeReport(
                         config,
                         reactorRoot,
-                        new AnalysisContext(
-                                changedFiles,
-                                changedProperties,
-                                changedManagedDepGAs,
-                                changedManagedPluginGAs,
-                                directlyAffected,
-                                affectedBySource,
-                                sourceResult.getTestOnlyAffected(),
-                                affectedByPom,
-                                forceIncluded,
-                                transitivelyAffected,
-                                trimResult));
+                        AnalysisContext.builder(
+                                        changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
+                                .directlyAffected(directlyAffected)
+                                .affectedBySource(affectedBySource)
+                                .testOnlyBySource(sourceResult.getTestOnlyAffected())
+                                .affectedByPom(affectedByPom)
+                                .forceIncluded(forceIncluded)
+                                .transitivelyAffected(transitivelyAffected)
+                                .trimResult(trimResult)
+                                .build());
                 return;
             }
 
@@ -382,21 +369,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (directlyAffected.contains(project)) {
                 continue;
             }
-            List<String> reasons = new ArrayList<>();
-            if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
-                reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
-            }
-            if (!changedManagedDepGAs.isEmpty()) {
-                String depScope =
-                        getChangedTransitiveDependencyScope(project, session, changedManagedDepGAs, resolveCache);
-                if (depScope != null) {
-                    if ("test".equals(depScope)) {
-                        reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
-                    } else {
-                        reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
-                    }
-                }
-            }
+            List<String> reasons = computeTransitiveReasons(
+                    project, changedManagedDepGAs, changedManagedPluginGAs, session, resolveCache);
             if (!reasons.isEmpty()) {
                 transitivelyAffected.put(project, reasons);
             }
@@ -408,6 +382,29 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     keys(transitivelyAffected.keySet()));
         }
         return transitivelyAffected;
+    }
+
+    private List<String> computeTransitiveReasons(
+            MavenProject project,
+            Set<String> changedManagedDepGAs,
+            Set<String> changedManagedPluginGAs,
+            MavenSession session,
+            Map<MavenProject, DependencyResolutionResult> resolveCache) {
+        List<String> reasons = new ArrayList<>();
+        if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
+            reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
+        }
+        if (!changedManagedDepGAs.isEmpty()) {
+            String depScope = getChangedTransitiveDependencyScope(project, session, changedManagedDepGAs, resolveCache);
+            if (depScope != null) {
+                if ("test".equals(depScope)) {
+                    reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
+                } else {
+                    reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+                }
+            }
+        }
+        return reasons;
     }
 
     private void applySkipTests(
@@ -787,6 +784,20 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 logger.warn("Scalpel: Malformed downstreamArgs entry '{}', expected key=value format", arg);
             }
         }
+    }
+
+    private boolean matchesForceBuild(MavenProject project, List<String> patterns) {
+        for (String pattern : patterns) {
+            try {
+                if (project.getArtifactId().matches(pattern)) {
+                    logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
+                    return true;
+                }
+            } catch (PatternSyntaxException e) {
+                logger.warn("Scalpel: Invalid regex pattern '{}' in forceBuildModules: {}", pattern, e.getMessage());
+            }
+        }
+        return false;
     }
 
     private void skipTestsOnAll(List<MavenProject> projects) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
@@ -7,7 +7,9 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.maven.project.MavenProject;
@@ -39,11 +41,11 @@ final class TrimResult {
             Set<MavenProject> upstreamOnly,
             Set<MavenProject> downstreamOnly,
             Set<MavenProject> downstreamTestOnly) {
-        this.buildSet = buildSet;
-        this.directlyAffected = directlyAffected;
-        this.upstreamOnly = upstreamOnly;
-        this.downstreamOnly = downstreamOnly;
-        this.downstreamTestOnly = downstreamTestOnly;
+        this.buildSet = Collections.unmodifiableList(new ArrayList<>(buildSet));
+        this.directlyAffected = Collections.unmodifiableSet(new LinkedHashSet<>(directlyAffected));
+        this.upstreamOnly = Collections.unmodifiableSet(new LinkedHashSet<>(upstreamOnly));
+        this.downstreamOnly = Collections.unmodifiableSet(new LinkedHashSet<>(downstreamOnly));
+        this.downstreamTestOnly = Collections.unmodifiableSet(new LinkedHashSet<>(downstreamTestOnly));
     }
 
     List<MavenProject> getBuildSet() {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 
 import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
 import eu.maveniverse.maven.scalpel.core.ScalpelCore;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -38,6 +39,7 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.DefaultDependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
@@ -47,6 +49,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 class ScalpelLifecycleParticipantTest {
 
@@ -668,7 +671,7 @@ class ScalpelLifecycleParticipantTest {
         participant.afterProjectsRead(session);
 
         @SuppressWarnings("unchecked")
-        org.mockito.ArgumentCaptor<List<MavenProject>> captor = org.mockito.ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<MavenProject>> captor = ArgumentCaptor.forClass(List.class);
         verify(session).setProjects(captor.capture());
         List<MavenProject> trimmed = captor.getValue();
         assertTrue(trimmed.contains(moduleA), "module-a should be in trimmed reactor");
@@ -1598,8 +1601,7 @@ class ScalpelLifecycleParticipantTest {
 
     private Model parseModel(String xml) {
         try {
-            return new org.apache.maven.model.io.xpp3.MavenXpp3Reader()
-                    .read(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            return new MavenXpp3Reader().read(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse POM XML: " + xml.substring(0, Math.min(xml.length(), 100)), e);
         }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1332,6 +1332,156 @@ class ScalpelLifecycleParticipantTest {
                 "module-b should NOT have tests skipped (uses changed managed plugin, safety guard)");
     }
 
+    @Test
+    void reportMode_forceBuildModulesIncludesMatchingModule() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // Only module-a has a source change
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        // Force module-b to be included even though it has no changes
+        session.getSystemProperties().setProperty("scalpel.forceBuildModules", "module-b");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(modulePresent(json, "module-a"), "module-a should be in report");
+        assertTrue(modulePresent(json, "module-b"), "module-b should be force-included");
+        assertTrue(moduleHasReason(json, "module-b", "FORCE_BUILD"), "module-b should have FORCE_BUILD reason");
+    }
+
+    @Test
+    void reportMode_excludePathsFiltersChanges() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        // Changes include an excluded path and a module source
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("README.md");
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "*.md");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        // module-a should still be affected (its source file is not excluded)
+        assertTrue(modulePresent(json, "module-a"));
+        // README.md should be filtered from changedFiles
+        assertFalse(json.contains("README.md"), "README.md should be excluded from changed files");
+    }
+
+    @Test
+    void reportMode_disableTriggerCausesFullBuild() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // A CI config file changed, matching the disable trigger
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add(".github/workflows/ci.yml");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.fullBuildTriggers", ".github/**");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"fullBuildTriggered\": true"), "Full build should be triggered");
+    }
+
+    @Test
+    void reportMode_nullDetectionResultSkipsProcessing() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        // Null detection result (e.g., no git repo or no base branch)
+        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        // No report should be written when detection returns null
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile), "Report file should not be created when detection returns null");
+    }
+
     // --- Helper methods ---
 
     private void setupEmptyDependencyResolution() throws Exception {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1485,6 +1485,567 @@ class ScalpelLifecycleParticipantTest {
         assertFalse(Files.exists(reportFile), "Report file should not be created when detection returns null");
     }
 
+    @Test
+    void disabled_doesNothing() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.enabled", "false");
+
+        participant.afterProjectsRead(session);
+
+        // No report, no trimming, no test skipping
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile), "No report should be created when disabled");
+    }
+
+    @Test
+    void disableOnSelectedProjects_withPlActive() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.disableOnSelectedProjects", "true");
+
+        // Simulate -pl by setting selected projects
+        when(session.getRequest().getSelectedProjects()).thenReturn(Collections.singletonList("module-a"));
+
+        participant.afterProjectsRead(session);
+
+        // Should not process — no report, no trimming
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile));
+    }
+
+    @Test
+    void noChanges_withBuildAllIfNoChanges() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        // No changed files
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(new LinkedHashSet<String>(), new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.buildAllIfNoChanges", "true");
+
+        participant.afterProjectsRead(session);
+
+        // Should return early, building all (no trimming applied)
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile));
+    }
+
+    @Test
+    void allFilesExcludedByPathFilters_buildsAll() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        // Only .md files changed
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("README.md");
+        changedFiles.add("CHANGELOG.md");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "*.md");
+
+        participant.afterProjectsRead(session);
+
+        // All files excluded → builds all modules (no trimming)
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile));
+    }
+
+    @Test
+    void fullBuildTrigger_inTrimMode_doesNotTrim() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add(".github/workflows/ci.yml");
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.fullBuildTriggers", ".github/**");
+
+        participant.afterProjectsRead(session);
+
+        // In trim mode, full build trigger means no trimming (no setProjects called)
+        // No report file should be created (not report mode)
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile));
+    }
+
+    @Test
+    void pomAnalysisError_failSafeTrue_buildsAll() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        // Provide invalid old POM content to trigger a parse error
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", "<<<INVALID XML>>>".getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.failSafe", "true");
+
+        participant.afterProjectsRead(session);
+
+        // failSafe=true → should not throw, just return (build all)
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile));
+    }
+
+    @Test
+    void noModulesAffected_skipTestsMode_skipsAllTests() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // Change a file that doesn't map to any module (e.g. root-level non-pom file)
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add(".gitignore");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+
+        participant.afterProjectsRead(session);
+
+        // All modules should have tests skipped when no modules are affected
+        assertEquals(
+                "true",
+                moduleA.getProperties().getProperty("maven.test.skip"),
+                "module-a should have tests skipped (no modules affected)");
+        assertEquals(
+                "true",
+                moduleB.getProperties().getProperty("maven.test.skip"),
+                "module-b should have tests skipped (no modules affected)");
+    }
+
+    @Test
+    void impactedLog_writesAffectedModulePaths() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.impactedLog", "target/scalpel-impacted.log");
+
+        participant.afterProjectsRead(session);
+
+        Path logFile = root.resolve("target/scalpel-impacted.log");
+        assertTrue(Files.exists(logFile), "Impacted log file should be created");
+        String content = new String(java.nio.file.Files.readAllBytes(logFile), StandardCharsets.UTF_8);
+        assertTrue(content.contains("module-a"), "Impacted log should contain module-a");
+    }
+
+    @Test
+    void skipTestsMode_skipTestsForUpstream_skipsUpstreamTests() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // module-b has source changes, module-a is upstream
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-b/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForUpstream", "true");
+        session.getSystemProperties().setProperty("scalpel.alsoMake", "true");
+
+        // Graph: module-a is upstream of module-b
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(Collections.singletonList(moduleA));
+        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        // module-a (upstream) should have tests skipped
+        assertEquals(
+                "true",
+                moduleA.getProperties().getProperty("maven.test.skip"),
+                "module-a (upstream) should have tests skipped");
+        // module-b (directly affected) should NOT have tests skipped
+        assertNotEquals(
+                "true",
+                moduleB.getProperties().getProperty("maven.test.skip"),
+                "module-b (directly affected) should run tests");
+    }
+
+    @Test
+    void trimMode_applyPerCategoryArgs() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b", "module-c");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+        String moduleCPom = simpleChildPom("module-c");
+        writePom(root, "module-c/pom.xml", moduleCPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
+        moduleC.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB, moduleC);
+
+        // module-b has source changes
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-b/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.alsoMake", "true");
+        session.getSystemProperties().setProperty("scalpel.alsoMakeDependents", "true");
+        session.getSystemProperties().setProperty("scalpel.upstreamArgs", "skipITs=true");
+        session.getSystemProperties().setProperty("scalpel.downstreamArgs", "quick=true");
+
+        // Graph: module-a is upstream of module-b, module-c is downstream of module-b
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(Collections.singletonList(moduleA));
+        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(moduleC, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.singletonList(moduleC));
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(moduleC, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        // module-a (upstream) should have upstream args applied
+        assertEquals(
+                "true", moduleA.getProperties().getProperty("skipITs"), "module-a (upstream) should have skipITs=true");
+        // module-c (downstream) should have downstream args applied
+        assertEquals(
+                "true", moduleC.getProperties().getProperty("quick"), "module-c (downstream) should have quick=true");
+        // module-b (directly affected) should NOT have either arg
+        assertNotEquals(
+                "true", moduleB.getProperties().getProperty("skipITs"), "module-b should not have upstream args");
+    }
+
+    @Test
+    void skipTestsMode_changedManagedPluginOnNonBuildsetModule_runsTests() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String oldParentPom = "<?xml version=\"1.0\"?>\n"
+                + "<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>com.example</groupId>\n"
+                + "  <artifactId>parent</artifactId>\n"
+                + "  <version>1.0</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
+                + "  <properties><compiler.version>3.11.0</compiler.version></properties>\n"
+                + "  <build><pluginManagement><plugins>\n"
+                + "    <plugin><groupId>org.apache.maven.plugins</groupId>"
+                + "<artifactId>maven-compiler-plugin</artifactId>"
+                + "<version>${compiler.version}</version></plugin>\n"
+                + "  </plugins></pluginManagement></build>\n"
+                + "</project>\n";
+        String newParentPom = oldParentPom.replace(
+                "<compiler.version>3.11.0</compiler.version>", "<compiler.version>3.12.0</compiler.version>");
+        writePom(root, "pom.xml", newParentPom);
+
+        // module-a: no source change, no direct POM change, but uses the changed plugin
+        String moduleAPom = "<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
+                + "  <artifactId>module-a</artifactId>\n"
+                + "  <build><plugins><plugin><groupId>org.apache.maven.plugins</groupId>"
+                + "<artifactId>maven-compiler-plugin</artifactId></plugin></plugins></build>\n</project>\n";
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        // module-b: no involvement at all
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        Build parentBuild = new Build();
+        parentProject.getModel().setBuild(parentBuild);
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        // module-a uses maven-compiler-plugin
+        Build buildA = new Build();
+        Plugin compilerPlugin = new Plugin();
+        compilerPlugin.setGroupId("org.apache.maven.plugins");
+        compilerPlugin.setArtifactId("maven-compiler-plugin");
+        buildA.addPlugin(compilerPlugin);
+        moduleA.getModel().setBuild(buildA);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // Only parent POM changed
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+
+        participant.afterProjectsRead(session);
+
+        // module-a uses the changed managed plugin — tests should NOT be skipped
+        assertNotEquals(
+                "true",
+                moduleA.getProperties().getProperty("maven.test.skip"),
+                "module-a should run tests (uses changed managed plugin)");
+        // module-b has no involvement — tests should be skipped
+        assertEquals(
+                "true", moduleB.getProperties().getProperty("maven.test.skip"), "module-b should have tests skipped");
+    }
+
+    @Test
+    void disableTrigger_inTrimMode_doesNotTrimOrReport() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("Jenkinsfile");
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.disableTriggers", "Jenkinsfile");
+
+        participant.afterProjectsRead(session);
+
+        // Disable trigger matched → scalpel bails out entirely (no trimming)
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile));
+    }
+
+    @Test
+    void reportMode_upstreamModulesInReport() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+
+        // module-b has source changes, module-a is upstream
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-b/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.alsoMake", "true");
+
+        // Graph: module-a is upstream of module-b
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(Collections.singletonList(moduleA));
+        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(java.nio.file.Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(moduleHasReason(json, "module-b", "SOURCE_CHANGE"), "module-b should have SOURCE_CHANGE");
+        assertTrue(
+                moduleHasReason(json, "module-a", "UPSTREAM_DEPENDENCY"),
+                "module-a should have UPSTREAM_DEPENDENCY reason in report");
+        assertTrue(moduleHasField(json, "module-a", "category", "UPSTREAM"), "module-a should have UPSTREAM category");
+    }
+
     // --- Helper methods ---
 
     private void setupEmptyDependencyResolution() throws Exception {


### PR DESCRIPTION
## Summary

- **Defensive coding fixes**: copy `changedFiles` before mutation, catch `PatternSyntaxException` in regex branch matching, restore Java 8-compatible `try/finally` for `Repository` close
- **Reduce duplication & improve efficiency**: consolidate two git status calls into `getStatusFiles()`, extract shared `Projects.key()`/`keys()` utility, cache dependency resolution results, use `HashSet` for O(1) parent lookup
- **Structural improvements**: decompose `afterProjectsRead()` into focused helpers (`matchesDisableTrigger`, `filterExcludedPaths`, `findFullBuildTrigger`, `computeTransitivelyAffected`), introduce `AnalysisContext` to reduce `writeReport()` from 13 to 3 params, add `AffectedModule.ModuleBuilder` to eliminate null placeholders in telescoping constructors
- **Hardening**: validate mode in `ScalpelConfiguration`, trim whitespace in `parseList()` entries, classifier-aware dependency keys in POM comparison, defensive copies in `TrimResult`, skip files >1MB in `scanDirectoryForPropertyRefs`

## Test plan

- [x] All 115 existing tests pass (22 in core, 93 in extension3)
- [x] Build succeeds with `mvn install -B`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mode validation and safer regex handling; unified git status checks to reduce duplicate queries and simplify error handling.

* **Performance**
  * Skip very large resource files during scanning; reduced redundant dependency resolution via per-run caching.

* **Improvements**
  * Trimmed/normalized list parsing and immutable collection returns; report modules support a fluent builder; consolidated analysis context and project-key helpers.

* **Tests**
  * Expanded tests for configuration modes, report generation, core change detection, and builder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->