### PR TITLE
Fix #23: Set testsSkippedReason for transitively affected downstream modules

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -636,7 +636,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .changedManagedPlugins(ctx.changedManagedPluginGAs);
 
         addDirectlyAffectedModules(builder, ctx, reactorRoot);
-        addTransitivelyAffectedModules(builder, ctx, reactorRoot);
+        addTransitivelyAffectedModules(builder, ctx, config, reactorRoot);
         addTrimResultModules(builder, ctx, config, reactorRoot);
 
         try {
@@ -676,22 +676,28 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private void addTransitivelyAffectedModules(ScalpelReport.Builder builder, AnalysisContext ctx, Path reactorRoot) {
+    private void addTransitivelyAffectedModules(
+            ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
         for (Map.Entry<MavenProject, List<String>> entry : ctx.transitivelyAffected.entrySet()) {
             MavenProject project = entry.getKey();
             String path = relativePath(reactorRoot, project);
             String category = null;
+            String testsSkippedReason = null;
             if (ctx.trimResult != null) {
                 if (ctx.trimResult.getUpstreamOnly().contains(project)) {
                     category = ScalpelReport.CATEGORY_UPSTREAM;
                 } else if (ctx.trimResult.getDownstreamOnly().contains(project)
                         || ctx.trimResult.getDownstreamTestOnly().contains(project)) {
                     category = ScalpelReport.CATEGORY_DOWNSTREAM;
+                    if (matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
+                        testsSkippedReason = ScalpelReport.REASON_EXCLUDED_DOWNSTREAM;
+                    }
                 }
             }
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, entry.getValue())
                     .category(category)
+                    .testsSkippedReason(testsSkippedReason)
                     .build());
         }
     }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1292,6 +1292,94 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void reportMode_transitivelyAffectedDownstreamExcludedHasTestsSkippedReason() throws Exception {
+        // module-b is downstream of module-a AND transitively affected by a changed managed dependency.
+        // module-b is in the exclusion list — should get testsSkippedReason even though it's handled
+        // by addTransitivelyAffectedModules rather than addDownstreamModules.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties><lib.version>1.0</lib.version></properties>
+                  <dependencyManagement><dependencies>
+                    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId><version>${lib.version}</version></dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
+
+        String newParentPom = oldParentPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
+        writePom(root, "pom.xml", newParentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        // module-b has commons-lang transitively (makes it transitively affected)
+        DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
+        org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
+        when(moduleBResolution.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
+        DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
+        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    if ("module-b".equals(req.getMavenProject().getArtifactId())) {
+                        return moduleBResolution;
+                    }
+                    return emptyResolution;
+                });
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
+
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(
+                moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY"),
+                "module-b should have TRANSITIVE_DEPENDENCY reason");
+        assertTrue(
+                moduleHasField(json, "module-b", "testsSkippedReason", "EXCLUDED_DOWNSTREAM"),
+                "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM even when transitively affected");
+    }
+
+    @Test
     void skipTestsMode_excludedDownstreamWithChangedPluginStillRunsTests() throws Exception {
         // module-b is downstream and in the exclusion list, but also uses a changed managed plugin.
         // The safety guard should prevent test skipping.


### PR DESCRIPTION
## Summary

- Fix `testsSkippedReason` being `null` for downstream modules that are also transitively affected (e.g. by a changed managed dependency)
- The bug was in `addTransitivelyAffectedModules` which handled these modules first without checking `skipTestsForDownstreamModules`, then `addDownstreamModules` skipped them since they were already processed
- Add test covering the exact scenario: module is both downstream and transitively affected, and is in the exclusion list

Fixes #23

## Test plan

- [x] New test `reportMode_transitivelyAffectedDownstreamExcludedHasTestsSkippedReason` verifies the fix
- [x] All 111 existing tests pass (no regressions)

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Report generation now includes complete test skip reason information for transitively affected downstream modules that are excluded from test execution. Previously, these details were not populated in reports.

* **Tests**
  * Added test coverage for verifying test skip reasons are correctly reported when modules are transitively affected by upstream changes and excluded from testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->