### PR TITLE
Use JDK 21 for test compilation and modernize test code

### DIFF
--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -13,8 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
@@ -173,7 +171,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.disableOnBranch", "main,release/.*");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList("main", "release/.*"), config.getDisableOnBranch());
+        assertEquals(List.of("main", "release/.*"), config.getDisableOnBranch());
     }
 
     @Test
@@ -181,7 +179,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.disableOnBranch", "main");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Collections.singletonList("main"), config.getDisableOnBranch());
+        assertEquals(List.of("main"), config.getDisableOnBranch());
     }
 
     @Test
@@ -189,7 +187,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.disableOnBaseBranch", "main,develop");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList("main", "develop"), config.getDisableOnBaseBranch());
+        assertEquals(List.of("main", "develop"), config.getDisableOnBaseBranch());
     }
 
     @Test
@@ -197,7 +195,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.excludePaths", "*.md,LICENSE,.editorconfig");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList("*.md", "LICENSE", ".editorconfig"), config.getExcludePaths());
+        assertEquals(List.of("*.md", "LICENSE", ".editorconfig"), config.getExcludePaths());
     }
 
     @Test
@@ -205,7 +203,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.disableTriggers", ".github/**,Jenkinsfile");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList(".github/**", "Jenkinsfile"), config.getDisableTriggers());
+        assertEquals(List.of(".github/**", "Jenkinsfile"), config.getDisableTriggers());
     }
 
     @Test
@@ -213,7 +211,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.upstreamArgs", "skipITs=true,someKey=val");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList("skipITs=true", "someKey=val"), config.getUpstreamArgs());
+        assertEquals(List.of("skipITs=true", "someKey=val"), config.getUpstreamArgs());
     }
 
     @Test
@@ -221,7 +219,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.downstreamArgs", "skipITs=true");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Collections.singletonList("skipITs=true"), config.getDownstreamArgs());
+        assertEquals(List.of("skipITs=true"), config.getDownstreamArgs());
     }
 
     @Test
@@ -229,7 +227,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.forceBuildModules", ".*-it,.*-tests");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList(".*-it", ".*-tests"), config.getForceBuildModules());
+        assertEquals(List.of(".*-it", ".*-tests"), config.getForceBuildModules());
     }
 
     @Test
@@ -249,7 +247,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList("module-b"), config.getSkipTestsForDownstreamModules());
+        assertEquals(List.of("module-b"), config.getSkipTestsForDownstreamModules());
     }
 
     @Test
@@ -257,7 +255,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.skipTestsForDownstreamModules", "module-b,module-c");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList("module-b", "module-c"), config.getSkipTestsForDownstreamModules());
+        assertEquals(List.of("module-b", "module-c"), config.getSkipTestsForDownstreamModules());
     }
 
     @Test
@@ -265,7 +263,7 @@ class ScalpelConfigurationTest {
         Properties sys = new Properties();
         sys.setProperty("scalpel.skipTestsForDownstreamModules", "com.example:module-b");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
-        assertEquals(Arrays.asList("com.example:module-b"), config.getSkipTestsForDownstreamModules());
+        assertEquals(List.of("com.example:module-b"), config.getSkipTestsForDownstreamModules());
     }
 
     @Test
@@ -274,7 +272,7 @@ class ScalpelConfigurationTest {
         Properties user = new Properties();
         user.setProperty("scalpel.skipTestsForDownstreamModules", "module-x");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, user);
-        assertEquals(Arrays.asList("module-x"), config.getSkipTestsForDownstreamModules());
+        assertEquals(List.of("module-x"), config.getSkipTestsForDownstreamModules());
     }
 
     @Test
@@ -308,7 +306,7 @@ class ScalpelConfigurationTest {
         Properties user = new Properties();
         user.setProperty("scalpel.disableOnBranch", "develop");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, user);
-        assertEquals(Collections.singletonList("main"), config.getDisableOnBranch());
+        assertEquals(List.of("main"), config.getDisableOnBranch());
     }
 
     @Test

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.Properties;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
@@ -48,7 +47,7 @@ class ScalpelCoreTest {
             sys.setProperty("scalpel.baseBranch", "main");
             ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
 
-            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
 
             assertNotNull(result);
             assertTrue(result.getChangedFiles().contains("new-file.txt"));
@@ -72,7 +71,7 @@ class ScalpelCoreTest {
             sys.setProperty("scalpel.uncommitted", "true");
             ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
 
-            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
 
             assertNotNull(result);
             assertTrue(result.getChangedFiles().contains("file.txt"), "uncommitted change should be detected");
@@ -96,7 +95,7 @@ class ScalpelCoreTest {
             sys.setProperty("scalpel.untracked", "true");
             ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
 
-            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
 
             assertNotNull(result);
             assertTrue(result.getChangedFiles().contains("untracked.txt"), "untracked file should be detected");
@@ -123,7 +122,7 @@ class ScalpelCoreTest {
             ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
 
             // Should not throw, just log a warning and continue
-            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
 
             assertNotNull(result);
         }
@@ -145,7 +144,7 @@ class ScalpelCoreTest {
             sys.setProperty("scalpel.disableOnBranch", currentBranch);
             ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
 
-            ChangeDetectionResult result = core.detectChanges(tempDir, config, Collections.<String>emptySet());
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
 
             assertNull(result, "Should return null when current branch matches disableOnBranch");
         }
@@ -162,7 +161,7 @@ class ScalpelCoreTest {
         sys.setProperty("scalpel.baseBranch", "main");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
 
-        ChangeDetectionResult result = core.detectChanges(nonGitDir, config, Collections.<String>emptySet());
+        ChangeDetectionResult result = core.detectChanges(nonGitDir, config, Set.of());
 
         assertNull(result, "Should return null for non-git directory");
     }
@@ -188,7 +187,7 @@ class ScalpelCoreTest {
             sys.setProperty("scalpel.baseBranch", "main");
             ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
 
-            Set<String> pomPaths = Collections.singleton("pom.xml");
+            Set<String> pomPaths = Set.of("pom.xml");
             ChangeDetectionResult result = core.detectChanges(tempDir, config, pomPaths);
 
             assertNotNull(result);

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -16,8 +16,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -31,12 +31,9 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .changedFiles(Set.of("module-a/src/Foo.java"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
-                        "com.example",
-                        "module-a",
-                        "module-a",
-                        Collections.singletonList(ScalpelReport.REASON_SOURCE_CHANGE)))
+                        "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE)))
                 .build();
 
         String json = report.toJson();
@@ -50,18 +47,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("pom.xml"))
-                .changedManagedDependencies(Collections.singleton("org.apache.kafka:kafka-clients"))
+                .changedFiles(Set.of("pom.xml"))
+                .changedManagedDependencies(Set.of("org.apache.kafka:kafka-clients"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
-                        "com.example",
-                        "module-a",
-                        "module-a",
-                        Collections.singletonList(ScalpelReport.REASON_POM_CHANGE)))
+                        "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_POM_CHANGE)))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
-                        "com.example",
-                        "module-b",
-                        "module-b",
-                        Collections.singletonList(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
+                        "com.example", "module-b", "module-b", List.of(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
                 .build();
 
         String json = report.toJson();
@@ -77,13 +68,10 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("pom.xml"))
-                .changedManagedPlugins(Collections.singleton("org.apache.maven.plugins:maven-compiler-plugin"))
+                .changedFiles(Set.of("pom.xml"))
+                .changedManagedPlugins(Set.of("org.apache.maven.plugins:maven-compiler-plugin"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
-                        "com.example",
-                        "module-a",
-                        "module-a",
-                        Collections.singletonList(ScalpelReport.REASON_MANAGED_PLUGIN)))
+                        "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_MANAGED_PLUGIN)))
                 .build();
 
         String json = report.toJson();
@@ -96,12 +84,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("pom.xml"))
+                .changedFiles(Set.of("pom.xml"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
                         "com.example",
                         "module-a",
                         "module-a",
-                        Arrays.asList(ScalpelReport.REASON_MANAGED_PLUGIN, ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
+                        List.of(ScalpelReport.REASON_MANAGED_PLUGIN, ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
                 .build();
 
         String json = report.toJson();
@@ -115,7 +103,7 @@ class ScalpelReportTest {
                 .baseBranch("origin/main")
                 .fullBuildTriggered(true)
                 .triggerFile(".mvn/extensions.xml")
-                .changedFiles(Collections.singleton(".mvn/extensions.xml"))
+                .changedFiles(Set.of(".mvn/extensions.xml"))
                 .build();
 
         String json = report.toJson();
@@ -143,13 +131,10 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("pom.xml"))
-                .changedManagedDependencies(Collections.singleton("commons-lang:commons-lang"))
+                .changedFiles(Set.of("pom.xml"))
+                .changedManagedDependencies(Set.of("commons-lang:commons-lang"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
-                        "com.example",
-                        "module-b",
-                        "module-b",
-                        Collections.singletonList(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
+                        "com.example", "module-b", "module-b", List.of(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY)))
                 .build();
 
         report.writeToFile(tempDir, "target/scalpel-report.json");
@@ -165,12 +150,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/test/java/FooTest.java"))
+                .changedFiles(Set.of("module-a/src/test/java/FooTest.java"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
                         "com.example",
                         "module-a",
                         "module-a",
-                        Collections.singletonList(ScalpelReport.REASON_TEST_CHANGE),
+                        List.of(ScalpelReport.REASON_TEST_CHANGE),
                         ScalpelReport.CATEGORY_DIRECT,
                         "test"))
                 .build();
@@ -186,12 +171,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/main/java/Foo.java"))
+                .changedFiles(Set.of("module-a/src/main/java/Foo.java"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
                         "com.example",
                         "module-a",
                         "module-a",
-                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
                         ScalpelReport.CATEGORY_DOWNSTREAM))
                 .build();
 
@@ -204,12 +189,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/main/java/Foo.java"))
+                .changedFiles(Set.of("module-a/src/main/java/Foo.java"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
                         "com.example",
                         "module-a",
                         "module-a",
-                        Collections.singletonList(ScalpelReport.REASON_SOURCE_CHANGE),
+                        List.of(ScalpelReport.REASON_SOURCE_CHANGE),
                         ScalpelReport.CATEGORY_DIRECT,
                         "main"))
                 .build();
@@ -224,12 +209,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .changedFiles(Set.of("module-a/src/Foo.java"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
                         "com.example",
                         "module-b",
                         "module-b",
-                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
                         ScalpelReport.CATEGORY_DOWNSTREAM,
                         null,
                         ScalpelReport.REASON_EXCLUDED_DOWNSTREAM))
@@ -245,12 +230,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .changedFiles(Set.of("module-a/src/Foo.java"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
                         "com.example",
                         "module-b",
                         "module-b",
-                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
                         ScalpelReport.CATEGORY_DOWNSTREAM))
                 .build();
 
@@ -264,12 +249,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .changedFiles(Set.of("module-a/src/Foo.java"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
                         "com.example",
                         "module-b",
                         "module-b",
-                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
                         null,
                         null,
                         ScalpelReport.REASON_EXCLUDED_DOWNSTREAM))
@@ -286,7 +271,7 @@ class ScalpelReportTest {
                 "com.example",
                 "module-a",
                 "module-a",
-                Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
                 ScalpelReport.CATEGORY_DOWNSTREAM,
                 null,
                 ScalpelReport.REASON_EXCLUDED_DOWNSTREAM);
@@ -294,7 +279,7 @@ class ScalpelReportTest {
         assertEquals("com.example", module.getGroupId());
         assertEquals("module-a", module.getArtifactId());
         assertEquals("module-a", module.getPath());
-        assertEquals(Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT), module.getReasons());
+        assertEquals(List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT), module.getReasons());
         assertEquals(ScalpelReport.CATEGORY_DOWNSTREAM, module.getCategory());
         assertEquals(ScalpelReport.REASON_EXCLUDED_DOWNSTREAM, module.getTestsSkippedReason());
     }
@@ -304,12 +289,12 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .changedFiles(Set.of("module-a/src/Foo.java"))
                 .addAffectedModule(new ScalpelReport.AffectedModule(
                         "com.example",
                         "module-b",
                         "module-b",
-                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
+                        List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT),
                         ScalpelReport.CATEGORY_DOWNSTREAM,
                         "main",
                         ScalpelReport.REASON_EXCLUDED_DOWNSTREAM))
@@ -328,13 +313,13 @@ class ScalpelReportTest {
     @Test
     void moduleBuilder_minimalBuild() {
         ScalpelReport.AffectedModule module = ScalpelReport.AffectedModule.moduleBuilder(
-                        "com.example", "module-a", "module-a", Collections.singletonList("SOURCE_CHANGE"))
+                        "com.example", "module-a", "module-a", List.of("SOURCE_CHANGE"))
                 .build();
 
         assertEquals("com.example", module.getGroupId());
         assertEquals("module-a", module.getArtifactId());
         assertEquals("module-a", module.getPath());
-        assertEquals(Collections.singletonList("SOURCE_CHANGE"), module.getReasons());
+        assertEquals(List.of("SOURCE_CHANGE"), module.getReasons());
         assertNull(module.getCategory());
         assertNull(module.getSourceSet());
         assertNull(module.getTestsSkippedReason());
@@ -343,10 +328,7 @@ class ScalpelReportTest {
     @Test
     void moduleBuilder_allFieldsSet() {
         ScalpelReport.AffectedModule module = ScalpelReport.AffectedModule.moduleBuilder(
-                        "com.example",
-                        "module-b",
-                        "path/module-b",
-                        Collections.singletonList(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT))
+                        "com.example", "module-b", "path/module-b", List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT))
                 .category(ScalpelReport.CATEGORY_DOWNSTREAM)
                 .sourceSet("main")
                 .testsSkippedReason(ScalpelReport.REASON_EXCLUDED_DOWNSTREAM)
@@ -365,12 +347,9 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("module-a/src/Foo.java"))
+                .changedFiles(Set.of("module-a/src/Foo.java"))
                 .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                                "com.example",
-                                "module-a",
-                                "module-a",
-                                Collections.singletonList(ScalpelReport.REASON_SOURCE_CHANGE))
+                                "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE))
                         .category(ScalpelReport.CATEGORY_DIRECT)
                         .sourceSet("main")
                         .build())
@@ -385,10 +364,7 @@ class ScalpelReportTest {
     @Test
     void moduleBuilder_categoryOnly() {
         ScalpelReport.AffectedModule module = ScalpelReport.AffectedModule.moduleBuilder(
-                        "com.example",
-                        "module-a",
-                        "module-a",
-                        Collections.singletonList(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY))
+                        "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY))
                 .category(ScalpelReport.CATEGORY_UPSTREAM)
                 .build();
 
@@ -402,7 +378,7 @@ class ScalpelReportTest {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
-                .changedFiles(Collections.singleton("path/with\"quotes.java"))
+                .changedFiles(Set.of("path/with\"quotes.java"))
                 .build();
 
         String json = report.toJson();

--- a/extension3/pom.xml
+++ b/extension3/pom.xml
@@ -69,6 +69,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>4.11.0</version>

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -63,7 +62,7 @@ class ModuleMapperTest {
         List<MavenProject> projects = createProjects(root);
 
         Set<String> changedFiles = new LinkedHashSet<>(
-                Arrays.asList("module-a/src/test/java/FooTest.java", "module-a/src/test/resources/test-data.xml"));
+                List.of("module-a/src/test/java/FooTest.java", "module-a/src/test/resources/test-data.xml"));
 
         ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
 
@@ -79,7 +78,7 @@ class ModuleMapperTest {
         List<MavenProject> projects = createProjects(root);
 
         Set<String> changedFiles = new LinkedHashSet<>(
-                Arrays.asList("module-a/src/main/java/Foo.java", "module-a/src/main/resources/config.xml"));
+                List.of("module-a/src/main/java/Foo.java", "module-a/src/main/resources/config.xml"));
 
         ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
 
@@ -93,8 +92,8 @@ class ModuleMapperTest {
         Path root = tempDir;
         List<MavenProject> projects = createProjects(root);
 
-        Set<String> changedFiles = new LinkedHashSet<>(
-                Arrays.asList("module-a/src/main/java/Foo.java", "module-a/src/test/java/FooTest.java"));
+        Set<String> changedFiles =
+                new LinkedHashSet<>(List.of("module-a/src/main/java/Foo.java", "module-a/src/test/java/FooTest.java"));
 
         ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
 
@@ -108,7 +107,7 @@ class ModuleMapperTest {
         Path root = tempDir;
         List<MavenProject> projects = createProjects(root);
 
-        Set<String> changedFiles = new LinkedHashSet<>(Arrays.asList(
+        Set<String> changedFiles = new LinkedHashSet<>(List.of(
                 "module-a/src/test/java/FooTest.java", // test-only for module-a
                 "module-b/src/main/java/Bar.java" // main for module-b
                 ));
@@ -127,7 +126,7 @@ class ModuleMapperTest {
         Path root = tempDir;
         List<MavenProject> projects = createProjects(root);
 
-        Set<String> changedFiles = new LinkedHashSet<>(Arrays.asList("module-a/README.md"));
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("module-a/README.md"));
 
         ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
 
@@ -143,7 +142,7 @@ class ModuleMapperTest {
                 "com.example", "module-a", root.resolve("module-a/pom.xml").toFile());
         MavenProject moduleB = createProject(
                 "com.example", "module-b", root.resolve("module-b/pom.xml").toFile());
-        return Arrays.asList(parent, moduleA, moduleB);
+        return List.of(parent, moduleA, moduleB);
     }
 
     private MavenProject createProject(String groupId, String artifactId, File pomFile) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -17,12 +17,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
@@ -37,6 +37,9 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class PomChangeAnalyzerTest {
 
@@ -70,7 +73,7 @@ class PomChangeAnalyzerTest {
         Properties b = new Properties();
         b.setProperty("dep.version", "2.0");
         Set<String> changed = analyzer.diffProperties(a, b);
-        assertEquals(Collections.singleton("dep.version"), changed);
+        assertEquals(Set.of("dep.version"), changed);
     }
 
     @Test
@@ -79,7 +82,7 @@ class PomChangeAnalyzerTest {
         Properties b = new Properties();
         b.setProperty("new.prop", "value");
         Set<String> changed = analyzer.diffProperties(a, b);
-        assertEquals(Collections.singleton("new.prop"), changed);
+        assertEquals(Set.of("new.prop"), changed);
     }
 
     @Test
@@ -88,7 +91,7 @@ class PomChangeAnalyzerTest {
         a.setProperty("old.prop", "value");
         Properties b = new Properties();
         Set<String> changed = analyzer.diffProperties(a, b);
-        assertEquals(Collections.singleton("old.prop"), changed);
+        assertEquals(Set.of("old.prop"), changed);
     }
 
     @Test
@@ -112,7 +115,7 @@ class PomChangeAnalyzerTest {
         Model old = modelWithManagedDep("com.example", "lib-a", "1.0");
         Model now = modelWithManagedDep("com.example", "lib-a", "2.0");
         Set<String> changed = analyzer.diffDependencyManagement(old, now);
-        assertEquals(Collections.singleton("com.example:lib-a"), changed);
+        assertEquals(Set.of("com.example:lib-a"), changed);
     }
 
     @Test
@@ -120,7 +123,7 @@ class PomChangeAnalyzerTest {
         Model old = new Model();
         Model now = modelWithManagedDep("com.example", "lib-new", "1.0");
         Set<String> changed = analyzer.diffDependencyManagement(old, now);
-        assertEquals(Collections.singleton("com.example:lib-new"), changed);
+        assertEquals(Set.of("com.example:lib-new"), changed);
     }
 
     // --- diffPluginManagement tests ---
@@ -137,7 +140,7 @@ class PomChangeAnalyzerTest {
         Model old = modelWithManagedPlugin("org.apache.maven.plugins", "maven-compiler-plugin", "3.11.0");
         Model now = modelWithManagedPlugin("org.apache.maven.plugins", "maven-compiler-plugin", "3.12.0");
         Set<String> changed = analyzer.diffPluginManagement(old, now);
-        assertEquals(Collections.singleton("org.apache.maven.plugins:maven-compiler-plugin"), changed);
+        assertEquals(Set.of("org.apache.maven.plugins:maven-compiler-plugin"), changed);
     }
 
     // --- analyzeChanges integration tests ---
@@ -149,7 +152,7 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createSimpleReactor(root);
         MavenProject moduleA = projects.get(1); // module-a
 
-        Set<String> changedPoms = Collections.singleton("module-a/pom.xml");
+        Set<String> changedPoms = Set.of("module-a/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("module-a/pom.xml", readFile(moduleA.getFile()));
 
@@ -167,20 +170,22 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createReactorWithPropertyUsage(root);
 
         // Old parent POM had dep.version=1.0
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <dep.version>1.0</dep.version>\n"
-                + "  </properties>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -202,24 +207,26 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createReactorWithDepMgmtUsage(root);
 
         // Old parent POM had lib-x:1.0 in depMgmt
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>com.example</groupId>\n"
-                + "      <artifactId>lib-x</artifactId>\n"
-                + "      <version>1.0</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>lib-x</artifactId>
+                      <version>1.0</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -240,17 +247,19 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createSimpleReactor(root);
 
         // Old POM is identical to current
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -266,7 +275,7 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createSimpleReactor(root);
 
         // POM didn't exist in old commit (no entry in oldPoms)
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
 
         Set<MavenProject> affected =
@@ -280,20 +289,22 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
         List<MavenProject> projects = createReactorWithPropertyUsage(root);
 
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <dep.version>1.0</dep.version>\n"
-                + "  </properties>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -309,27 +320,29 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
         List<MavenProject> projects = createReactorWithManagedDepPropertyIndirection(root);
 
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <spring.version>5.3.0</spring.version>\n"
-                + "  </properties>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>org.springframework</groupId>\n"
-                + "      <artifactId>spring-core</artifactId>\n"
-                + "      <version>${spring.version}</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <spring.version>5.3.0</spring.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>org.springframework</groupId>
+                      <artifactId>spring-core</artifactId>
+                      <version>${spring.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -349,27 +362,29 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createReactorWithManagedDepPropertyIndirection(root);
 
         // Old parent POM had spring.version=5.3.0
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <spring.version>5.3.0</spring.version>\n"
-                + "  </properties>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>org.springframework</groupId>\n"
-                + "      <artifactId>spring-core</artifactId>\n"
-                + "      <version>${spring.version}</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <spring.version>5.3.0</spring.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>org.springframework</groupId>
+                      <artifactId>spring-core</artifactId>
+                      <version>${spring.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -394,27 +409,29 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createReactorWithManagedPluginPropertyIndirection(root);
 
         // Old parent POM had compiler.version=3.11.0
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <compiler.version>3.11.0</compiler.version>\n"
-                + "  </properties>\n"
-                + "  <build><pluginManagement><plugins>\n"
-                + "    <plugin>\n"
-                + "      <groupId>org.apache.maven.plugins</groupId>\n"
-                + "      <artifactId>maven-compiler-plugin</artifactId>\n"
-                + "      <version>${compiler.version}</version>\n"
-                + "    </plugin>\n"
-                + "  </plugins></pluginManagement></build>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <compiler.version>3.11.0</compiler.version>
+                  </properties>
+                  <build><pluginManagement><plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>${compiler.version}</version>
+                    </plugin>
+                  </plugins></pluginManagement></build>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -438,39 +455,45 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
 
         // Parent POM with profile "my-profile" having dep.version=2.0 (new value)
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <profiles><profile>\n"
-                + "    <id>my-profile</id>\n"
-                + "    <properties><dep.version>2.0</dep.version></properties>\n"
-                + "  </profile></profiles>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <profiles><profile>
+                    <id>my-profile</id>
+                    <properties><dep.version>2.0</dep.version></properties>
+                  </profile></profiles>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
         // module-b references ${dep.version}
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>${dep.version}</version></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>${dep.version}</version></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
@@ -478,24 +501,26 @@ class PomChangeAnalyzerTest {
         // Set profile as active on parent
         Profile activeProfile = new Profile();
         activeProfile.setId("my-profile");
-        projects.get(0).setActiveProfiles(Collections.singletonList(activeProfile));
+        projects.get(0).setActiveProfiles(List.of(activeProfile));
 
         // Old parent POM had dep.version=1.0 in the profile
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <profiles><profile>\n"
-                + "    <id>my-profile</id>\n"
-                + "    <properties><dep.version>1.0</dep.version></properties>\n"
-                + "  </profile></profiles>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <profiles><profile>
+                    <id>my-profile</id>
+                    <properties><dep.version>1.0</dep.version></properties>
+                  </profile></profiles>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -514,58 +539,66 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
 
         // Parent POM with profile "my-profile" having dep.version=2.0
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <profiles><profile>\n"
-                + "    <id>my-profile</id>\n"
-                + "    <properties><dep.version>2.0</dep.version></properties>\n"
-                + "  </profile></profiles>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <profiles><profile>
+                    <id>my-profile</id>
+                    <properties><dep.version>2.0</dep.version></properties>
+                  </profile></profiles>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>${dep.version}</version></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>${dep.version}</version></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
         // Do NOT set active profiles - the profile is inactive
 
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <profiles><profile>\n"
-                + "    <id>my-profile</id>\n"
-                + "    <properties><dep.version>1.0</dep.version></properties>\n"
-                + "  </profile></profiles>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <profiles><profile>
+                    <id>my-profile</id>
+                    <properties><dep.version>1.0</dep.version></properties>
+                  </profile></profiles>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -580,66 +613,74 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
 
         // Parent POM with profile that has managed dep lib-x:2.0
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <profiles><profile>\n"
-                + "    <id>my-profile</id>\n"
-                + "    <dependencyManagement><dependencies>\n"
-                + "      <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>2.0</version></dependency>\n"
-                + "    </dependencies></dependencyManagement>\n"
-                + "  </profile></profiles>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <profiles><profile>
+                    <id>my-profile</id>
+                    <dependencyManagement><dependencies>
+                      <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>2.0</version></dependency>
+                    </dependencies></dependencyManagement>
+                  </profile></profiles>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
         // module-b uses lib-x
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
         Profile activeProfile = new Profile();
         activeProfile.setId("my-profile");
-        projects.get(0).setActiveProfiles(Collections.singletonList(activeProfile));
+        projects.get(0).setActiveProfiles(List.of(activeProfile));
 
         // Old parent POM had lib-x:1.0 in the profile
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <profiles><profile>\n"
-                + "    <id>my-profile</id>\n"
-                + "    <dependencyManagement><dependencies>\n"
-                + "      <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>1.0</version></dependency>\n"
-                + "    </dependencies></dependencyManagement>\n"
-                + "  </profile></profiles>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <profiles><profile>
+                    <id>my-profile</id>
+                    <dependencyManagement><dependencies>
+                      <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>1.0</version></dependency>
+                    </dependencies></dependencyManagement>
+                  </profile></profiles>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -670,7 +711,7 @@ class PomChangeAnalyzerTest {
         Model now = modelWithManagedPluginConfig("org.apache.maven.plugins", "maven-compiler-plugin", "3.11.0", "17");
         Set<String> changed = analyzer.diffPluginManagement(old, now);
         assertEquals(
-                Collections.singleton("org.apache.maven.plugins:maven-compiler-plugin"),
+                Set.of("org.apache.maven.plugins:maven-compiler-plugin"),
                 changed,
                 "Config value change should be detected");
     }
@@ -683,7 +724,7 @@ class PomChangeAnalyzerTest {
                 "org.apache.maven.plugins", "maven-surefire-plugin", "3.0.0", "default-test", "integration-test");
         Set<String> changed = analyzer.diffPluginManagement(old, now);
         assertEquals(
-                Collections.singleton("org.apache.maven.plugins:maven-surefire-plugin"),
+                Set.of("org.apache.maven.plugins:maven-surefire-plugin"),
                 changed,
                 "Execution phase change should be detected");
     }
@@ -697,1030 +738,249 @@ class PomChangeAnalyzerTest {
         assertTrue(analyzer.diffPluginManagement(old, now).isEmpty(), "Identical executions should not trigger diff");
     }
 
-    // --- Source directory comparison tests ---
+    // --- Source directory, resource, and repository comparison tests (parameterized) ---
 
-    @Test
-    void analyzeChanges_sourceDirectoryChangeAffectsParent() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("parentElementChangeAffectsParentCases")
+    void analyzeChanges_parentElementChangeAffectsParent(
+            String description, String newParentPomXml, String oldParentPomXml) throws Exception {
         Path root = setupReactorRoot();
 
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <sourceDirectory>src/main/java2</sourceDirectory>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
+        writePom(root.resolve("pom.xml"), newParentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+        List<MavenProject> projects = buildProjectList(root, newParentPomXml, moduleAPomXml, moduleBPomXml);
 
-        // Old POM had src/main/java as source directory
-        String oldParentPom = parentPomXml.replace("src/main/java2", "src/main/java");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        oldPoms.put("pom.xml", oldParentPomXml.getBytes(StandardCharsets.UTF_8));
 
         PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
 
         assertTrue(
                 result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (source directory changed)");
+                "Parent should be self-affected (" + description + ")");
     }
 
-    @Test
-    void analyzeChanges_testSourceDirectoryChangeAffectsParent() throws Exception {
+    static Stream<Arguments> parentElementChangeAffectsParentCases() {
+        return Stream.of(
+                // Source directory changes
+                Arguments.of(
+                        "source directory changed",
+                        parentPomWith("<build><sourceDirectory>src/main/java2</sourceDirectory></build>"),
+                        parentPomWith("<build><sourceDirectory>src/main/java</sourceDirectory></build>")),
+                Arguments.of(
+                        "test source directory changed",
+                        parentPomWith("<build><testSourceDirectory>src/test/java2</testSourceDirectory></build>"),
+                        parentPomWith("<build><testSourceDirectory>src/test/java</testSourceDirectory></build>")),
+                Arguments.of(
+                        "script source directory changed",
+                        parentPomWith(
+                                "<build><scriptSourceDirectory>src/main/scripts2</scriptSourceDirectory></build>"),
+                        parentPomWith(
+                                "<build><scriptSourceDirectory>src/main/scripts</scriptSourceDirectory></build>")),
+                // Resource changes
+                Arguments.of(
+                        "resource directory changed",
+                        parentPomWith("<build><resources><resource><directory>src/main/resources2</directory>"
+                                + "</resource></resources></build>"),
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "</resource></resources></build>")),
+                Arguments.of(
+                        "resource filtering changed",
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<filtering>true</filtering></resource></resources></build>"),
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<filtering>false</filtering></resource></resources></build>")),
+                Arguments.of(
+                        "resource targetPath changed",
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<targetPath>META-INF/new</targetPath></resource></resources></build>"),
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<targetPath>META-INF/old</targetPath></resource></resources></build>")),
+                Arguments.of(
+                        "resource includes changed",
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<includes><include>**/*.xml</include><include>**/*.properties</include>"
+                                + "</includes></resource></resources></build>"),
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<includes><include>**/*.xml</include></includes>"
+                                + "</resource></resources></build>")),
+                Arguments.of(
+                        "test resource directory changed",
+                        parentPomWith("<build><testResources><testResource>"
+                                + "<directory>src/test/resources2</directory>"
+                                + "</testResource></testResources></build>"),
+                        parentPomWith("<build><testResources><testResource>"
+                                + "<directory>src/test/resources</directory>"
+                                + "</testResource></testResources></build>")),
+                // Repository changes
+                Arguments.of(
+                        "repository added",
+                        parentPomWith("<repositories><repository><id>central</id>"
+                                + "<url>https://repo.maven.apache.org/maven2</url>"
+                                + "</repository></repositories>"),
+                        parentPomWith("")),
+                Arguments.of(
+                        "repository URL changed",
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://new-repo.example.com/maven2</url>"
+                                + "</repository></repositories>"),
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://old-repo.example.com/maven2</url>"
+                                + "</repository></repositories>")),
+                Arguments.of(
+                        "repository snapshot policy changed",
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "<snapshots><enabled>true</enabled></snapshots>"
+                                + "</repository></repositories>"),
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "<snapshots><enabled>false</enabled></snapshots>"
+                                + "</repository></repositories>")),
+                Arguments.of(
+                        "plugin repository added",
+                        parentPomWith("<pluginRepositories><pluginRepository><id>plugin-repo</id>"
+                                + "<url>https://plugins.example.com/maven2</url>"
+                                + "</pluginRepository></pluginRepositories>"),
+                        parentPomWith("")),
+                Arguments.of(
+                        "repository layout changed",
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "<layout>default</layout></repository></repositories>"),
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "<layout>legacy</layout></repository></repositories>")),
+                Arguments.of(
+                        "repository updatePolicy changed",
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "<snapshots><enabled>true</enabled>"
+                                + "<updatePolicy>always</updatePolicy></snapshots>"
+                                + "</repository></repositories>"),
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "<snapshots><enabled>true</enabled>"
+                                + "<updatePolicy>daily</updatePolicy></snapshots>"
+                                + "</repository></repositories>")),
+                Arguments.of(
+                        "repository checksumPolicy changed",
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "<releases><checksumPolicy>fail</checksumPolicy></releases>"
+                                + "</repository></repositories>"),
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "<releases><checksumPolicy>warn</checksumPolicy></releases>"
+                                + "</repository></repositories>")),
+                Arguments.of(
+                        "repository removed",
+                        parentPomWith(""),
+                        parentPomWith("<repositories><repository><id>custom</id>"
+                                + "<url>https://repo.example.com/maven2</url>"
+                                + "</repository></repositories>")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("parentElementNoChangeCases")
+    void analyzeChanges_parentElementNoChange(String description, String newParentPomXml, String oldParentPomXml)
+            throws Exception {
         Path root = setupReactorRoot();
 
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <testSourceDirectory>src/test/java2</testSourceDirectory>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
+        writePom(root.resolve("pom.xml"), newParentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
+        List<MavenProject> projects = buildProjectList(root, newParentPomXml, moduleAPomXml, moduleBPomXml);
 
-        String oldParentPom = parentPomXml.replace("src/test/java2", "src/test/java");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        oldPoms.put("pom.xml", oldParentPomXml.getBytes(StandardCharsets.UTF_8));
 
         PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
 
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (test source directory changed)");
+        assertTrue(result.getAffectedProjects().isEmpty(), description);
     }
 
-    @Test
-    void analyzeChanges_scriptSourceDirectoryChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
+    static Stream<Arguments> parentElementNoChangeCases() {
+        String resourceIncludesA = "<build><resources><resource><directory>src/main/resources</directory>"
+                + "<includes><include>**/*.xml</include><include>**/*.properties</include>"
+                + "</includes></resource></resources></build>";
+        String resourceIncludesB = "<build><resources><resource><directory>src/main/resources</directory>"
+                + "<includes><include>**/*.properties</include><include>**/*.xml</include>"
+                + "</includes></resource></resources></build>";
 
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <scriptSourceDirectory>src/main/scripts2</scriptSourceDirectory>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        String oldParentPom = parentPomXml.replace("src/main/scripts2", "src/main/scripts");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (script source directory changed)");
+        return Stream.of(
+                Arguments.of(
+                        "Reordered includes with same patterns should not affect any module",
+                        parentPomWith(resourceIncludesB),
+                        parentPomWith(resourceIncludesA)),
+                Arguments.of(
+                        "Same source directories should not affect any module",
+                        parentPomWith("<build><sourceDirectory>src/main/java</sourceDirectory></build>"),
+                        parentPomWith("<build><sourceDirectory>src/main/java</sourceDirectory></build>")),
+                Arguments.of(
+                        "Same repositories should not affect any module",
+                        parentPomWith("<repositories><repository><id>central</id>"
+                                + "<url>https://repo.maven.apache.org/maven2</url>"
+                                + "</repository></repositories>"),
+                        parentPomWith("<repositories><repository><id>central</id>"
+                                + "<url>https://repo.maven.apache.org/maven2</url>"
+                                + "</repository></repositories>")));
     }
 
-    @Test
-    void analyzeChanges_resourceDirectoryChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <resources><resource><directory>src/main/resources2</directory></resource></resources>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        String oldParentPom = parentPomXml.replace("src/main/resources2", "src/main/resources");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (resource directory changed)");
-    }
-
-    @Test
-    void analyzeChanges_resourceFilteringChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <resources><resource><directory>src/main/resources</directory><filtering>true</filtering></resource></resources>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        // Old POM had filtering=false
-        String oldParentPom = parentPomXml.replace("<filtering>true</filtering>", "<filtering>false</filtering>");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (resource filtering changed)");
-    }
-
-    @Test
-    void analyzeChanges_resourceTargetPathChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <resources><resource><directory>src/main/resources</directory><targetPath>META-INF/new</targetPath></resource></resources>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        String oldParentPom = parentPomXml.replace("META-INF/new", "META-INF/old");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (resource targetPath changed)");
-    }
-
-    @Test
-    void analyzeChanges_resourceIncludesChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <resources><resource><directory>src/main/resources</directory>"
-                + "<includes><include>**/*.xml</include><include>**/*.properties</include></includes>"
-                + "</resource></resources>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        // Old POM had only *.xml include
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <resources><resource><directory>src/main/resources</directory>"
-                + "<includes><include>**/*.xml</include></includes>"
-                + "</resource></resources>\n"
-                + "  </build>\n"
-                + "</project>\n";
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (resource includes changed)");
-    }
-
-    @Test
-    void analyzeChanges_resourceIncludesReorderedNoChange() throws Exception {
-        Path root = setupReactorRoot();
-
-        // New POM: includes in order B, A
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <resources><resource><directory>src/main/resources</directory>"
-                + "<includes><include>**/*.properties</include><include>**/*.xml</include></includes>"
-                + "</resource></resources>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        // Old POM: same includes in order A, B
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <resources><resource><directory>src/main/resources</directory>"
-                + "<includes><include>**/*.xml</include><include>**/*.properties</include></includes>"
-                + "</resource></resources>\n"
-                + "  </build>\n"
-                + "</project>\n";
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().isEmpty(),
-                "Reordered includes with same patterns should not affect any module");
-    }
-
-    @Test
-    void analyzeChanges_testResourceDirectoryChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <testResources><testResource><directory>src/test/resources2</directory></testResource></testResources>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        String oldParentPom = parentPomXml.replace("src/test/resources2", "src/test/resources");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (test resource directory changed)");
-    }
-
-    @Test
-    void analyzeChanges_sameSourceDirectoriesNoChange() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build>\n"
-                + "    <sourceDirectory>src/main/java</sourceDirectory>\n"
-                + "  </build>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", parentPomXml.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(result.getAffectedProjects().isEmpty(), "Same source directories should not affect any module");
-    }
-
-    // --- Repository comparison tests ---
-
-    @Test
-    void analyzeChanges_repositoryAddedAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <repositories>\n"
-                + "    <repository>\n"
-                + "      <id>central</id>\n"
-                + "      <url>https://repo.maven.apache.org/maven2</url>\n"
-                + "    </repository>\n"
-                + "  </repositories>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        // Old POM had no repositories
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (repository added)");
-    }
-
-    @Test
-    void analyzeChanges_repositoryUrlChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <repositories>\n"
-                + "    <repository>\n"
-                + "      <id>custom</id>\n"
-                + "      <url>https://new-repo.example.com/maven2</url>\n"
-                + "    </repository>\n"
-                + "  </repositories>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        String oldParentPom =
-                parentPomXml.replace("https://new-repo.example.com/maven2", "https://old-repo.example.com/maven2");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (repository URL changed)");
-    }
-
-    @Test
-    void analyzeChanges_repositorySnapshotPolicyChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <repositories>\n"
-                + "    <repository>\n"
-                + "      <id>custom</id>\n"
-                + "      <url>https://repo.example.com/maven2</url>\n"
-                + "      <snapshots><enabled>true</enabled></snapshots>\n"
-                + "    </repository>\n"
-                + "  </repositories>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        // Old POM had snapshots disabled
-        String oldParentPom = parentPomXml.replace(
-                "<snapshots><enabled>true</enabled></snapshots>", "<snapshots><enabled>false</enabled></snapshots>");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (repository snapshot policy changed)");
-    }
-
-    @Test
-    void analyzeChanges_pluginRepositoryChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <pluginRepositories>\n"
-                + "    <pluginRepository>\n"
-                + "      <id>plugin-repo</id>\n"
-                + "      <url>https://plugins.example.com/maven2</url>\n"
-                + "    </pluginRepository>\n"
-                + "  </pluginRepositories>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        // Old POM had no plugin repositories
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (plugin repository added)");
-    }
-
-    @Test
-    void analyzeChanges_repositoryLayoutChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <repositories>\n"
-                + "    <repository>\n"
-                + "      <id>custom</id>\n"
-                + "      <url>https://repo.example.com/maven2</url>\n"
-                + "      <layout>default</layout>\n"
-                + "    </repository>\n"
-                + "  </repositories>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        String oldParentPom = parentPomXml.replace("<layout>default</layout>", "<layout>legacy</layout>");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (repository layout changed)");
-    }
-
-    @Test
-    void analyzeChanges_repositoryUpdatePolicyChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <repositories>\n"
-                + "    <repository>\n"
-                + "      <id>custom</id>\n"
-                + "      <url>https://repo.example.com/maven2</url>\n"
-                + "      <snapshots><enabled>true</enabled><updatePolicy>always</updatePolicy></snapshots>\n"
-                + "    </repository>\n"
-                + "  </repositories>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        String oldParentPom =
-                parentPomXml.replace("<updatePolicy>always</updatePolicy>", "<updatePolicy>daily</updatePolicy>");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (repository updatePolicy changed)");
-    }
-
-    @Test
-    void analyzeChanges_repositoryChecksumPolicyChangeAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <repositories>\n"
-                + "    <repository>\n"
-                + "      <id>custom</id>\n"
-                + "      <url>https://repo.example.com/maven2</url>\n"
-                + "      <releases><checksumPolicy>fail</checksumPolicy></releases>\n"
-                + "    </repository>\n"
-                + "  </repositories>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        String oldParentPom =
-                parentPomXml.replace("<checksumPolicy>fail</checksumPolicy>", "<checksumPolicy>warn</checksumPolicy>");
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (repository checksumPolicy changed)");
-    }
-
-    @Test
-    void analyzeChanges_sameRepositoriesNoChange() throws Exception {
-        Path root = setupReactorRoot();
-
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <repositories>\n"
-                + "    <repository>\n"
-                + "      <id>central</id>\n"
-                + "      <url>https://repo.maven.apache.org/maven2</url>\n"
-                + "    </repository>\n"
-                + "  </repositories>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", parentPomXml.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(result.getAffectedProjects().isEmpty(), "Same repositories should not affect any module");
-    }
-
-    @Test
-    void analyzeChanges_repositoryRemovedAffectsParent() throws Exception {
-        Path root = setupReactorRoot();
-
-        // New POM has no repositories
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
-        writePom(root.resolve("pom.xml"), parentPomXml);
-
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
-
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
-        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
-
-        List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
-
-        // Old POM had a repository
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <repositories>\n"
-                + "    <repository>\n"
-                + "      <id>custom</id>\n"
-                + "      <url>https://repo.example.com/maven2</url>\n"
-                + "    </repository>\n"
-                + "  </repositories>\n"
-                + "</project>\n";
-
-        Set<String> changedPoms = Collections.singleton("pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-
-        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
-
-        assertTrue(
-                result.getAffectedProjects().contains(projects.get(0)),
-                "Parent should be self-affected (repository removed)");
+    private static String parentPomWith(String extraSection) {
+        return """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  %s
+                </project>
+                """.formatted(extraSection);
     }
 
     // --- Resource filtering property tracking tests ---
@@ -1730,36 +990,42 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
 
         // Parent POM with app.version=2.0 (new)
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <app.version>2.0</app.version>\n"
-                + "  </properties>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <app.version>2.0</app.version>
+                  </properties>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
         // module-a: no filtered resources
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
         // module-b: has filtered resources
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         // Create filtered resource file referencing ${app.version}
@@ -1781,20 +1047,22 @@ class PomChangeAnalyzerTest {
         moduleB.getModel().setBuild(build);
 
         // Old parent POM had app.version=1.0
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <app.version>1.0</app.version>\n"
-                + "  </properties>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <app.version>1.0</app.version>
+                  </properties>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -1813,34 +1081,40 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
 
         // Parent POM with app.version=2.0
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <app.version>2.0</app.version>\n"
-                + "  </properties>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <app.version>2.0</app.version>
+                  </properties>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         // Create filtered resource that does NOT reference ${app.version}
@@ -1859,20 +1133,22 @@ class PomChangeAnalyzerTest {
         build.addResource(resource);
         moduleB.getModel().setBuild(build);
 
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <app.version>1.0</app.version>\n"
-                + "  </properties>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <app.version>1.0</app.version>
+                  </properties>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -1892,7 +1168,7 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createSimpleReactor(root);
 
         // No old POM bytes = new POM file
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         // Intentionally no entry for "pom.xml" (null = new file)
 
@@ -1909,31 +1185,37 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
 
         // New parent POM: profile 'prod' removed
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
@@ -1941,27 +1223,29 @@ class PomChangeAnalyzerTest {
         // Profile 'prod' is active but has been removed from the POM
         Profile activeProfile = new Profile();
         activeProfile.setId("prod");
-        projects.get(0).setActiveProfiles(Collections.singletonList(activeProfile));
+        projects.get(0).setActiveProfiles(List.of(activeProfile));
 
         // Old parent POM had profile 'prod' with direct dependencies
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <profiles><profile>\n"
-                + "    <id>prod</id>\n"
-                + "    <properties><prod.version>1.0</prod.version></properties>\n"
-                + "    <dependencies>\n"
-                + "      <dependency><groupId>com.prod</groupId><artifactId>lib</artifactId><version>1.0</version></dependency>\n"
-                + "    </dependencies>\n"
-                + "  </profile></profiles>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <profiles><profile>
+                    <id>prod</id>
+                    <properties><prod.version>1.0</prod.version></properties>
+                    <dependencies>
+                      <dependency><groupId>com.prod</groupId><artifactId>lib</artifactId><version>1.0</version></dependency>
+                    </dependencies>
+                  </profile></profiles>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -1980,48 +1264,54 @@ class PomChangeAnalyzerTest {
     void analyzeChanges_profileDirectDepsChangeAffectsParent() throws Exception {
         Path root = setupReactorRoot();
 
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <profiles><profile>\n"
-                + "    <id>prod</id>\n"
-                + "    <dependencies>\n"
-                + "      <dependency><groupId>com.prod</groupId><artifactId>lib</artifactId><version>2.0</version></dependency>\n"
-                + "    </dependencies>\n"
-                + "  </profile></profiles>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <profiles><profile>
+                    <id>prod</id>
+                    <dependencies>
+                      <dependency><groupId>com.prod</groupId><artifactId>lib</artifactId><version>2.0</version></dependency>
+                    </dependencies>
+                  </profile></profiles>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
         Profile activeProfile = new Profile();
         activeProfile.setId("prod");
-        projects.get(0).setActiveProfiles(Collections.singletonList(activeProfile));
+        projects.get(0).setActiveProfiles(List.of(activeProfile));
 
         // Old POM: profile had lib version 1.0
         String oldParentPom = parentPomXml.replace("<version>2.0</version>", "<version>1.0</version>");
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -2038,7 +1328,7 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createSimpleReactor(root);
 
         // Change only module-a's POM (leaf module)
-        Set<String> changedPoms = Collections.singleton("module-a/pom.xml");
+        Set<String> changedPoms = Set.of("module-a/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
 
         Set<MavenProject> affected =
@@ -2053,41 +1343,47 @@ class PomChangeAnalyzerTest {
     void analyzeChanges_directPluginChangeAffectsParent() throws Exception {
         Path root = setupReactorRoot();
 
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <build><plugins>\n"
-                + "    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>3.12.0</version></plugin>\n"
-                + "  </plugins></build>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <build><plugins>
+                    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>3.12.0</version></plugin>
+                  </plugins></build>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
 
         String oldParentPom = parentPomXml.replace("3.12.0", "3.11.0");
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -2102,41 +1398,47 @@ class PomChangeAnalyzerTest {
     void analyzeChanges_directDependencyChangeAffectsParent() throws Exception {
         Path root = setupReactorRoot();
 
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>junit</groupId><artifactId>junit</artifactId><version>4.13.2</version></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <dependencies>
+                    <dependency><groupId>junit</groupId><artifactId>junit</artifactId><version>4.13.2</version></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
 
         String oldParentPom = parentPomXml.replace("4.13.2", "4.13.1");
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -2151,31 +1453,37 @@ class PomChangeAnalyzerTest {
     void analyzeChanges_packagingChangeAffectsParent() throws Exception {
         Path root = setupReactorRoot();
 
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         List<MavenProject> projects = buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
@@ -2183,7 +1491,7 @@ class PomChangeAnalyzerTest {
         // Old POM had jar packaging
         String oldParentPom = parentPomXml.replace("<packaging>pom</packaging>", "<packaging>jar</packaging>");
 
-        Set<String> changedPoms = Collections.singleton("pom.xml");
+        Set<String> changedPoms = Set.of("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
@@ -2200,7 +1508,7 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createSimpleReactor(root);
 
         // POM path doesn't match any reactor project
-        Set<String> changedPoms = Collections.singleton("nonexistent/pom.xml");
+        Set<String> changedPoms = Set.of("nonexistent/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
 
         Set<MavenProject> affected =
@@ -2219,22 +1527,24 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createReactorWithBomImport(root);
 
         // Old BOM POM had lib-x:1.0
-        String oldBomPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>bom</artifactId>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>com.example</groupId>\n"
-                + "      <artifactId>lib-x</artifactId>\n"
-                + "      <version>1.0</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String oldBomPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>bom</artifactId>
+                  <packaging>pom</packaging>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>lib-x</artifactId>
+                      <version>1.0</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("bom/pom.xml");
+        Set<String> changedPoms = Set.of("bom/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
 
@@ -2260,22 +1570,24 @@ class PomChangeAnalyzerTest {
         List<MavenProject> projects = createReactorWithBomImport(root);
 
         // Old BOM POM is identical to current (lib-x:2.0)
-        String oldBomPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>bom</artifactId>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>com.example</groupId>\n"
-                + "      <artifactId>lib-x</artifactId>\n"
-                + "      <version>2.0</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String oldBomPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>bom</artifactId>
+                  <packaging>pom</packaging>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>lib-x</artifactId>
+                      <version>2.0</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
 
-        Set<String> changedPoms = Collections.singleton("bom/pom.xml");
+        Set<String> changedPoms = Set.of("bom/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
 
@@ -2291,23 +1603,25 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRootWithBom();
 
         // BOM with property-based version
-        String bomPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>bom</artifactId>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <properties>\n"
-                + "    <lib.version>2.0</lib.version>\n"
-                + "  </properties>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>com.example</groupId>\n"
-                + "      <artifactId>lib-x</artifactId>\n"
-                + "      <version>${lib.version}</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String bomPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>bom</artifactId>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <lib.version>2.0</lib.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>lib-x</artifactId>
+                      <version>${lib.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
         writePom(root.resolve("bom/pom.xml"), bomPomXml);
 
         List<MavenProject> projects = createReactorWithBomImportCustomBom(root, bomPomXml);
@@ -2315,7 +1629,7 @@ class PomChangeAnalyzerTest {
         // Old BOM POM had lib.version=1.0
         String oldBomPom = bomPomXml.replace("<lib.version>2.0</lib.version>", "<lib.version>1.0</lib.version>");
 
-        Set<String> changedPoms = Collections.singleton("bom/pom.xml");
+        Set<String> changedPoms = Set.of("bom/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
 
@@ -2336,7 +1650,7 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRootWithBom();
         List<MavenProject> projects = createReactorWithBomImport(root);
 
-        Set<String> changedPoms = Collections.singleton("bom/pom.xml");
+        Set<String> changedPoms = Set.of("bom/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         // No entry for bom/pom.xml = new file
 
@@ -2354,43 +1668,46 @@ class PomChangeAnalyzerTest {
         // Verify findBomImporters correctly detects import-scope BOM entries
         MavenProject parent = createProject(
                 "com.example", "parent", "1.0", tempDir.resolve("pom.xml").toFile());
-        parent.setOriginalModel(parseModel("<?xml version=\"1.0\"?>\n"
-                + "<project><modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "</project>"));
+        parent.setOriginalModel(parseModel("""
+                <?xml version="1.0"?>
+                <project><modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version>
+                  <packaging>pom</packaging>
+                </project>"""));
 
         MavenProject bom = createProject(
                 "com.example", "bom", "1.0", tempDir.resolve("bom/pom.xml").toFile());
-        bom.setOriginalModel(parseModel("<?xml version=\"1.0\"?>\n"
-                + "<project><modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId><artifactId>bom</artifactId><version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "</project>"));
+        bom.setOriginalModel(parseModel("""
+                <?xml version="1.0"?>
+                <project><modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId><artifactId>bom</artifactId><version>1.0</version>
+                  <packaging>pom</packaging>
+                </project>"""));
 
         MavenProject moduleA = createProject(
                 "com.example",
                 "module-a",
                 "1.0",
                 tempDir.resolve("module-a/pom.xml").toFile());
-        moduleA.setOriginalModel(parseModel("<?xml version=\"1.0\"?>\n"
-                + "<project><modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>bom</artifactId>"
-                + "<version>1.0</version><type>pom</type><scope>import</scope></dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>"));
+        moduleA.setOriginalModel(parseModel("""
+                <?xml version="1.0"?>
+                <project><modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version>
+                  <dependencyManagement><dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>bom</artifactId><version>1.0</version><type>pom</type><scope>import</scope></dependency>
+                  </dependencies></dependencyManagement>
+                </project>"""));
 
         MavenProject moduleB = createProject(
                 "com.example",
                 "module-b",
                 "1.0",
                 tempDir.resolve("module-b/pom.xml").toFile());
-        moduleB.setOriginalModel(parseModel("<?xml version=\"1.0\"?>\n"
-                + "<project><modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId><artifactId>module-b</artifactId><version>1.0</version>\n"
-                + "</project>"));
+        moduleB.setOriginalModel(parseModel("""
+                <?xml version="1.0"?>
+                <project><modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId><artifactId>module-b</artifactId><version>1.0</version>
+                </project>"""));
 
         List<MavenProject> projects = new ArrayList<>();
         projects.add(parent);
@@ -2418,65 +1735,73 @@ class PomChangeAnalyzerTest {
     }
 
     private List<MavenProject> createReactorWithBomImport(Path root) throws IOException {
-        String bomPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>bom</artifactId>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>com.example</groupId>\n"
-                + "      <artifactId>lib-x</artifactId>\n"
-                + "      <version>2.0</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String bomPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>bom</artifactId>
+                  <packaging>pom</packaging>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>lib-x</artifactId>
+                      <version>2.0</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
         return createReactorWithBomImportCustomBom(root, bomPomXml);
     }
 
     private List<MavenProject> createReactorWithBomImportCustomBom(Path root, String bomPomXml) throws IOException {
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>bom</module><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>bom</module><module>module-a</module><module>module-b</module></modules>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
         writePom(root.resolve("bom/pom.xml"), bomPomXml);
 
         // module-a: imports BOM, uses lib-x
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>com.example</groupId>\n"
-                + "      <artifactId>bom</artifactId>\n"
-                + "      <version>${project.version}</version>\n"
-                + "      <type>pom</type>\n"
-                + "      <scope>import</scope>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>bom</artifactId>
+                      <version>${project.version}</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
         // module-b: no BOM import, no lib-x
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         MavenProject parent = createProject(
@@ -2524,31 +1849,37 @@ class PomChangeAnalyzerTest {
 
     private List<MavenProject> createSimpleReactor(Path root) throws IOException {
         // Parent POM
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         return buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
@@ -2556,42 +1887,48 @@ class PomChangeAnalyzerTest {
 
     private List<MavenProject> createReactorWithPropertyUsage(Path root) throws IOException {
         // Parent POM with dep.version=2.0 (new value)
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <dep.version>2.0</dep.version>\n"
-                + "  </properties>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>2.0</dep.version>
+                  </properties>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
         // module-a: does NOT reference ${dep.version}
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>org.other</groupId><artifactId>other-lib</artifactId><version>3.0</version></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencies>
+                    <dependency><groupId>org.other</groupId><artifactId>other-lib</artifactId><version>3.0</version></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
         // module-b: references ${dep.version} in a dependency
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>${dep.version}</version></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId><version>${dep.version}</version></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         return buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
@@ -2599,43 +1936,49 @@ class PomChangeAnalyzerTest {
 
     private List<MavenProject> createReactorWithDepMgmtUsage(Path root) throws IOException {
         // Parent POM with depMgmt for lib-x:2.0 (new value)
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>com.example</groupId>\n"
-                + "      <artifactId>lib-x</artifactId>\n"
-                + "      <version>2.0</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>lib-x</artifactId>
+                      <version>2.0</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
         // module-a: does NOT use lib-x
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
         // module-b: uses lib-x (managed, no version)
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>lib-x</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         return buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
@@ -2643,46 +1986,52 @@ class PomChangeAnalyzerTest {
 
     private List<MavenProject> createReactorWithManagedDepPropertyIndirection(Path root) throws IOException {
         // Parent POM: spring.version=6.0.0 (new), managed dep spring-core uses ${spring.version}
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <spring.version>6.0.0</spring.version>\n"
-                + "  </properties>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>org.springframework</groupId>\n"
-                + "      <artifactId>spring-core</artifactId>\n"
-                + "      <version>${spring.version}</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <spring.version>6.0.0</spring.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>org.springframework</groupId>
+                      <artifactId>spring-core</artifactId>
+                      <version>${spring.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
         // module-a: does NOT use spring-core
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
         // module-b: uses spring-core (managed, no version in child POM)
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>org.springframework</groupId><artifactId>spring-core</artifactId></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>org.springframework</groupId><artifactId>spring-core</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         return buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
@@ -2690,49 +2039,55 @@ class PomChangeAnalyzerTest {
 
     private List<MavenProject> createReactorWithManagedPluginPropertyIndirection(Path root) throws IOException {
         // Parent POM: compiler.version=3.12.0 (new), managed plugin uses ${compiler.version}
-        String parentPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <compiler.version>3.12.0</compiler.version>\n"
-                + "  </properties>\n"
-                + "  <build><pluginManagement><plugins>\n"
-                + "    <plugin>\n"
-                + "      <groupId>org.apache.maven.plugins</groupId>\n"
-                + "      <artifactId>maven-compiler-plugin</artifactId>\n"
-                + "      <version>${compiler.version}</version>\n"
-                + "    </plugin>\n"
-                + "  </plugins></pluginManagement></build>\n"
-                + "</project>\n";
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <compiler.version>3.12.0</compiler.version>
+                  </properties>
+                  <build><pluginManagement><plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>${compiler.version}</version>
+                    </plugin>
+                  </plugins></pluginManagement></build>
+                </project>
+                """;
         writePom(root.resolve("pom.xml"), parentPomXml);
 
         // module-a: does NOT use maven-compiler-plugin
-        String moduleAPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
 
         // module-b: uses maven-compiler-plugin (managed, no version in child POM)
-        String moduleBPomXml = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <build><plugins>\n"
-                + "    <plugin>\n"
-                + "      <groupId>org.apache.maven.plugins</groupId>\n"
-                + "      <artifactId>maven-compiler-plugin</artifactId>\n"
-                + "    </plugin>\n"
-                + "  </plugins></build>\n"
-                + "</project>\n";
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <build><plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                  </plugins></build>
+                </project>
+                """;
         writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
 
         return buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
@@ -13,8 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -44,18 +42,16 @@ class ReactorTrimmerTest {
         MavenProject projectB = createProject("com.example", "module-b");
         addDependency(projectB, "com.example", "module-a", "test");
 
-        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB);
+        List<MavenProject> sortedProjects = List.of(projectA, projectB);
         Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
-        downstreamMap.put(projectA, Collections.singletonList(projectB));
+        downstreamMap.put(projectA, List.of(projectB));
 
-        ProjectDependencyGraph graph = new TestDependencyGraph(
-                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
 
-        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
         ScalpelConfiguration config = configWith(true, true);
 
-        TrimResult result =
-                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, Set.of(), graph, config);
 
         assertTrue(result.getBuildSet().contains(projectA));
         assertTrue(result.getBuildSet().contains(projectB));
@@ -74,18 +70,16 @@ class ReactorTrimmerTest {
         MavenProject projectB = createProject("com.example", "module-b");
         addDependency(projectB, "com.example", "module-a", "compile");
 
-        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB);
+        List<MavenProject> sortedProjects = List.of(projectA, projectB);
         Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
-        downstreamMap.put(projectA, Collections.singletonList(projectB));
+        downstreamMap.put(projectA, List.of(projectB));
 
-        ProjectDependencyGraph graph = new TestDependencyGraph(
-                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
 
-        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
         ScalpelConfiguration config = configWith(true, true);
 
-        TrimResult result =
-                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, Set.of(), graph, config);
 
         assertTrue(
                 result.getDownstreamOnly().contains(projectB), "Compile-scoped downstream should be in downstreamOnly");
@@ -101,15 +95,14 @@ class ReactorTrimmerTest {
         addTestJarDependency(projectB, "com.example", "module-a");
         addDependency(projectC, "com.example", "module-a", "compile");
 
-        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB, projectC);
+        List<MavenProject> sortedProjects = List.of(projectA, projectB, projectC);
         Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
-        downstreamMap.put(projectA, Arrays.asList(projectB, projectC));
+        downstreamMap.put(projectA, List.of(projectB, projectC));
 
-        ProjectDependencyGraph graph = new TestDependencyGraph(
-                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
 
-        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
-        Set<MavenProject> testOnlyProjects = new LinkedHashSet<>(Collections.singleton(projectA));
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
+        Set<MavenProject> testOnlyProjects = new LinkedHashSet<>(Set.of(projectA));
         ScalpelConfiguration config = configWith(true, true);
 
         TrimResult result = trimmer.computeBuildSet(directlyAffected, testOnlyProjects, graph, config);
@@ -128,18 +121,16 @@ class ReactorTrimmerTest {
         MavenProject projectA = createProject("com.example", "module-a");
         MavenProject projectB = createProject("com.example", "module-b");
 
-        List<MavenProject> sortedProjects = Arrays.asList(projectB, projectA);
+        List<MavenProject> sortedProjects = List.of(projectB, projectA);
         Map<MavenProject, List<MavenProject>> upstreamMap = new HashMap<>();
-        upstreamMap.put(projectA, Collections.singletonList(projectB));
+        upstreamMap.put(projectA, List.of(projectB));
 
-        ProjectDependencyGraph graph = new TestDependencyGraph(
-                sortedProjects, Collections.<MavenProject, List<MavenProject>>emptyMap(), upstreamMap);
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, Map.of(), upstreamMap);
 
-        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
         ScalpelConfiguration config = configWith(true, false); // alsoMake=true, alsoMakeDependents=false
 
-        TrimResult result =
-                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, Set.of(), graph, config);
 
         assertTrue(result.getBuildSet().contains(projectB));
         assertTrue(result.getUpstreamOnly().contains(projectB));
@@ -150,18 +141,16 @@ class ReactorTrimmerTest {
         MavenProject projectA = createProject("com.example", "module-a");
         MavenProject projectB = createProject("com.example", "module-b");
 
-        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB);
+        List<MavenProject> sortedProjects = List.of(projectA, projectB);
         Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
-        downstreamMap.put(projectA, Collections.singletonList(projectB));
+        downstreamMap.put(projectA, List.of(projectB));
 
-        ProjectDependencyGraph graph = new TestDependencyGraph(
-                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
 
-        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
         ScalpelConfiguration config = configWith(false, false); // both disabled
 
-        TrimResult result =
-                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, Set.of(), graph, config);
 
         assertEquals(1, result.getBuildSet().size());
         assertTrue(result.getBuildSet().contains(projectA));
@@ -171,14 +160,11 @@ class ReactorTrimmerTest {
     @Test
     void computeBuildSet_backwardCompatibleOverload() {
         MavenProject projectA = createProject("com.example", "module-a");
-        List<MavenProject> sortedProjects = Collections.singletonList(projectA);
+        List<MavenProject> sortedProjects = List.of(projectA);
 
-        ProjectDependencyGraph graph = new TestDependencyGraph(
-                sortedProjects,
-                Collections.<MavenProject, List<MavenProject>>emptyMap(),
-                Collections.<MavenProject, List<MavenProject>>emptyMap());
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, Map.of(), Map.of());
 
-        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
         ScalpelConfiguration config = configWith(true, true);
 
         // Use the 3-arg overload (no testOnlyProjects)
@@ -196,21 +182,19 @@ class ReactorTrimmerTest {
         addDependency(projectC, "com.example", "module-a", "compile");
 
         // Sorted order: A, B, C
-        List<MavenProject> sortedProjects = Arrays.asList(projectA, projectB, projectC);
+        List<MavenProject> sortedProjects = List.of(projectA, projectB, projectC);
         Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
-        downstreamMap.put(projectA, Collections.singletonList(projectC));
+        downstreamMap.put(projectA, List.of(projectC));
 
-        ProjectDependencyGraph graph = new TestDependencyGraph(
-                sortedProjects, downstreamMap, Collections.<MavenProject, List<MavenProject>>emptyMap());
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
 
-        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Collections.singleton(projectA));
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
         ScalpelConfiguration config = configWith(true, true);
 
-        TrimResult result =
-                trimmer.computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, Set.of(), graph, config);
 
         // B should not be in the build set, only A and C
-        assertEquals(Arrays.asList(projectA, projectC), result.getBuildSet());
+        assertEquals(List.of(projectA, projectC), result.getBuildSet());
     }
 
     // --- Helper methods ---
@@ -277,13 +261,13 @@ class ReactorTrimmerTest {
         @Override
         public List<MavenProject> getDownstreamProjects(MavenProject project, boolean transitive) {
             List<MavenProject> result = downstreamMap.get(project);
-            return result != null ? result : new ArrayList<MavenProject>();
+            return result != null ? result : new ArrayList<>();
         }
 
         @Override
         public List<MavenProject> getUpstreamProjects(MavenProject project, boolean transitive) {
             List<MavenProject> result = upstreamMap.get(project);
-            return result != null ? result : new ArrayList<MavenProject>();
+            return result != null ? result : new ArrayList<>();
         }
     }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -24,8 +24,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -78,61 +76,69 @@ class ScalpelLifecycleParticipantTest {
         Files.createDirectories(root);
 
         // Old parent POM (before property change)
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module><module>module-c</module></modules>\n"
-                + "  <properties>\n"
-                + "    <lib.version>1.0</lib.version>\n"
-                + "  </properties>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>commons-lang</groupId>\n"
-                + "      <artifactId>commons-lang</artifactId>\n"
-                + "      <version>${lib.version}</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module><module>module-c</module></modules>
+                  <properties>
+                    <lib.version>1.0</lib.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>commons-lang</groupId>
+                      <artifactId>commons-lang</artifactId>
+                      <version>${lib.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
 
         // New parent POM (after property change)
         String newParentPom = oldParentPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
         writePom(root, "pom.xml", newParentPom);
 
         // module-a: directly uses managed dep commons-lang
-        String moduleAPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencies>
+                    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root, "module-a/pom.xml", moduleAPom);
 
         // module-b: depends on module-a (gets commons-lang transitively)
-        String moduleBPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root, "module-b/pom.xml", moduleBPom);
 
         // module-c: no dependencies
-        String moduleCPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-c</artifactId>\n"
-                + "</project>\n";
+        String moduleCPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-c</artifactId>
+                </project>
+                """;
         writePom(root, "module-c/pom.xml", moduleCPom);
 
         // Build MavenProject objects
@@ -145,7 +151,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
         moduleC.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB, moduleC);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleC);
 
         // Mock ScalpelCore to return changed files
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -159,12 +165,11 @@ class ScalpelLifecycleParticipantTest {
         DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
         org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
                 new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
-        when(moduleBResolution.getResolvedDependencies()).thenReturn(Collections.singletonList(commonsLangDep));
+        when(moduleBResolution.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
 
         // Mock dependency resolution: module-c has no matching deps
         DependencyResolutionResult moduleCResolution = mock(DependencyResolutionResult.class);
-        when(moduleCResolution.getResolvedDependencies())
-                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(moduleCResolution.getResolvedDependencies()).thenReturn(List.of());
 
         // Route resolution calls based on project
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
@@ -187,8 +192,8 @@ class ScalpelLifecycleParticipantTest {
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -222,52 +227,58 @@ class ScalpelLifecycleParticipantTest {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <compiler.version>3.11.0</compiler.version>\n"
-                + "  </properties>\n"
-                + "  <build><pluginManagement><plugins>\n"
-                + "    <plugin>\n"
-                + "      <groupId>org.apache.maven.plugins</groupId>\n"
-                + "      <artifactId>maven-compiler-plugin</artifactId>\n"
-                + "      <version>${compiler.version}</version>\n"
-                + "    </plugin>\n"
-                + "  </plugins></pluginManagement></build>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <compiler.version>3.11.0</compiler.version>
+                  </properties>
+                  <build><pluginManagement><plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <version>${compiler.version}</version>
+                    </plugin>
+                  </plugins></pluginManagement></build>
+                </project>
+                """;
 
         String newParentPom = oldParentPom.replace(
                 "<compiler.version>3.11.0</compiler.version>", "<compiler.version>3.12.0</compiler.version>");
         writePom(root, "pom.xml", newParentPom);
 
         // module-a: no plugins
-        String moduleAPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root, "module-a/pom.xml", moduleAPom);
 
         // module-b: uses maven-compiler-plugin
-        String moduleBPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <build><plugins>\n"
-                + "    <plugin>\n"
-                + "      <groupId>org.apache.maven.plugins</groupId>\n"
-                + "      <artifactId>maven-compiler-plugin</artifactId>\n"
-                + "    </plugin>\n"
-                + "  </plugins></build>\n"
-                + "</project>\n";
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <build><plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                    </plugin>
+                  </plugins></build>
+                </project>
+                """;
         writePom(root, "module-b/pom.xml", moduleBPom);
 
         MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
@@ -289,7 +300,7 @@ class ScalpelLifecycleParticipantTest {
         build.addPlugin(compilerPlugin);
         moduleB.getModel().setBuild(build);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("pom.xml");
@@ -300,8 +311,7 @@ class ScalpelLifecycleParticipantTest {
 
         // No transitive deps to resolve
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies())
-                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
 
@@ -317,8 +327,8 @@ class ScalpelLifecycleParticipantTest {
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
         ProjectDependencyGraph graph2 = mock(ProjectDependencyGraph.class);
-        when(graph2.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(graph2.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph2.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph2.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph2.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph2);
 
@@ -339,31 +349,37 @@ class ScalpelLifecycleParticipantTest {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 
-        String parentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
+        String parentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                </project>
+                """;
         writePom(root, "pom.xml", parentPom);
 
-        String moduleAPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root, "module-a/pom.xml", moduleAPom);
 
-        String moduleBPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root, "module-b/pom.xml", moduleBPom);
 
         MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
@@ -373,18 +389,17 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // module-a: test-only change (src/test/), module-b: main source change
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/test/java/com/example/MyTest.java");
         changedFiles.add("module-b/src/main/java/com/example/Service.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
 
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies())
-                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
 
@@ -400,8 +415,8 @@ class ScalpelLifecycleParticipantTest {
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -430,48 +445,54 @@ class ScalpelLifecycleParticipantTest {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties>\n"
-                + "    <lib.version>1.0</lib.version>\n"
-                + "  </properties>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency>\n"
-                + "      <groupId>commons-lang</groupId>\n"
-                + "      <artifactId>commons-lang</artifactId>\n"
-                + "      <version>${lib.version}</version>\n"
-                + "    </dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <lib.version>1.0</lib.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>commons-lang</groupId>
+                      <artifactId>commons-lang</artifactId>
+                      <version>${lib.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
 
         String newParentPom = oldParentPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
         writePom(root, "pom.xml", newParentPom);
 
         // module-a: uses managed dep directly
-        String moduleAPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencies>
+                    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root, "module-a/pom.xml", moduleAPom);
 
         // module-b: gets commons-lang only via test scope transitively
-        String moduleBPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "</project>\n";
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
         writePom(root, "module-b/pom.xml", moduleBPom);
 
         MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
@@ -481,7 +502,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("pom.xml");
@@ -494,7 +515,7 @@ class ScalpelLifecycleParticipantTest {
         DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
         org.eclipse.aether.graph.Dependency testDep = new org.eclipse.aether.graph.Dependency(
                 new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "test");
-        when(moduleBResolution.getResolvedDependencies()).thenReturn(Collections.singletonList(testDep));
+        when(moduleBResolution.getResolvedDependencies()).thenReturn(List.of(testDep));
 
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenAnswer(invocation -> {
@@ -503,8 +524,7 @@ class ScalpelLifecycleParticipantTest {
                         return moduleBResolution;
                     }
                     DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
-                    when(empty.getResolvedDependencies())
-                            .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+                    when(empty.getResolvedDependencies()).thenReturn(List.of());
                     return empty;
                 });
 
@@ -520,8 +540,8 @@ class ScalpelLifecycleParticipantTest {
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -542,35 +562,41 @@ class ScalpelLifecycleParticipantTest {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 
-        String parentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "</project>\n";
+        String parentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                </project>
+                """;
         writePom(root, "pom.xml", parentPom);
 
-        String moduleAPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "</project>\n";
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
         writePom(root, "module-a/pom.xml", moduleAPom);
 
         // module-b depends on module-a via test scope
-        String moduleBPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version><scope>test</scope></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version><scope>test</scope></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root, "module-b/pom.xml", moduleBPom);
 
         MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
@@ -587,17 +613,16 @@ class ScalpelLifecycleParticipantTest {
         dep.setScope("test");
         moduleB.getDependencies().add(dep);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // module-a has a source change
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/com/example/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
 
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies())
-                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
 
@@ -615,9 +640,9 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-b is downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -658,12 +683,12 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "trim");
@@ -697,12 +722,12 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
@@ -733,12 +758,12 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "report");
@@ -767,13 +792,13 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add(".github/workflows/ci.yml");
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "report");
@@ -806,13 +831,13 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/README.md");
         changedFiles.add("module-b/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "report");
@@ -838,69 +863,78 @@ class ScalpelLifecycleParticipantTest {
         Files.createDirectories(root);
 
         // Parent POM (no managed deps — those are in the BOM)
-        String parentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>bom</module><module>module-a</module><module>module-b</module><module>module-c</module></modules>\n"
-                + "</project>\n";
+        String parentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>bom</module><module>module-a</module><module>module-b</module><module>module-c</module></modules>
+                </project>
+                """;
         writePom(root, "pom.xml", parentPom);
 
         // Old BOM POM (before version change)
-        String oldBomPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>bom</artifactId>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <properties><lib.version>1.0</lib.version></properties>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId><version>${lib.version}</version></dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "</project>\n";
+        String oldBomPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>bom</artifactId>
+                  <packaging>pom</packaging>
+                  <properties><lib.version>1.0</lib.version></properties>
+                  <dependencyManagement><dependencies>
+                    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId><version>${lib.version}</version></dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
 
         // New BOM POM (after version bump)
         String newBomPom = oldBomPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
         writePom(root, "bom/pom.xml", newBomPom);
 
         // module-a: imports BOM, uses commons-lang
-        String moduleAPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-a</artifactId>\n"
-                + "  <dependencyManagement><dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>bom</artifactId>"
-                + "<version>${project.version}</version><type>pom</type><scope>import</scope></dependency>\n"
-                + "  </dependencies></dependencyManagement>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencyManagement><dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>bom</artifactId><version>${project.version}</version><type>pom</type><scope>import</scope></dependency>
+                  </dependencies></dependencyManagement>
+                  <dependencies>
+                    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root, "module-a/pom.xml", moduleAPom);
 
         // module-b: depends on module-a (gets commons-lang transitively)
-        String moduleBPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies>\n"
-                + "    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version></dependency>\n"
-                + "  </dependencies>\n"
-                + "</project>\n";
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version></dependency>
+                  </dependencies>
+                </project>
+                """;
         writePom(root, "module-b/pom.xml", moduleBPom);
 
         // module-c: no dependencies
-        String moduleCPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-c</artifactId>\n"
-                + "</project>\n";
+        String moduleCPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-c</artifactId>
+                </project>
+                """;
         writePom(root, "module-c/pom.xml", moduleCPom);
 
         // Build MavenProject objects
@@ -916,7 +950,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
         moduleC.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, bomProject, moduleA, moduleB, moduleC);
+        List<MavenProject> allProjects = List.of(parentProject, bomProject, moduleA, moduleB, moduleC);
 
         // Mock ScalpelCore to return changed BOM POM
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -930,12 +964,11 @@ class ScalpelLifecycleParticipantTest {
         DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
         org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
                 new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
-        when(moduleBResolution.getResolvedDependencies()).thenReturn(Collections.singletonList(commonsLangDep));
+        when(moduleBResolution.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
 
         // Other modules: no matching deps
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies())
-                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
 
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenAnswer(invocation -> {
@@ -958,8 +991,8 @@ class ScalpelLifecycleParticipantTest {
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1012,12 +1045,12 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
         moduleC.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB, moduleC);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleC);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
@@ -1025,11 +1058,11 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-b and module-c are downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Arrays.asList(moduleB, moduleC));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(moduleC, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB, moduleC));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(moduleC, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1068,12 +1101,12 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
@@ -1081,8 +1114,8 @@ class ScalpelLifecycleParticipantTest {
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-a");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1115,22 +1148,22 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "com.example:module-b");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1161,22 +1194,22 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "report");
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1202,11 +1235,15 @@ class ScalpelLifecycleParticipantTest {
         writePom(root, "pom.xml", parentPom);
         String moduleAPom = simpleChildPom("module-a");
         writePom(root, "module-a/pom.xml", moduleAPom);
-        String moduleBPom = "<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>module-b</artifactId>\n"
-                + "  <dependencies><dependency><groupId>com.example</groupId><artifactId>module-a</artifactId>"
-                + "<version>1.0</version><scope>test</scope></dependency></dependencies>\n</project>\n";
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies><dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version><scope>test</scope></dependency></dependencies>
+                </project>
+                """;
         writePom(root, "module-b/pom.xml", moduleBPom);
 
         MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
@@ -1222,22 +1259,22 @@ class ScalpelLifecycleParticipantTest {
         dep.setScope("test");
         moduleB.getDependencies().add(dep);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "report");
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1261,21 +1298,21 @@ class ScalpelLifecycleParticipantTest {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 
-        String oldParentPom = "<?xml version=\"1.0\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <groupId>com.example</groupId>\n"
-                + "  <artifactId>parent</artifactId>\n"
-                + "  <version>1.0</version>\n"
-                + "  <packaging>pom</packaging>\n"
-                + "  <modules><module>module-a</module><module>module-b</module></modules>\n"
-                + "  <properties><compiler.version>3.11.0</compiler.version></properties>\n"
-                + "  <build><pluginManagement><plugins>\n"
-                + "    <plugin><groupId>org.apache.maven.plugins</groupId>"
-                + "<artifactId>maven-compiler-plugin</artifactId>"
-                + "<version>${compiler.version}</version></plugin>\n"
-                + "  </plugins></pluginManagement></build>\n"
-                + "</project>\n";
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties><compiler.version>3.11.0</compiler.version></properties>
+                  <build><pluginManagement><plugins>
+                    <plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-compiler-plugin</artifactId><version>${compiler.version}</version></plugin>
+                  </plugins></pluginManagement></build>
+                </project>
+                """;
 
         String newParentPom = oldParentPom.replace(
                 "<compiler.version>3.11.0</compiler.version>", "<compiler.version>3.12.0</compiler.version>");
@@ -1301,7 +1338,7 @@ class ScalpelLifecycleParticipantTest {
         build.addPlugin(compilerPlugin);
         moduleB.getModel().setBuild(build);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // Changed files: parent POM (property change) + module-a source
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1318,10 +1355,10 @@ class ScalpelLifecycleParticipantTest {
 
         // module-b is downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.singletonList(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1354,7 +1391,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // Only module-a has a source change
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1392,7 +1429,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         // Changes include an excluded path and a module source
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1435,7 +1472,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // A CI config file changed, matching the disable trigger
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1470,7 +1507,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         // Null detection result (e.g., no git repo or no base branch)
         when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
@@ -1500,7 +1537,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         MavenSession session = createSimpleSession(root, allProjects, "trim");
         session.getSystemProperties().setProperty("scalpel.enabled", "false");
@@ -1527,13 +1564,13 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         MavenSession session = createSimpleSession(root, allProjects, "trim");
         session.getSystemProperties().setProperty("scalpel.disableOnSelectedProjects", "true");
 
         // Simulate -pl by setting selected projects
-        when(session.getRequest().getSelectedProjects()).thenReturn(Collections.singletonList("module-a"));
+        when(session.getRequest().getSelectedProjects()).thenReturn(List.of("module-a"));
 
         participant.afterProjectsRead(session);
 
@@ -1557,7 +1594,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         // No changed files
         when(scalpelCore.detectChanges(any(), any(), any()))
@@ -1589,7 +1626,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         // Only .md files changed
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1628,7 +1665,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add(".github/workflows/ci.yml");
@@ -1663,7 +1700,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         // Provide invalid old POM content to trigger a parse error
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1703,7 +1740,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // Change a file that doesn't map to any module (e.g. root-level non-pom file)
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1746,7 +1783,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
@@ -1784,7 +1821,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // module-b has source changes, module-a is upstream
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1799,10 +1836,10 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-a is upstream of module-b
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(Collections.singletonList(moduleA));
-        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(List.of(moduleA));
+        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1843,7 +1880,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
         moduleC.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB, moduleC);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleC);
 
         // module-b has source changes
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1860,14 +1897,14 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-a is upstream of module-b, module-c is downstream of module-b
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(Collections.singletonList(moduleA));
-        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(moduleC, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(Collections.singletonList(moduleC));
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(moduleC, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
+        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(List.of(moduleA));
+        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(moduleC, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of(moduleC));
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(moduleC, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -1935,7 +1972,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // Only parent POM changed
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -1975,7 +2012,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
         moduleA.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("Jenkinsfile");
@@ -2013,7 +2050,7 @@ class ScalpelLifecycleParticipantTest {
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
 
-        List<MavenProject> allProjects = Arrays.asList(parentProject, moduleA, moduleB);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
         // module-b has source changes, module-a is upstream
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -2027,10 +2064,10 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-a is upstream of module-b
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(Collections.singletonList(moduleA));
-        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(Collections.<MavenProject>emptyList());
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(List.of(moduleA));
+        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -2050,8 +2087,7 @@ class ScalpelLifecycleParticipantTest {
 
     private void setupEmptyDependencyResolution() throws Exception {
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies())
-                .thenReturn(Collections.<org.eclipse.aether.graph.Dependency>emptyList());
+        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
     }
@@ -2069,8 +2105,8 @@ class ScalpelLifecycleParticipantTest {
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(Collections.emptyList());
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
         return session;
@@ -2089,17 +2125,32 @@ class ScalpelLifecycleParticipantTest {
     }
 
     private String simpleChildPom(String artifactId) {
-        return "<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>" + artifactId + "</artifactId>\n</project>\n";
+        return """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>""" + artifactId + """
+                </artifactId>
+                </project>
+                """;
     }
 
     private String simpleChildPomWithDep(String artifactId, String depArtifactId) {
-        return "<?xml version=\"1.0\"?>\n<project>\n  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>\n"
-                + "  <artifactId>" + artifactId + "</artifactId>\n"
-                + "  <dependencies><dependency><groupId>com.example</groupId><artifactId>" + depArtifactId
-                + "</artifactId><version>1.0</version></dependency></dependencies>\n</project>\n";
+        return """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>"""
+                + artifactId
+                + "</artifactId>\n"
+                + "  <dependencies><dependency><groupId>com.example</groupId><artifactId>"
+                + depArtifactId
+                + """
+                </artifactId><version>1.0</version></dependency></dependencies>
+                </project>
+                """;
     }
 
     private void writePom(Path root, String relativePath, String content) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <project.build.outputTimestamp>2025-12-19T13:39:09Z</project.build.outputTimestamp>
 
     <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.testRelease>21</maven.compiler.testRelease>
     <requireRuntimeMavenVersion.range>[3.9,)</requireRuntimeMavenVersion.range>
 
     <!-- Maven 3 versions -->
@@ -138,6 +139,11 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
+        <version>6.0.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
         <version>6.0.3</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- Set `maven.compiler.testRelease=21` so tests can use JDK 21 language features while main jars remain at Java 8 bytecode (same approach as Domtrip)
- Convert all multi-line XML string concatenations to text blocks (`"""..."""`) in PomChangeAnalyzerTest and ScalpelLifecycleParticipantTest
- Replace `Collections.singletonList()`, `Arrays.asList()`, `Collections.singleton()`, `Collections.emptyList()`, etc. with `List.of()`, `Set.of()`, `Map.of()` across all 6 test files

## Test plan
- [x] `mvn verify -B` passes (all modules, all tests)
- [x] Main jar bytecode target unchanged (Java 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Modernized test code to use Java 9+ immutable collection factories, text blocks, and cleaner generics; minor test cleanups and mock updates.
* **Chores**
  * Test compilation set to Java 21 while production targets Java 8.
  * Added JUnit Jupiter parameterized-tests support for test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->