### PR TITLE
Fix non-git-repo test failing in CI

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -57,7 +57,7 @@ public class ScalpelCore {
         Repository repository;
         try {
             repository = openRepository(reactorRoot);
-        } catch (RepositoryNotFoundException e) {
+        } catch (RepositoryNotFoundException | IllegalArgumentException e) {
             logger.info("Scalpel: Not a git repository, building all modules");
             return null;
         } catch (IOException e) {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
@@ -152,18 +153,21 @@ class ScalpelCoreTest {
 
     @Test
     void detectChanges_notAGitRepo_returnsNull() throws Exception {
-        // A directory that is not a git repo
-        Path nonGitDir = tempDir.resolve("not-a-repo");
-        Files.createDirectories(nonGitDir);
+        // Create a temp directory outside the project tree to avoid JGit walking up
+        // and discovering the project's own .git (java.io.tmpdir may be inside the repo)
+        Path nonGitDir = Files.createTempDirectory(Paths.get("/tmp"), "scalpel-test-no-git");
+        try {
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
 
-        ScalpelCore core = new ScalpelCore(new GitChangeDetector());
-        Properties sys = new Properties();
-        sys.setProperty("scalpel.baseBranch", "main");
-        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+            ChangeDetectionResult result = core.detectChanges(nonGitDir, config, Set.of());
 
-        ChangeDetectionResult result = core.detectChanges(nonGitDir, config, Set.of());
-
-        assertNull(result, "Should return null for non-git directory");
+            assertNull(result, "Should return null for non-git directory");
+        } finally {
+            Files.deleteIfExists(nonGitDir);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fix `ScalpelCoreTest.detectChanges_notAGitRepo_returnsNull` failing because Surefire sets `java.io.tmpdir` to `target/surefire-tmp` (inside the git work tree), causing JGit's `findGitDir()` to discover the parent repo
- Use `/tmp` for the test's temp directory to ensure isolation from any parent git repo
- Catch `IllegalArgumentException` in `detectChanges()` since JGit throws it (not `RepositoryNotFoundException`) when no git dir is found by the builder

## Test plan
- [x] `ScalpelCoreTest.detectChanges_notAGitRepo_returnsNull` passes locally
- [x] All 71 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced exception handling during repository detection to treat certain error conditions consistently with non-git repositories, improving robustness when building modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->