### PR TITLE
Fix git worktree detection by opening repo from common directory

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -226,54 +226,55 @@ public class ScalpelCore {
         Path gitDirPath = gitDir.toPath();
         Path commondirFile = gitDirPath.resolve("commondir");
         if (Files.isRegularFile(commondirFile)) {
-            logger.debug("Detected git worktree, gitdir={}", gitDir);
-
-            // Read worktree HEAD (e.g., "ref: refs/heads/feature")
-            String currentBranch = null;
-            String headRef = null;
-            Path worktreeHead = gitDirPath.resolve("HEAD");
-            if (Files.isRegularFile(worktreeHead)) {
-                String headContent = new String(Files.readAllBytes(worktreeHead), StandardCharsets.UTF_8).trim();
-                if (headContent.startsWith("ref: ")) {
-                    headRef = headContent.substring(5);
-                    if (headRef.startsWith("refs/heads/")) {
-                        currentBranch = headRef.substring("refs/heads/".length());
-                    }
-                } else {
-                    headRef = headContent;
-                }
-            }
-
-            // Resolve common directory (the main .git/)
-            String commondirValue = new String(Files.readAllBytes(commondirFile), StandardCharsets.UTF_8).trim();
-            Path commonDir = Paths.get(commondirValue);
-            if (!commonDir.isAbsolute()) {
-                commonDir = gitDirPath.resolve(commondirValue);
-            }
-            File commonDirFile = commonDir.toRealPath().toFile();
-
-            // Resolve worktree root from gitdir pointer
-            Path gitdirPointer = gitDirPath.resolve("gitdir");
-            File workTree = null;
-            if (Files.isRegularFile(gitdirPointer)) {
-                String dotGitPath = new String(Files.readAllBytes(gitdirPointer), StandardCharsets.UTF_8).trim();
-                Path dotGitFile = Paths.get(dotGitPath);
-                if (!dotGitFile.isAbsolute()) {
-                    dotGitFile = gitDirPath.resolve(dotGitPath);
-                }
-                workTree = dotGitFile.toRealPath().getParent().toFile();
-            }
-
-            FileRepositoryBuilder worktreeBuilder =
-                    new FileRepositoryBuilder().readEnvironment().setGitDir(commonDirFile);
-            if (workTree != null) {
-                worktreeBuilder.setWorkTree(workTree);
-            }
-            Repository repository = worktreeBuilder.setMustExist(true).build();
-            return new RepositoryInfo(repository, true, currentBranch, headRef);
+            return openWorktreeRepository(gitDirPath, commondirFile);
         }
 
         return new RepositoryInfo(builder.setMustExist(true).build(), false, null, null);
+    }
+
+    private RepositoryInfo openWorktreeRepository(Path gitDirPath, Path commondirFile) throws IOException {
+        logger.debug("Detected git worktree, gitdir={}", gitDirPath);
+
+        String currentBranch = null;
+        String headRef = null;
+        Path worktreeHead = gitDirPath.resolve("HEAD");
+        if (Files.isRegularFile(worktreeHead)) {
+            String headContent = new String(Files.readAllBytes(worktreeHead), StandardCharsets.UTF_8).trim();
+            if (headContent.startsWith("ref: ")) {
+                headRef = headContent.substring(5);
+                if (headRef.startsWith("refs/heads/")) {
+                    currentBranch = headRef.substring("refs/heads/".length());
+                }
+            } else {
+                headRef = headContent;
+            }
+        }
+
+        File commonDirFile = resolvePathFromFile(commondirFile, gitDirPath).toFile();
+
+        Path gitdirPointer = gitDirPath.resolve("gitdir");
+        File workTree = null;
+        if (Files.isRegularFile(gitdirPointer)) {
+            workTree =
+                    resolvePathFromFile(gitdirPointer, gitDirPath).getParent().toFile();
+        }
+
+        FileRepositoryBuilder worktreeBuilder =
+                new FileRepositoryBuilder().readEnvironment().setGitDir(commonDirFile);
+        if (workTree != null) {
+            worktreeBuilder.setWorkTree(workTree);
+        }
+        Repository repository = worktreeBuilder.setMustExist(true).build();
+        return new RepositoryInfo(repository, true, currentBranch, headRef);
+    }
+
+    private static Path resolvePathFromFile(Path file, Path baseDir) throws IOException {
+        String value = new String(Files.readAllBytes(file), StandardCharsets.UTF_8).trim();
+        Path path = Paths.get(value);
+        if (!path.isAbsolute()) {
+            path = baseDir.resolve(value);
+        }
+        return path.toRealPath();
     }
 
     private ChangeDetectionResult handleError(ScalpelConfiguration config, String message, Exception e)

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -67,9 +67,8 @@ public class ScalpelCore {
         try {
             // Check branch-based disable conditions
             if (!config.getDisableOnBranch().isEmpty()) {
-                String currentBranch = repoInfo.currentBranch != null
-                        ? repoInfo.currentBranch
-                        : gitChangeDetector.getCurrentBranch(repository);
+                String currentBranch =
+                        repoInfo.worktree ? repoInfo.currentBranch : gitChangeDetector.getCurrentBranch(repository);
                 if (currentBranch != null) {
                     for (String pattern : config.getDisableOnBranch()) {
                         if (matchesSafely(currentBranch, pattern, "disableOnBranch")) {
@@ -126,10 +125,11 @@ public class ScalpelCore {
                 }
             }
 
-            // For worktrees, use the worktree's head ref instead of HEAD
+            // For worktrees, replace HEAD in revspecs with the worktree's head ref
+            // (e.g., "HEAD" -> "refs/heads/feature", "HEAD~1" -> "refs/heads/feature~1")
             String head = config.getHead();
-            if (repoInfo.headRef != null && "HEAD".equals(head)) {
-                head = repoInfo.headRef;
+            if (repoInfo.headRef != null && head.startsWith("HEAD")) {
+                head = repoInfo.headRef + head.substring("HEAD".length());
             }
 
             ObjectId mergeBase = gitChangeDetector.findMergeBase(repository, baseBranch, head);
@@ -197,11 +197,13 @@ public class ScalpelCore {
 
     private static class RepositoryInfo {
         final Repository repository;
+        final boolean worktree;
         final String currentBranch;
         final String headRef;
 
-        RepositoryInfo(Repository repository, String currentBranch, String headRef) {
+        RepositoryInfo(Repository repository, boolean worktree, String currentBranch, String headRef) {
             this.repository = repository;
+            this.worktree = worktree;
             this.currentBranch = currentBranch;
             this.headRef = headRef;
         }
@@ -234,8 +236,9 @@ public class ScalpelCore {
                 String headContent = new String(Files.readAllBytes(worktreeHead), StandardCharsets.UTF_8).trim();
                 if (headContent.startsWith("ref: ")) {
                     headRef = headContent.substring(5);
-                    int lastSlash = headRef.lastIndexOf('/');
-                    currentBranch = lastSlash >= 0 ? headRef.substring(lastSlash + 1) : headRef;
+                    if (headRef.startsWith("refs/heads/")) {
+                        currentBranch = headRef.substring("refs/heads/".length());
+                    }
                 } else {
                     headRef = headContent;
                 }
@@ -267,10 +270,10 @@ public class ScalpelCore {
                 worktreeBuilder.setWorkTree(workTree);
             }
             Repository repository = worktreeBuilder.setMustExist(true).build();
-            return new RepositoryInfo(repository, currentBranch, headRef);
+            return new RepositoryInfo(repository, true, currentBranch, headRef);
         }
 
-        return new RepositoryInfo(builder.setMustExist(true).build(), null, null);
+        return new RepositoryInfo(builder.setMustExist(true).build(), false, null, null);
     }
 
     private ChangeDetectionResult handleError(ScalpelConfiguration config, String message, Exception e)

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -9,7 +9,6 @@ package eu.maveniverse.maven.scalpel.core;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,9 +53,9 @@ public class ScalpelCore {
      */
     public ChangeDetectionResult detectChanges(Path reactorRoot, ScalpelConfiguration config, Set<String> allPomPaths)
             throws ScalpelException {
-        Repository repository;
+        RepositoryInfo repoInfo;
         try {
-            repository = openRepository(reactorRoot);
+            repoInfo = openRepository(reactorRoot);
         } catch (RepositoryNotFoundException | IllegalArgumentException e) {
             logger.info("Scalpel: Not a git repository, building all modules");
             return null;
@@ -64,10 +63,13 @@ public class ScalpelCore {
             return handleError(config, "Error opening git repository", e);
         }
 
+        Repository repository = repoInfo.repository;
         try {
             // Check branch-based disable conditions
             if (!config.getDisableOnBranch().isEmpty()) {
-                String currentBranch = gitChangeDetector.getCurrentBranch(repository);
+                String currentBranch = repoInfo.currentBranch != null
+                        ? repoInfo.currentBranch
+                        : gitChangeDetector.getCurrentBranch(repository);
                 if (currentBranch != null) {
                     for (String pattern : config.getDisableOnBranch()) {
                         if (matchesSafely(currentBranch, pattern, "disableOnBranch")) {
@@ -124,7 +126,12 @@ public class ScalpelCore {
                 }
             }
 
+            // For worktrees, use the worktree's head ref instead of HEAD
             String head = config.getHead();
+            if (repoInfo.headRef != null && "HEAD".equals(head)) {
+                head = repoInfo.headRef;
+            }
+
             ObjectId mergeBase = gitChangeDetector.findMergeBase(repository, baseBranch, head);
             if (mergeBase == null) {
                 if (config.isFailSafe()) {
@@ -188,53 +195,82 @@ public class ScalpelCore {
         }
     }
 
-    private Repository openRepository(Path reactorRoot) throws IOException {
+    private static class RepositoryInfo {
+        final Repository repository;
+        final String currentBranch;
+        final String headRef;
+
+        RepositoryInfo(Repository repository, String currentBranch, String headRef) {
+            this.repository = repository;
+            this.currentBranch = currentBranch;
+            this.headRef = headRef;
+        }
+    }
+
+    private RepositoryInfo openRepository(Path reactorRoot) throws IOException {
         FileRepositoryBuilder builder =
                 new FileRepositoryBuilder().readEnvironment().findGitDir(reactorRoot.toFile());
 
         File gitDir = builder.getGitDir();
-
-        // Handle git worktrees: .git may be a file containing "gitdir: <path>"
-        // JGit 5.x does not support worktrees natively, so we handle it manually
         if (gitDir == null) {
-            File dotGit = findDotGit(reactorRoot.toFile());
-            if (dotGit != null && dotGit.isFile()) {
-                String gitDirPath = readGitDirFromFile(dotGit);
-                if (gitDirPath != null) {
-                    Path resolvedPath = Paths.get(gitDirPath);
-                    if (!resolvedPath.isAbsolute()) {
-                        resolvedPath = dotGit.getParentFile().toPath().resolve(gitDirPath);
-                    }
-                    File resolved = resolvedPath.toFile();
-                    logger.debug("Detected git worktree, gitdir={}", resolved);
-                    builder.setGitDir(resolved);
+            throw new RepositoryNotFoundException(reactorRoot.toFile());
+        }
+
+        // JGit 5.x findGitDir() correctly follows .git files (worktree pointers)
+        // to .git/worktrees/<name>/, but JGit 5.x lacks commondir support, so
+        // refs and objects from the common directory are invisible. To work around
+        // this, we open the repository from the common directory (the main .git/)
+        // and separately read the worktree's HEAD for branch/head resolution.
+        Path gitDirPath = gitDir.toPath();
+        Path commondirFile = gitDirPath.resolve("commondir");
+        if (Files.isRegularFile(commondirFile)) {
+            logger.debug("Detected git worktree, gitdir={}", gitDir);
+
+            // Read worktree HEAD (e.g., "ref: refs/heads/feature")
+            String currentBranch = null;
+            String headRef = null;
+            Path worktreeHead = gitDirPath.resolve("HEAD");
+            if (Files.isRegularFile(worktreeHead)) {
+                String headContent = new String(Files.readAllBytes(worktreeHead), StandardCharsets.UTF_8).trim();
+                if (headContent.startsWith("ref: ")) {
+                    headRef = headContent.substring(5);
+                    int lastSlash = headRef.lastIndexOf('/');
+                    currentBranch = lastSlash >= 0 ? headRef.substring(lastSlash + 1) : headRef;
+                } else {
+                    headRef = headContent;
                 }
             }
-        }
 
-        return builder.setMustExist(true).build();
-    }
-
-    private static File findDotGit(File dir) {
-        Path current = dir.toPath();
-        while (current != null) {
-            Path dotGit = current.resolve(".git");
-            if (Files.exists(dotGit)) {
-                return dotGit.toFile();
+            // Resolve common directory (the main .git/)
+            String commondirValue = new String(Files.readAllBytes(commondirFile), StandardCharsets.UTF_8).trim();
+            Path commonDir = Paths.get(commondirValue);
+            if (!commonDir.isAbsolute()) {
+                commonDir = gitDirPath.resolve(commondirValue);
             }
-            current = current.getParent();
-        }
-        return null;
-    }
+            File commonDirFile = commonDir.toRealPath().toFile();
 
-    private static String readGitDirFromFile(File dotGitFile) throws IOException {
-        try (BufferedReader reader = Files.newBufferedReader(dotGitFile.toPath(), StandardCharsets.UTF_8)) {
-            String line = reader.readLine();
-            if (line != null && line.startsWith("gitdir:")) {
-                return line.substring("gitdir:".length()).trim();
+            // Resolve worktree root from gitdir pointer
+            Path gitdirPointer = gitDirPath.resolve("gitdir");
+            File workTree = null;
+            if (Files.isRegularFile(gitdirPointer)) {
+                String dotGitPath = new String(Files.readAllBytes(gitdirPointer), StandardCharsets.UTF_8).trim();
+                Path dotGitFile = Paths.get(dotGitPath);
+                if (!dotGitFile.isAbsolute()) {
+                    dotGitFile = gitDirPath.resolve(dotGitPath);
+                }
+                workTree = dotGitFile.toRealPath().getParent().toFile();
             }
+
+            FileRepositoryBuilder worktreeBuilder =
+                    new FileRepositoryBuilder().readEnvironment().setGitDir(commonDirFile);
+            if (workTree != null) {
+                worktreeBuilder.setWorkTree(workTree);
+            }
+            Repository repository = worktreeBuilder.setMustExist(true).build();
+            return new RepositoryInfo(repository, currentBranch, headRef);
         }
-        return null;
+
+        return new RepositoryInfo(builder.setMustExist(true).build(), null, null);
     }
 
     private ChangeDetectionResult handleError(ScalpelConfiguration config, String message, Exception e)

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -7,6 +7,7 @@
  */
 package eu.maveniverse.maven.scalpel.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -206,7 +207,7 @@ class ScalpelCoreTest {
                 .start();
         process.getInputStream().readAllBytes();
         int exitCode = process.waitFor();
-        assertTrue(exitCode == 0, "git worktree add should succeed, exit code: " + exitCode);
+        assertEquals(0, exitCode, "git worktree add should succeed");
 
         // Make a change in the worktree using git commands
         Files.write(worktreeDir.resolve("new-file.txt"), "world".getBytes(StandardCharsets.UTF_8));
@@ -215,14 +216,14 @@ class ScalpelCoreTest {
                 .redirectErrorStream(true)
                 .start();
         byte[] addOutput = add.getInputStream().readAllBytes();
-        assertTrue(add.waitFor() == 0, "git add failed: " + new String(addOutput, StandardCharsets.UTF_8));
+        assertEquals(0, add.waitFor(), "git add failed: " + new String(addOutput, StandardCharsets.UTF_8));
 
         Process commit = new ProcessBuilder("git", "commit", "-m", "add new file")
                 .directory(worktreeDir.toFile())
                 .redirectErrorStream(true)
                 .start();
         byte[] commitOutput = commit.getInputStream().readAllBytes();
-        assertTrue(commit.waitFor() == 0, "git commit failed: " + new String(commitOutput, StandardCharsets.UTF_8));
+        assertEquals(0, commit.waitFor(), "git commit failed: " + new String(commitOutput, StandardCharsets.UTF_8));
 
         ScalpelCore core = new ScalpelCore(new GitChangeDetector());
         Properties sys = new Properties();

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -189,6 +189,10 @@ class ScalpelCoreTest {
         Files.createDirectories(mainRepo);
 
         try (Git git = Git.init().setDirectory(mainRepo.toFile()).call()) {
+            git.getRepository().getConfig().setString("user", null, "name", "Scalpel Test");
+            git.getRepository().getConfig().setString("user", null, "email", "scalpel@test.invalid");
+            git.getRepository().getConfig().save();
+
             Files.write(mainRepo.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
             git.add().addFilepattern("file.txt").call();
             git.commit().setMessage("initial").call();
@@ -206,14 +210,19 @@ class ScalpelCoreTest {
 
         // Make a change in the worktree using git commands
         Files.write(worktreeDir.resolve("new-file.txt"), "world".getBytes(StandardCharsets.UTF_8));
-        new ProcessBuilder("git", "add", "new-file.txt")
+        Process add = new ProcessBuilder("git", "add", "new-file.txt")
                 .directory(worktreeDir.toFile())
-                .start()
-                .waitFor();
-        new ProcessBuilder("git", "commit", "-m", "add new file")
+                .redirectErrorStream(true)
+                .start();
+        byte[] addOutput = add.getInputStream().readAllBytes();
+        assertTrue(add.waitFor() == 0, "git add failed: " + new String(addOutput, StandardCharsets.UTF_8));
+
+        Process commit = new ProcessBuilder("git", "commit", "-m", "add new file")
                 .directory(worktreeDir.toFile())
-                .start()
-                .waitFor();
+                .redirectErrorStream(true)
+                .start();
+        byte[] commitOutput = commit.getInputStream().readAllBytes();
+        assertTrue(commit.waitFor() == 0, "git commit failed: " + new String(commitOutput, StandardCharsets.UTF_8));
 
         ScalpelCore core = new ScalpelCore(new GitChangeDetector());
         Properties sys = new Properties();

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
 
 class ScalpelCoreTest {
@@ -168,6 +169,61 @@ class ScalpelCoreTest {
         } finally {
             Files.deleteIfExists(nonGitDir);
         }
+    }
+
+    static boolean isGitWorktreeSupported() {
+        try {
+            Process p = new ProcessBuilder("git", "worktree", "list")
+                    .redirectErrorStream(true)
+                    .start();
+            return p.waitFor() == 0 || p.waitFor() == 128;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Test
+    @EnabledIf("isGitWorktreeSupported")
+    void detectChanges_worksInGitWorktree() throws Exception {
+        Path mainRepo = tempDir.resolve("main-repo");
+        Files.createDirectories(mainRepo);
+
+        try (Git git = Git.init().setDirectory(mainRepo.toFile()).call()) {
+            Files.write(mainRepo.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+        }
+
+        Path worktreeDir = tempDir.resolve("worktree");
+        Process process = new ProcessBuilder("git", "worktree", "add", worktreeDir.toString(), "-b", "feature")
+                .directory(mainRepo.toFile())
+                .redirectErrorStream(true)
+                .start();
+        process.getInputStream().readAllBytes();
+        int exitCode = process.waitFor();
+        assertTrue(exitCode == 0, "git worktree add should succeed, exit code: " + exitCode);
+
+        // Make a change in the worktree using git commands
+        Files.write(worktreeDir.resolve("new-file.txt"), "world".getBytes(StandardCharsets.UTF_8));
+        new ProcessBuilder("git", "add", "new-file.txt")
+                .directory(worktreeDir.toFile())
+                .start()
+                .waitFor();
+        new ProcessBuilder("git", "commit", "-m", "add new file")
+                .directory(worktreeDir.toFile())
+                .start()
+                .waitFor();
+
+        ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.baseBranch", "main");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+        ChangeDetectionResult result = core.detectChanges(worktreeDir, config, Set.of());
+
+        assertNotNull(result, "Should detect git repository in worktree");
+        assertTrue(result.getChangedFiles().contains("new-file.txt"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix Scalpel failing to detect git repositories in git worktrees (logs "Not a git repository, building all modules")
- JGit 5.x `findGitDir()` follows `.git` file pointers but `FileRepository` lacks `commondir` support, making refs/objects invisible
- Work around by detecting worktrees via the `commondir` file, opening the repo from the common directory (main `.git/`), and separately resolving the worktree's HEAD for branch/head detection

## Test plan

- [x] Added `detectChanges_worksInGitWorktree` test that creates a real worktree via `git worktree add` and verifies change detection works
- [x] All 182 existing tests pass (72 core + 110 extension3)
- [x] Modernizer plugin passes (uses NIO Path APIs)
- [ ] Manual test in a real worktree with `mvn validate -Dscalpel.enabled=true -Dscalpel.mode=report`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git worktree support with enhanced branch and HEAD reference resolution. Repository opening logic now properly handles common directory structures and worktree-specific metadata for accurate change detection in worktree environments.

* **Tests**
  * Added integration tests validating Git worktree functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->