### PR TITLE
Fix #30: Exclude uncategorized transitively affected modules from report

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -32,6 +32,7 @@ public final class ScalpelReport {
     public static final String CATEGORY_DIRECT = "DIRECT";
     public static final String CATEGORY_UPSTREAM = "UPSTREAM";
     public static final String CATEGORY_DOWNSTREAM = "DOWNSTREAM";
+    public static final String CATEGORY_TRANSITIVE = "TRANSITIVE";
 
     private final String baseBranch;
     private final boolean fullBuildTriggered;

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -699,6 +699,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                 }
             }
+            if (category == null) {
+                continue;
+            }
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, entry.getValue())
                     .category(category)

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -553,44 +553,46 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             MavenSession session,
             Set<String> changedGAs,
             Map<MavenProject, DependencyResolutionResult> resolveCache) {
-        try {
-            DependencyResolutionResult result = resolveCache.get(project);
-            if (result == null) {
+        DependencyResolutionResult result = resolveCache.get(project);
+        if (result == null) {
+            try {
                 DefaultDependencyResolutionRequest request =
                         new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
                 result = dependenciesResolver.resolve(request);
-                resolveCache.put(project, result);
-            }
-
-            String narrowestScope = null;
-            for (Dependency dep : result.getResolvedDependencies()) {
-                String ga =
-                        dep.getArtifact().getGroupId() + ":" + dep.getArtifact().getArtifactId();
-                if (changedGAs.contains(ga)) {
-                    String scope = dep.getScope();
+            } catch (DependencyResolutionException e) {
+                result = e.getResult();
+                if (result == null) {
                     logger.debug(
-                            "Module {} has transitive dependency on changed managed dep {} (scope={})",
+                            "Cannot resolve dependencies for {}, no partial results available: {}",
                             key(project),
-                            ga,
-                            scope);
-                    // Non-test scope means production code is affected
-                    if (scope == null || !"test".equals(scope)) {
-                        return scope != null ? scope : "compile";
-                    }
-                    narrowestScope = "test";
+                            e.getMessage());
+                    return null;
                 }
+                logger.debug(
+                        "Partial dependency resolution for {}, checking available results: {}",
+                        key(project),
+                        e.getMessage());
             }
-            return narrowestScope;
-        } catch (DependencyResolutionException e) {
-            // Conservative: if we can't resolve, assume affected.
-            // This commonly happens in afterProjectsRead when reactor siblings
-            // haven't been built yet, so treating as affected is the safe default.
-            logger.debug(
-                    "Cannot resolve dependencies for {}, conservatively treating as affected: {}",
-                    key(project),
-                    e.getMessage());
-            return "compile";
+            resolveCache.put(project, result);
         }
+
+        String narrowestScope = null;
+        for (Dependency dep : result.getResolvedDependencies()) {
+            String ga = dep.getArtifact().getGroupId() + ":" + dep.getArtifact().getArtifactId();
+            if (changedGAs.contains(ga)) {
+                String scope = dep.getScope();
+                logger.debug(
+                        "Module {} has transitive dependency on changed managed dep {} (scope={})",
+                        key(project),
+                        ga,
+                        scope);
+                if (scope == null || !"test".equals(scope)) {
+                    return scope != null ? scope : "compile";
+                }
+                narrowestScope = "test";
+            }
+        }
+        return narrowestScope;
     }
 
     private void writeImpactedLog(ScalpelConfiguration config, Path reactorRoot, Set<MavenProject> affectedModules)
@@ -700,7 +702,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 }
             }
             if (category == null) {
-                continue;
+                category = ScalpelReport.CATEGORY_TRANSITIVE;
             }
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, entry.getValue())

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -39,6 +39,7 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.DefaultDependencyResolutionRequest;
+import org.apache.maven.project.DependencyResolutionException;
 import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
@@ -141,7 +142,7 @@ class ScalpelLifecycleParticipantTest {
                 """;
         writePom(root, "module-c/pom.xml", moduleCPom);
 
-        // module-d: no reactor dependency on module-a, but has commons-lang transitively
+        // module-d: no reactor dependency on module-a, but has commons-lang transitively (genuine)
         String moduleDPom = """
                 <?xml version="1.0"?>
                 <project>
@@ -151,6 +152,17 @@ class ScalpelLifecycleParticipantTest {
                 </project>
                 """;
         writePom(root, "module-d/pom.xml", moduleDPom);
+
+        // module-e: dependency resolution fails, should NOT appear in report
+        String moduleEPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-e</artifactId>
+                </project>
+                """;
+        writePom(root, "module-e/pom.xml", moduleEPom);
 
         // Build MavenProject objects
         MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
@@ -169,8 +181,10 @@ class ScalpelLifecycleParticipantTest {
         moduleC.setParent(parentProject);
         MavenProject moduleD = createProject("com.example", "module-d", "1.0", root, "module-d/pom.xml", moduleDPom);
         moduleD.setParent(parentProject);
+        MavenProject moduleE = createProject("com.example", "module-e", "1.0", root, "module-e/pom.xml", moduleEPom);
+        moduleE.setParent(parentProject);
 
-        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleC, moduleD);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleC, moduleD, moduleE);
 
         // Mock ScalpelCore to return changed files
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -184,7 +198,10 @@ class ScalpelLifecycleParticipantTest {
         org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
                 new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
 
-        // Route resolution calls: module-b and module-d have commons-lang, others don't
+        // Route resolution calls:
+        // module-b and module-d: resolution succeeds, has commons-lang
+        // module-e: resolution fails with empty partial results (simulates unresolvable deps)
+        // others: resolution succeeds, no matching deps
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenAnswer(invocation -> {
                     DefaultDependencyResolutionRequest req = invocation.getArgument(0);
@@ -193,6 +210,11 @@ class ScalpelLifecycleParticipantTest {
                         DependencyResolutionResult res = mock(DependencyResolutionResult.class);
                         when(res.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
                         return res;
+                    }
+                    if ("module-e".equals(aid)) {
+                        DependencyResolutionResult partial = mock(DependencyResolutionResult.class);
+                        when(partial.getResolvedDependencies()).thenReturn(List.of());
+                        throw new DependencyResolutionException(partial, "Cannot resolve", new Exception());
                     }
                     DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
                     when(empty.getResolvedDependencies()).thenReturn(List.of());
@@ -210,7 +232,7 @@ class ScalpelLifecycleParticipantTest {
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
 
-        // Graph: module-b is downstream of module-a; module-d is NOT downstream
+        // Graph: module-b is downstream of module-a; module-d and module-e are NOT downstream
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
@@ -246,10 +268,18 @@ class ScalpelLifecycleParticipantTest {
         // module-c should NOT be in the report (no deps at all)
         assertFalse(modulePresent(json, "module-c"), "module-c should NOT be in report");
 
-        // module-d should NOT be in the report (has commons-lang transitively but is NOT downstream)
+        // module-d should be in the report with TRANSITIVE category (genuine transitive dep, not downstream)
+        assertTrue(
+                moduleHasReason(json, "module-d", "TRANSITIVE_DEPENDENCY"),
+                "module-d should have TRANSITIVE_DEPENDENCY reason");
+        assertTrue(
+                moduleHasField(json, "module-d", "category", "TRANSITIVE"),
+                "module-d should have TRANSITIVE category (not downstream, but genuinely uses changed dep)");
+
+        // module-e should NOT be in the report (resolution failed, dep not found in partial results)
         assertFalse(
-                modulePresent(json, "module-d"),
-                "module-d should NOT be in report (transitively affected but not downstream — issue #30)");
+                modulePresent(json, "module-e"),
+                "module-e should NOT be in report (resolution failed, no matching dep in partial results)");
 
         // changedManagedDependencies should list the GA whose version changed via property
         assertTrue(

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -141,6 +141,17 @@ class ScalpelLifecycleParticipantTest {
                 """;
         writePom(root, "module-c/pom.xml", moduleCPom);
 
+        // module-d: no reactor dependency on module-a, but has commons-lang transitively
+        String moduleDPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-d</artifactId>
+                </project>
+                """;
+        writePom(root, "module-d/pom.xml", moduleDPom);
+
         // Build MavenProject objects
         MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
         parentProject.getModel().setPackaging("pom");
@@ -148,10 +159,18 @@ class ScalpelLifecycleParticipantTest {
         moduleA.setParent(parentProject);
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
+        // Add dependency on module-a to module-b's effective model
+        Dependency moduleBDep = new Dependency();
+        moduleBDep.setGroupId("com.example");
+        moduleBDep.setArtifactId("module-a");
+        moduleBDep.setVersion("1.0");
+        moduleB.getDependencies().add(moduleBDep);
         MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
         moduleC.setParent(parentProject);
+        MavenProject moduleD = createProject("com.example", "module-d", "1.0", root, "module-d/pom.xml", moduleDPom);
+        moduleD.setParent(parentProject);
 
-        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleC);
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleC, moduleD);
 
         // Mock ScalpelCore to return changed files
         Set<String> changedFiles = new LinkedHashSet<>();
@@ -161,24 +180,23 @@ class ScalpelLifecycleParticipantTest {
         ChangeDetectionResult detectionResult = new ChangeDetectionResult(changedFiles, oldPoms);
         when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(detectionResult);
 
-        // Mock dependency resolution: module-b has commons-lang transitively
-        DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
+        // commons-lang dependency used for transitive resolution
         org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
                 new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
-        when(moduleBResolution.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
 
-        // Mock dependency resolution: module-c has no matching deps
-        DependencyResolutionResult moduleCResolution = mock(DependencyResolutionResult.class);
-        when(moduleCResolution.getResolvedDependencies()).thenReturn(List.of());
-
-        // Route resolution calls based on project
+        // Route resolution calls: module-b and module-d have commons-lang, others don't
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenAnswer(invocation -> {
                     DefaultDependencyResolutionRequest req = invocation.getArgument(0);
-                    if ("module-b".equals(req.getMavenProject().getArtifactId())) {
-                        return moduleBResolution;
+                    String aid = req.getMavenProject().getArtifactId();
+                    if ("module-b".equals(aid) || "module-d".equals(aid)) {
+                        DependencyResolutionResult res = mock(DependencyResolutionResult.class);
+                        when(res.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
+                        return res;
                     }
-                    return moduleCResolution;
+                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
+                    when(empty.getResolvedDependencies()).thenReturn(List.of());
+                    return empty;
                 });
 
         // Mock MavenSession
@@ -191,8 +209,11 @@ class ScalpelLifecycleParticipantTest {
         when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+
+        // Graph: module-b is downstream of module-a; module-d is NOT downstream
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -210,16 +231,25 @@ class ScalpelLifecycleParticipantTest {
 
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
 
-        // module-a should be directly affected (POM_CHANGE)
+        // module-a should be directly affected (POM_CHANGE) with DIRECT category
         assertTrue(moduleHasReason(json, "module-a", "POM_CHANGE"), "module-a should have POM_CHANGE reason");
+        assertTrue(moduleHasField(json, "module-a", "category", "DIRECT"), "module-a should have DIRECT category");
 
-        // module-b should be transitively affected
+        // module-b should be transitively affected with DOWNSTREAM category
         assertTrue(
                 moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY"),
                 "module-b should have TRANSITIVE_DEPENDENCY reason");
+        assertTrue(
+                moduleHasField(json, "module-b", "category", "DOWNSTREAM"),
+                "module-b should have DOWNSTREAM category (downstream of module-a)");
 
-        // module-c should NOT be in the report
+        // module-c should NOT be in the report (no deps at all)
         assertFalse(modulePresent(json, "module-c"), "module-c should NOT be in report");
+
+        // module-d should NOT be in the report (has commons-lang transitively but is NOT downstream)
+        assertFalse(
+                modulePresent(json, "module-d"),
+                "module-d should NOT be in report (transitively affected but not downstream — issue #30)");
 
         // changedManagedDependencies should list the GA whose version changed via property
         assertTrue(
@@ -635,13 +665,16 @@ class ScalpelLifecycleParticipantTest {
                 """;
         writePom(root, "module-a/pom.xml", moduleAPom);
 
-        // module-b: gets commons-lang only via test scope transitively
+        // module-b: depends on module-a via test scope, gets commons-lang only via test scope transitively
         String moduleBPom = """
                 <?xml version="1.0"?>
                 <project>
                   <modelVersion>4.0.0</modelVersion>
                   <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
                   <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version><scope>test</scope></dependency>
+                  </dependencies>
                 </project>
                 """;
         writePom(root, "module-b/pom.xml", moduleBPom);
@@ -652,6 +685,13 @@ class ScalpelLifecycleParticipantTest {
         moduleA.setParent(parentProject);
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
+        // Add test-scoped dependency on module-a to module-b's effective model
+        Dependency dep = new Dependency();
+        dep.setGroupId("com.example");
+        dep.setArtifactId("module-a");
+        dep.setVersion("1.0");
+        dep.setScope("test");
+        moduleB.getDependencies().add(dep);
 
         List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
 
@@ -690,8 +730,11 @@ class ScalpelLifecycleParticipantTest {
         when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+
+        // Graph: module-b is downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -706,6 +749,8 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(
                 moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY_TEST"),
                 "module-b should have TRANSITIVE_DEPENDENCY_TEST (test-scoped transitive dep)");
+        assertTrue(
+                moduleHasField(json, "module-b", "category", "DOWNSTREAM"), "module-b should have DOWNSTREAM category");
     }
 
     @Test
@@ -1098,6 +1143,12 @@ class ScalpelLifecycleParticipantTest {
         moduleA.setParent(parentProject);
         MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
         moduleB.setParent(parentProject);
+        // Add dependency on module-a to module-b's effective model
+        Dependency moduleBDep = new Dependency();
+        moduleBDep.setGroupId("com.example");
+        moduleBDep.setArtifactId("module-a");
+        moduleBDep.setVersion("1.0");
+        moduleB.getDependencies().add(moduleBDep);
         MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
         moduleC.setParent(parentProject);
 
@@ -1141,8 +1192,11 @@ class ScalpelLifecycleParticipantTest {
         when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
         when(session.getRequest()).thenReturn(execRequest);
         when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+
+        // Graph: module-b is downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -1159,10 +1213,12 @@ class ScalpelLifecycleParticipantTest {
                 moduleHasReason(json, "module-a", "POM_CHANGE"),
                 "module-a should have POM_CHANGE reason (imports BOM with changed managed dep)");
 
-        // module-b should be transitively affected (gets commons-lang through module-a)
+        // module-b should be transitively affected with DOWNSTREAM category
         assertTrue(
                 moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY"),
                 "module-b should have TRANSITIVE_DEPENDENCY reason");
+        assertTrue(
+                moduleHasField(json, "module-b", "category", "DOWNSTREAM"), "module-b should have DOWNSTREAM category");
 
         // module-c should NOT be in the report
         assertFalse(modulePresent(json, "module-c"), "module-c should NOT be in report");


### PR DESCRIPTION
## Summary

Fixes #30 — `affectedModules` no longer includes ~600 false positives from dependency resolution failures.

**Two changes:**

1. **`TRANSITIVE` category** — Modules that have a changed managed dependency in their resolved transitive tree but are not upstream/downstream of any directly affected module now get `TRANSITIVE` category instead of no category.

2. **Partial dependency resolution** — `getChangedTransitiveDependencyScope()` now uses partial results from `DependencyResolutionException` instead of conservatively treating all unresolvable modules as affected. Only modules where the changed GA is actually found in the (partial) resolved dependencies are flagged.

## Report categories

| Category | Meaning |
|---|---|
| `DIRECT` | Module's own source or POM changed |
| `UPSTREAM` | Build dependency of an affected module |
| `DOWNSTREAM` | Depends on a directly affected module |
| `TRANSITIVE` | Has changed managed dep in resolved tree, but not upstream/downstream |

## Before (Apache Camel, `kafka-version` change)

```
affectedModules: 647 (3 DIRECT + 42 DOWNSTREAM + 602 uncategorized)
```

## After

```
affectedModules: ~65 (3 DIRECT + 42 DOWNSTREAM + ~20 TRANSITIVE)
```

## Test plan

- [x] Updated `reportMode_includesTransitivelyAffectedModules` — module-d (genuine transitive) gets `TRANSITIVE` category, module-e (resolution failure with empty partial results) excluded
- [x] Updated `reportMode_testScopedTransitiveDependencyProducesTestReason` — downstream + test-scoped transitive dep
- [x] Updated `reportMode_bomImportScopeDetected` — downstream + transitive dep via BOM
- [x] All 113 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)