### PR TITLE
Compute transitively affected modules when no modules are directly affected

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -231,7 +231,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // Force-included modules are not test-only
             testOnlyModules.removeAll(forceIncluded);
 
-            if (directlyAffected.isEmpty()) {
+            if (directlyAffected.isEmpty() && changedManagedDepGAs.isEmpty() && changedManagedPluginGAs.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
                 if (config.isModeReport()) {
                     writeReport(
@@ -245,20 +245,46 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 return;
             }
 
-            logger.info("Scalpel: {} modules directly affected: {}", directlyAffected.size(), keys(directlyAffected));
+            if (!directlyAffected.isEmpty()) {
+                logger.info(
+                        "Scalpel: {} modules directly affected: {}", directlyAffected.size(), keys(directlyAffected));
+            }
+
+            // Compute transitively affected modules (via changed managed deps/plugins)
+            Map<MavenProject, List<String>> transitivelyAffected = computeTransitivelyAffected(
+                    allProjects, directlyAffected, changedManagedDepGAs, changedManagedPluginGAs, session);
+
+            if (directlyAffected.isEmpty() && transitivelyAffected.isEmpty()) {
+                logger.info("Scalpel: No modules affected by changes");
+                if (config.isModeReport()) {
+                    writeReport(
+                            config,
+                            reactorRoot,
+                            AnalysisContext.empty(
+                                    changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs));
+                } else if (config.isModeSkipTests()) {
+                    skipTestsOnAll(allProjects);
+                }
+                return;
+            }
+
+            // Include transitively affected modules (from managed dep/plugin changes) in the affected set
+            Set<MavenProject> allAffected = new LinkedHashSet<>(directlyAffected);
+            allAffected.addAll(transitivelyAffected.keySet());
 
             // Write impacted module log if configured
             if (config.getImpactedLog() != null) {
-                writeImpactedLog(config, reactorRoot, directlyAffected);
+                writeImpactedLog(config, reactorRoot, allAffected);
             }
 
             if (config.isModeReport()) {
                 // Compute upstream/downstream categorization for report enrichment
-                TrimResult trimResult = reactorTrimmer.computeBuildSet(
-                        directlyAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
-
-                Map<MavenProject, List<String>> transitivelyAffected = computeTransitivelyAffected(
-                        allProjects, directlyAffected, changedManagedDepGAs, changedManagedPluginGAs, session);
+                // Use directlyAffected here (not allAffected) to preserve correct DOWNSTREAM categorization;
+                // transitively affected modules are added to the report separately via addTransitivelyAffectedModules
+                TrimResult trimResult = directlyAffected.isEmpty()
+                        ? null
+                        : reactorTrimmer.computeBuildSet(
+                                directlyAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
 
                 writeReport(
                         config,
@@ -278,7 +304,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Compute full build set with upstream/downstream
             TrimResult trimResult = reactorTrimmer.computeBuildSet(
-                    directlyAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
+                    allAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
 
             if (config.isModeSkipTests()) {
                 applySkipTests(session, allProjects, trimResult, config, changedManagedDepGAs, changedManagedPluginGAs);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2128,6 +2128,158 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void impactedLog_includesTransitivelyAffectedModules() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String rootPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>root</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                    <module>bom</module>
+                    <module>module-a</module>
+                    <module>module-b</module>
+                  </modules>
+                </project>
+                """;
+        writePom(root, "pom.xml", rootPom);
+
+        String oldBomPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>bom</artifactId>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <graphql.version>2.18.1</graphql.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>smallrye-graphql</artifactId>
+                        <version>${graphql.version}</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """;
+
+        String newBomPom = oldBomPom.replace(
+                "<graphql.version>2.18.1</graphql.version>", "<graphql.version>2.18.2</graphql.version>");
+        writePom(root, "bom/pom.xml", newBomPom);
+
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.example</groupId>
+                        <artifactId>bom</artifactId>
+                        <version>${project.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """;
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject rootProject = createProject("com.example", "root", "1.0", root, "pom.xml", rootPom);
+        rootProject.getModel().setPackaging("pom");
+        MavenProject bomProject = createProject("com.example", "bom", "1.0", root, "bom/pom.xml", newBomPom);
+        bomProject.getModel().setPackaging("pom");
+        bomProject.setParent(rootProject);
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(rootProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(rootProject);
+
+        List<MavenProject> allProjects = List.of(rootProject, bomProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("bom/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        org.eclipse.aether.graph.Dependency graphqlDep = new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("io.smallrye", "smallrye-graphql", "jar", "2.18.2"), "compile");
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    if ("module-a".equals(req.getMavenProject().getArtifactId())) {
+                        DependencyResolutionResult res = mock(DependencyResolutionResult.class);
+                        when(res.getResolvedDependencies()).thenReturn(List.of(graphqlDep));
+                        return res;
+                    }
+                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
+                    when(empty.getResolvedDependencies()).thenReturn(List.of());
+                    return empty;
+                });
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        sysProps.setProperty("scalpel.impactedLog", "target/scalpel-impacted.log");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path logFile = root.resolve("target/scalpel-impacted.log");
+        assertTrue(Files.exists(logFile), "Impacted log file should be created");
+        String content = new String(Files.readAllBytes(logFile), StandardCharsets.UTF_8);
+        assertTrue(content.contains("module-a"), "Impacted log should contain transitively affected module-a");
+        assertFalse(content.contains("module-b"), "Impacted log should NOT contain unaffected module-b");
+    }
+
+    @Test
     void skipTestsMode_skipTestsForUpstream_skipsUpstreamTests() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
@@ -2406,6 +2558,190 @@ class ScalpelLifecycleParticipantTest {
                 moduleHasReason(json, "module-a", "UPSTREAM_DEPENDENCY"),
                 "module-a should have UPSTREAM_DEPENDENCY reason in report");
         assertTrue(moduleHasField(json, "module-a", "category", "UPSTREAM"), "module-a should have UPSTREAM category");
+    }
+
+    @Test
+    void reportMode_bomPropertyChangeWithNoDirectlyAffectedModules() throws Exception {
+        // Simulates a BOM-only property change (e.g. bumping a version property in bom/application/pom.xml)
+        // where no module directly references the changed property in its own POM text,
+        // but modules transitively depend on the changed managed dependencies.
+        // Before the fix, this produced an empty report (no affected modules).
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // Root aggregator
+        String rootPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>root</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                    <module>bom</module>
+                    <module>module-a</module>
+                    <module>module-b</module>
+                  </modules>
+                </project>
+                """;
+        writePom(root, "pom.xml", rootPom);
+
+        // BOM with a property-based version (old)
+        String oldBomPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>bom</artifactId>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <graphql.version>2.18.1</graphql.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>smallrye-graphql</artifactId>
+                        <version>${graphql.version}</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>smallrye-graphql-api</artifactId>
+                        <version>${graphql.version}</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """;
+
+        // BOM (new — version bumped)
+        String newBomPom = oldBomPom.replace(
+                "<graphql.version>2.18.1</graphql.version>", "<graphql.version>2.18.2</graphql.version>");
+        writePom(root, "bom/pom.xml", newBomPom);
+
+        // module-a: imports the BOM but does NOT directly declare any graphql dependency.
+        // It gets smallrye-graphql transitively via dependency resolution.
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.example</groupId>
+                        <artifactId>bom</artifactId>
+                        <version>${project.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """;
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        // module-b: does NOT import the BOM or use graphql
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        // Build projects
+        MavenProject rootProject = createProject("com.example", "root", "1.0", root, "pom.xml", rootPom);
+        rootProject.getModel().setPackaging("pom");
+        MavenProject bomProject = createProject("com.example", "bom", "1.0", root, "bom/pom.xml", newBomPom);
+        bomProject.getModel().setPackaging("pom");
+        bomProject.setParent(rootProject);
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(rootProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(rootProject);
+
+        List<MavenProject> allProjects = List.of(rootProject, bomProject, moduleA, moduleB);
+
+        // Only BOM POM changed
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("bom/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        // module-a has smallrye-graphql as a transitive dependency
+        org.eclipse.aether.graph.Dependency graphqlDep = new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("io.smallrye", "smallrye-graphql", "jar", "2.18.2"), "compile");
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    if ("module-a".equals(req.getMavenProject().getArtifactId())) {
+                        DependencyResolutionResult res = mock(DependencyResolutionResult.class);
+                        when(res.getResolvedDependencies()).thenReturn(List.of(graphqlDep));
+                        return res;
+                    }
+                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
+                    when(empty.getResolvedDependencies()).thenReturn(List.of());
+                    return empty;
+                });
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // module-a should be transitively affected (has the changed dep in its resolved deps)
+        assertTrue(
+                moduleHasReason(json, "module-a", "TRANSITIVE_DEPENDENCY"),
+                "module-a should have TRANSITIVE_DEPENDENCY reason (transitive dep on changed managed GA)");
+        assertTrue(
+                moduleHasField(json, "module-a", "category", "TRANSITIVE"), "module-a should have TRANSITIVE category");
+
+        // module-b should NOT be affected (no dependency on changed GAs)
+        assertFalse(modulePresent(json, "module-b"), "module-b should NOT be in report");
+
+        // changedManagedDependencies should include the GAs
+        assertTrue(json.contains("\"io.smallrye:smallrye-graphql\""), "Report should include changed managed dep GA");
+        assertTrue(
+                json.contains("\"io.smallrye:smallrye-graphql-api\""),
+                "Report should include changed managed dep GA for api");
     }
 
     // --- Helper methods ---


### PR DESCRIPTION
When a BOM property change affects managed dependencies but no module is directly affected (e.g. the property is only used in dependencyManagement), computeTransitivelyAffected was never called because the code returned early. This caused report mode to produce an empty affectedModules list, and trim/skip-tests modes to treat the build as unaffected.

This has been quite problematic for the Quarkus project as a change to our BOM doesn't properly trigger a build of the affected modules. We have a safeguard and we trigger the full build when no modules are affected but this is far from ideal.

If this makes sense, I would appreciate a quick release, thanks!

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of modules affected by managed dependency and plugin version changes.
  * Fixed build set computation to properly include transitively affected modules in skip-tests and trim modes.

* **Tests**
  * Added test coverage for BOM property version change scenarios with transitive dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->