### PR TITLE
Fix #34: Skip binary files in resource scanning and make size limit configurable

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,6 +52,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -173,7 +173,16 @@ public final class ScalpelConfiguration {
         String maxResourceFileSizeStr = resolve(system, user, MAX_RESOURCE_FILE_SIZE, null);
         long maxResourceFileSize = DEFAULT_MAX_RESOURCE_FILE_SIZE;
         if (maxResourceFileSizeStr != null) {
-            maxResourceFileSize = Long.parseLong(maxResourceFileSizeStr);
+            try {
+                maxResourceFileSize = Long.parseLong(maxResourceFileSizeStr);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid " + MAX_RESOURCE_FILE_SIZE + " '" + maxResourceFileSizeStr
+                        + "', expected a positive integer (bytes)");
+            }
+            if (maxResourceFileSize <= 0) {
+                throw new IllegalArgumentException("Invalid " + MAX_RESOURCE_FILE_SIZE + " '" + maxResourceFileSizeStr
+                        + "', must be a positive integer (bytes)");
+            }
         }
 
         return new ScalpelConfiguration(

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -46,6 +46,7 @@ public final class ScalpelConfiguration {
     public static final String BUILD_ALL_IF_NO_CHANGES = PREFIX + "buildAllIfNoChanges";
     public static final String IMPACTED_LOG = PREFIX + "impactedLog";
     public static final String REPORT_FILE = PREFIX + "reportFile";
+    public static final String MAX_RESOURCE_FILE_SIZE = PREFIX + "maxResourceFileSize";
 
     public static final String MODE_TRIM = "trim";
     public static final String MODE_SKIP_TESTS = "skip-tests";
@@ -53,6 +54,7 @@ public final class ScalpelConfiguration {
 
     private static final String DEFAULT_FULL_BUILD_TRIGGERS = ".mvn/**";
     private static final String DEFAULT_REPORT_FILE = "target/scalpel-report.json";
+    public static final long DEFAULT_MAX_RESOURCE_FILE_SIZE = 10L * 1024 * 1024; // 10 MB
 
     private final boolean enabled;
     private final String baseBranch;
@@ -78,6 +80,7 @@ public final class ScalpelConfiguration {
     private final boolean failSafe;
     private final String mode;
     private final String reportFile;
+    private final long maxResourceFileSize;
 
     private ScalpelConfiguration(
             boolean enabled,
@@ -103,7 +106,8 @@ public final class ScalpelConfiguration {
             String impactedLog,
             boolean failSafe,
             String mode,
-            String reportFile) {
+            String reportFile,
+            long maxResourceFileSize) {
         this.enabled = enabled;
         this.baseBranch = baseBranch;
         this.head = head;
@@ -128,6 +132,7 @@ public final class ScalpelConfiguration {
         this.failSafe = failSafe;
         this.mode = mode;
         this.reportFile = reportFile;
+        this.maxResourceFileSize = maxResourceFileSize;
     }
 
     public static ScalpelConfiguration fromProperties(Properties system, Properties user) {
@@ -165,6 +170,11 @@ public final class ScalpelConfiguration {
                     + ", " + MODE_SKIP_TESTS + ", " + MODE_REPORT);
         }
         String reportFile = resolve(system, user, REPORT_FILE, DEFAULT_REPORT_FILE);
+        String maxResourceFileSizeStr = resolve(system, user, MAX_RESOURCE_FILE_SIZE, null);
+        long maxResourceFileSize = DEFAULT_MAX_RESOURCE_FILE_SIZE;
+        if (maxResourceFileSizeStr != null) {
+            maxResourceFileSize = Long.parseLong(maxResourceFileSizeStr);
+        }
 
         return new ScalpelConfiguration(
                 enabled,
@@ -190,7 +200,8 @@ public final class ScalpelConfiguration {
                 impactedLog,
                 failSafe,
                 mode,
-                reportFile);
+                reportFile,
+                maxResourceFileSize);
     }
 
     private static String resolve(Properties system, Properties user, String key, String defaultValue) {
@@ -344,6 +355,10 @@ public final class ScalpelConfiguration {
         return reportFile;
     }
 
+    public long getMaxResourceFileSize() {
+        return maxResourceFileSize;
+    }
+
     @Override
     public String toString() {
         return "ScalpelConfiguration{"
@@ -371,6 +386,7 @@ public final class ScalpelConfiguration {
                 + ", impactedLog='" + impactedLog + '\''
                 + ", failSafe=" + failSafe
                 + ", reportFile='" + reportFile + '\''
+                + ", maxResourceFileSize=" + maxResourceFileSize
                 + '}';
     }
 }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -404,6 +404,45 @@ class ScalpelConfigurationTest {
     // ---------------------------------------------------------------
 
     @Test
+    void maxResourceFileSize_defaultValue() {
+        assertEquals(10L * 1024 * 1024, defaultConfig().getMaxResourceFileSize());
+    }
+
+    @Test
+    void maxResourceFileSize_customValue() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.maxResourceFileSize", "5242880");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertEquals(5242880L, config.getMaxResourceFileSize());
+    }
+
+    @Test
+    void maxResourceFileSize_invalidFormat_throwsException() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.maxResourceFileSize", "not-a-number");
+        Properties user = new Properties();
+        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, user));
+    }
+
+    @Test
+    void maxResourceFileSize_negativeValue_throwsException() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.maxResourceFileSize", "-1");
+        Properties user = new Properties();
+        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, user));
+    }
+
+    @Test
+    void maxResourceFileSize_zero_throwsException() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.maxResourceFileSize", "0");
+        Properties user = new Properties();
+        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, user));
+    }
+
+    // ---------------------------------------------------------------
+
+    @Test
     void listField_trimsWhitespaceInValues() {
         Properties sys = new Properties();
         sys.setProperty("scalpel.disableOnBranch", "main, release/.*,hotfix");

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -16,6 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class ScalpelConfigurationTest {
 
@@ -381,10 +383,16 @@ class ScalpelConfigurationTest {
     // Mode validation
     // ---------------------------------------------------------------
 
-    @Test
-    void invalidMode_throwsException() {
+    @ParameterizedTest
+    @CsvSource({
+        "scalpel.mode, invalid",
+        "scalpel.maxResourceFileSize, not-a-number",
+        "scalpel.maxResourceFileSize, -1",
+        "scalpel.maxResourceFileSize, 0"
+    })
+    void invalidPropertyValue_throwsException(String key, String value) {
         Properties sys = new Properties();
-        sys.setProperty("scalpel.mode", "invalid");
+        sys.setProperty(key, value);
         Properties user = new Properties();
         assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, user));
     }
@@ -414,30 +422,6 @@ class ScalpelConfigurationTest {
         sys.setProperty("scalpel.maxResourceFileSize", "5242880");
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
         assertEquals(5242880L, config.getMaxResourceFileSize());
-    }
-
-    @Test
-    void maxResourceFileSize_invalidFormat_throwsException() {
-        Properties sys = new Properties();
-        sys.setProperty("scalpel.maxResourceFileSize", "not-a-number");
-        Properties user = new Properties();
-        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, user));
-    }
-
-    @Test
-    void maxResourceFileSize_negativeValue_throwsException() {
-        Properties sys = new Properties();
-        sys.setProperty("scalpel.maxResourceFileSize", "-1");
-        Properties user = new Properties();
-        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, user));
-    }
-
-    @Test
-    void maxResourceFileSize_zero_throwsException() {
-        Properties sys = new Properties();
-        sys.setProperty("scalpel.maxResourceFileSize", "0");
-        Properties user = new Properties();
-        assertThrows(IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, user));
     }
 
     // ---------------------------------------------------------------

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -370,11 +370,11 @@ class PomChangeAnalyzer {
             }
 
             // Check if child has filtered resources referencing changed properties
-            if (!childAffected && !changedProperties.isEmpty()) {
-                if (hasFilteredResourcesWithChangedProperty(child, changedProperties, maxResourceFileSize)) {
-                    logger.debug("Child {} has filtered resources referencing changed properties", key(child));
-                    childAffected = true;
-                }
+            if (!childAffected
+                    && !changedProperties.isEmpty()
+                    && hasFilteredResourcesWithChangedProperty(child, changedProperties, maxResourceFileSize)) {
+                logger.debug("Child {} has filtered resources referencing changed properties", key(child));
+                childAffected = true;
             }
 
             if (childAffected) {
@@ -1085,41 +1085,47 @@ class PomChangeAnalyzer {
                 for (Path entry : stream) {
                     if (Files.isDirectory(entry)) {
                         stack.add(entry);
-                    } else if (Files.isRegularFile(entry)) {
-                        try {
-                            long size = Files.size(entry);
-                            // Read the first 8000 bytes to detect binary files (same heuristic as git)
-                            if (isBinaryFile(entry, size)) {
-                                logger.debug("Skipping binary file: {}", entry);
-                                continue;
-                            }
-                            if (size > maxResourceFileSize) {
-                                // Conservative: treat oversized text files as potentially affected
-                                logger.warn(
-                                        "Filtered resource {} ({} bytes) exceeds size limit ({} bytes)."
-                                                + " Module will be conservatively marked as affected."
-                                                + " Increase the limit with -D{}=<bytes> or disable filtering"
-                                                + " for this resource.",
-                                        entry,
-                                        size,
-                                        maxResourceFileSize,
-                                        ScalpelConfiguration.MAX_RESOURCE_FILE_SIZE);
-                                return true;
-                            }
-                            String content = new String(Files.readAllBytes(entry), StandardCharsets.UTF_8);
-                            for (String ref : refs) {
-                                if (content.contains(ref)) {
-                                    return true;
-                                }
-                            }
-                        } catch (IOException e) {
-                            // Skip unreadable files
-                        }
+                    } else if (Files.isRegularFile(entry)
+                            && checkFileForPropertyRefs(entry, refs, maxResourceFileSize)) {
+                        return true;
                     }
                 }
             } catch (IOException e) {
                 // Skip unreadable directories
             }
+        }
+        return false;
+    }
+
+    private boolean checkFileForPropertyRefs(Path entry, List<String> refs, long maxResourceFileSize) {
+        try {
+            long size = Files.size(entry);
+            // Read the first 8000 bytes to detect binary files (same heuristic as git)
+            if (isBinaryFile(entry, size)) {
+                logger.debug("Skipping binary file: {}", entry);
+                return false;
+            }
+            if (size > maxResourceFileSize) {
+                // Conservative: treat oversized text files as potentially affected
+                logger.warn(
+                        "Filtered resource {} ({} bytes) exceeds size limit ({} bytes)."
+                                + " Module will be conservatively marked as affected."
+                                + " Increase the limit with -D{}=<bytes> or disable filtering"
+                                + " for this resource.",
+                        entry,
+                        size,
+                        maxResourceFileSize,
+                        ScalpelConfiguration.MAX_RESOURCE_FILE_SIZE);
+                return true;
+            }
+            String content = new String(Files.readAllBytes(entry), StandardCharsets.UTF_8);
+            for (String ref : refs) {
+                if (content.contains(ref)) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            // Skip unreadable files
         }
         return false;
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -9,8 +9,10 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
 
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -101,6 +103,20 @@ class PomChangeAnalyzer {
             Map<String, byte[]> oldPomContents,
             List<MavenProject> allProjects,
             Path reactorRoot) {
+        return analyzeChanges(
+                changedPomPaths,
+                oldPomContents,
+                allProjects,
+                reactorRoot,
+                ScalpelConfiguration.DEFAULT_MAX_RESOURCE_FILE_SIZE);
+    }
+
+    public Result analyzeChanges(
+            Set<String> changedPomPaths,
+            Map<String, byte[]> oldPomContents,
+            List<MavenProject> allProjects,
+            Path reactorRoot,
+            long maxResourceFileSize) {
 
         Set<MavenProject> affected = new LinkedHashSet<>();
         Set<String> allChangedManagedDepGAs = new LinkedHashSet<>();
@@ -159,7 +175,8 @@ class PomChangeAnalyzer {
                         affected,
                         allChangedManagedDepGAs,
                         allChangedManagedPluginGAs,
-                        allChangedProperties);
+                        allChangedProperties,
+                        maxResourceFileSize);
             } catch (Exception e) {
                 // If we can't parse the old POM, be conservative and mark all dependents
                 logger.warn(
@@ -182,7 +199,8 @@ class PomChangeAnalyzer {
             Set<MavenProject> affected,
             Set<String> allChangedManagedDepGAs,
             Set<String> allChangedManagedPluginGAs,
-            Set<String> allChangedProperties)
+            Set<String> allChangedProperties,
+            long maxResourceFileSize)
             throws IOException, XmlPullParserException {
 
         MavenXpp3Reader reader = new MavenXpp3Reader();
@@ -353,7 +371,7 @@ class PomChangeAnalyzer {
 
             // Check if child has filtered resources referencing changed properties
             if (!childAffected && !changedProperties.isEmpty()) {
-                if (hasFilteredResourcesWithChangedProperty(child, changedProperties)) {
+                if (hasFilteredResourcesWithChangedProperty(child, changedProperties, maxResourceFileSize)) {
                     logger.debug("Child {} has filtered resources referencing changed properties", key(child));
                     childAffected = true;
                 }
@@ -1021,7 +1039,8 @@ class PomChangeAnalyzer {
         return false;
     }
 
-    private boolean hasFilteredResourcesWithChangedProperty(MavenProject project, Set<String> changedProperties) {
+    private boolean hasFilteredResourcesWithChangedProperty(
+            MavenProject project, Set<String> changedProperties, long maxResourceFileSize) {
         List<String> refs = new ArrayList<>();
         for (String prop : changedProperties) {
             refs.add("${" + prop + "}");
@@ -1050,16 +1069,14 @@ class PomChangeAnalyzer {
             if (!Files.isDirectory(resourceDir)) {
                 continue;
             }
-            if (scanDirectoryForPropertyRefs(resourceDir, refs)) {
+            if (scanDirectoryForPropertyRefs(resourceDir, refs, maxResourceFileSize)) {
                 return true;
             }
         }
         return false;
     }
 
-    private static final long MAX_RESOURCE_FILE_SIZE = 1024L * 1024; // 1 MB
-
-    private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs) {
+    private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs, long maxResourceFileSize) {
         List<Path> stack = new ArrayList<>();
         stack.add(dir);
         while (!stack.isEmpty()) {
@@ -1071,8 +1088,22 @@ class PomChangeAnalyzer {
                     } else if (Files.isRegularFile(entry)) {
                         try {
                             long size = Files.size(entry);
-                            if (size > MAX_RESOURCE_FILE_SIZE) {
-                                // Conservative: treat oversized files as potentially affected
+                            // Read the first 8000 bytes to detect binary files (same heuristic as git)
+                            if (isBinaryFile(entry, size)) {
+                                logger.debug("Skipping binary file: {}", entry);
+                                continue;
+                            }
+                            if (size > maxResourceFileSize) {
+                                // Conservative: treat oversized text files as potentially affected
+                                logger.warn(
+                                        "Filtered resource {} ({} bytes) exceeds size limit ({} bytes)."
+                                                + " Module will be conservatively marked as affected."
+                                                + " Increase the limit with -D{}=<bytes> or disable filtering"
+                                                + " for this resource.",
+                                        entry,
+                                        size,
+                                        maxResourceFileSize,
+                                        ScalpelConfiguration.MAX_RESOURCE_FILE_SIZE);
                                 return true;
                             }
                             String content = new String(Files.readAllBytes(entry), StandardCharsets.UTF_8);
@@ -1082,13 +1113,36 @@ class PomChangeAnalyzer {
                                 }
                             }
                         } catch (IOException e) {
-                            // Skip binary or unreadable files
+                            // Skip unreadable files
                         }
                     }
                 }
             } catch (IOException e) {
                 // Skip unreadable directories
             }
+        }
+        return false;
+    }
+
+    /**
+     * Detect binary files using the same heuristic as git: scan for a NUL byte (0x00)
+     * in the first 8000 bytes of the file.
+     */
+    private static boolean isBinaryFile(Path file, long fileSize) {
+        int bytesToRead = (int) Math.min(fileSize, 8000);
+        if (bytesToRead == 0) {
+            return false;
+        }
+        byte[] buffer = new byte[bytesToRead];
+        try (InputStream in = Files.newInputStream(file)) {
+            int read = in.read(buffer, 0, bytesToRead);
+            for (int i = 0; i < read; i++) {
+                if (buffer[i] == 0) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            // If we can't read the file, treat as non-binary (will fail later when reading full content)
         }
         return false;
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -179,7 +179,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 logger.debug("POM changes detected: {}", pomChanges);
                 try {
                     PomChangeAnalyzer.Result pomResult = pomChangeAnalyzer.analyzeChanges(
-                            pomChanges, result.getOldPomContents(), allProjects, reactorRoot);
+                            pomChanges,
+                            result.getOldPomContents(),
+                            allProjects,
+                            reactorRoot,
+                            config.getMaxResourceFileSize());
                     affectedByPom = pomResult.getAffectedProjects();
                     changedManagedDepGAs = pomResult.getChangedManagedDependencyGAs();
                     changedManagedPluginGAs = pomResult.getChangedManagedPluginGAs();

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -1160,6 +1160,227 @@ class PomChangeAnalyzerTest {
                 "module-b's filtered resources don't reference ${app.version} - should NOT be affected");
     }
 
+    @Test
+    void analyzeChanges_filteredResourceBinaryFileSkipped() throws Exception {
+        Path root = setupReactorRoot();
+
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module></modules>
+                  <properties>
+                    <app.version>2.0</app.version>
+                  </properties>
+                </project>
+                """;
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        // Create a binary file (contains NUL bytes) in filtered resources
+        Path resourceDir = root.resolve("module-a/src/main/resources");
+        Files.createDirectories(resourceDir);
+        byte[] binaryContent = new byte[100];
+        binaryContent[50] = 0; // NUL byte makes it binary
+        Files.write(resourceDir.resolve("image.png"), binaryContent);
+
+        MavenProject parent = createProject(
+                "com.example", "parent", "1.0", root.resolve("pom.xml").toFile());
+        parent.setOriginalModel(parseModel(parentPomXml));
+        parent.getModel().setPackaging("pom");
+
+        MavenProject moduleA = createProject(
+                "com.example",
+                "module-a",
+                "1.0",
+                root.resolve("module-a/pom.xml").toFile());
+        moduleA.setOriginalModel(parseModel(moduleAPomXml));
+        moduleA.setParent(parent);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleA.getModel().setBuild(build);
+
+        List<MavenProject> projects = List.of(parent, moduleA);
+
+        String oldParentPom = parentPomXml.replace("<app.version>2.0</app.version>", "<app.version>1.0</app.version>");
+
+        Set<MavenProject> affected = analyzer.analyzeChanges(
+                        Set.of("pom.xml"),
+                        Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)),
+                        projects,
+                        root)
+                .getAffectedProjects();
+
+        assertFalse(
+                affected.contains(moduleA),
+                "module-a has only binary files in filtered resources and should NOT be affected");
+    }
+
+    @Test
+    void analyzeChanges_filteredResourceOversizedTextFileMarkedAsAffected() throws Exception {
+        Path root = setupReactorRoot();
+
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module></modules>
+                  <properties>
+                    <app.version>2.0</app.version>
+                  </properties>
+                </project>
+                """;
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        // Create a large text file (no NUL bytes) exceeding a small custom limit
+        Path resourceDir = root.resolve("module-a/src/main/resources");
+        Files.createDirectories(resourceDir);
+        byte[] largeText = new byte[2000];
+        java.util.Arrays.fill(largeText, (byte) 'x');
+        Files.write(resourceDir.resolve("large.txt"), largeText);
+
+        MavenProject parent = createProject(
+                "com.example", "parent", "1.0", root.resolve("pom.xml").toFile());
+        parent.setOriginalModel(parseModel(parentPomXml));
+        parent.getModel().setPackaging("pom");
+
+        MavenProject moduleA = createProject(
+                "com.example",
+                "module-a",
+                "1.0",
+                root.resolve("module-a/pom.xml").toFile());
+        moduleA.setOriginalModel(parseModel(moduleAPomXml));
+        moduleA.setParent(parent);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleA.getModel().setBuild(build);
+
+        List<MavenProject> projects = List.of(parent, moduleA);
+
+        String oldParentPom = parentPomXml.replace("<app.version>2.0</app.version>", "<app.version>1.0</app.version>");
+
+        // Use a custom small limit (1000 bytes) so the 2000-byte file exceeds it
+        Set<MavenProject> affected = analyzer.analyzeChanges(
+                        Set.of("pom.xml"),
+                        Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)),
+                        projects,
+                        root,
+                        1000L)
+                .getAffectedProjects();
+
+        assertTrue(
+                affected.contains(moduleA),
+                "module-a has oversized text file in filtered resources and should be conservatively affected");
+    }
+
+    @Test
+    void analyzeChanges_filteredResourceOversizedBinaryFileSkipped() throws Exception {
+        Path root = setupReactorRoot();
+
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module></modules>
+                  <properties>
+                    <app.version>2.0</app.version>
+                  </properties>
+                </project>
+                """;
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        // Create a large binary file (contains NUL bytes AND exceeds the size limit)
+        // Binary detection should run BEFORE size check, so it should be skipped
+        Path resourceDir = root.resolve("module-a/src/main/resources");
+        Files.createDirectories(resourceDir);
+        byte[] largeBinary = new byte[2000];
+        largeBinary[10] = 0; // NUL byte makes it binary
+        Files.write(resourceDir.resolve("font.woff2"), largeBinary);
+
+        MavenProject parent = createProject(
+                "com.example", "parent", "1.0", root.resolve("pom.xml").toFile());
+        parent.setOriginalModel(parseModel(parentPomXml));
+        parent.getModel().setPackaging("pom");
+
+        MavenProject moduleA = createProject(
+                "com.example",
+                "module-a",
+                "1.0",
+                root.resolve("module-a/pom.xml").toFile());
+        moduleA.setOriginalModel(parseModel(moduleAPomXml));
+        moduleA.setParent(parent);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleA.getModel().setBuild(build);
+
+        List<MavenProject> projects = List.of(parent, moduleA);
+
+        String oldParentPom = parentPomXml.replace("<app.version>2.0</app.version>", "<app.version>1.0</app.version>");
+
+        // Use a small limit so the file would exceed it IF it weren't binary
+        Set<MavenProject> affected = analyzer.analyzeChanges(
+                        Set.of("pom.xml"),
+                        Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)),
+                        projects,
+                        root,
+                        1000L)
+                .getAffectedProjects();
+
+        assertFalse(
+                affected.contains(moduleA),
+                "module-a has only a large binary file - binary check should bail before size limit kicks in");
+    }
+
     // --- New POM and edge case tests ---
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #34

Three improvements to `scanDirectoryForPropertyRefs` in `PomChangeAnalyzer`:

### 1. Binary file detection (fast bail)
Adds a `isBinaryFile()` method using **git's NUL-byte heuristic**: scan the first 8000 bytes for a NUL byte (0x00). Binary files (images, fonts, JARs, .woff2, etc.) are skipped immediately instead of being read into memory and scanned for property references.

This prevents binary files > 1 MB from being flagged as false positives, which was the root cause of the Quarkus issue (1.4 MB dev-UI resource file → 1335 of 1394 modules built).

### 2. Configurable size limit (raised from 1 MB to 10 MB)
- New property: `-Dscalpel.maxResourceFileSize=<bytes>`
- Default: 10 MB (was 1 MB hardcoded)
- Added to `ScalpelConfiguration` with getter and backward-compatible overload

### 3. Warning log on size limit hit
When a text file exceeds the size limit, Scalpel now logs a WARNING with:
- The file path
- The file size and the limit
- Remediation advice (`-Dscalpel.maxResourceFileSize` or disable filtering)

Previously this was completely silent, making the false positive impossible to diagnose.

## Flow change

**Before:**
```
for each file:
  if size > 1MB → return true (conservative, SILENT)
  read as UTF-8, scan for ${property}
```

**After:**
```
for each file:
  if NUL byte in first 8KB → skip (binary), log DEBUG
  if size > configurable limit → return true (conservative), log WARN
  read as UTF-8, scan for ${property}
```

## Tests

All 113 existing tests pass with zero regressions. The backward-compatible `analyzeChanges()` overload ensures all existing call sites continue to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum resource file size limit (default: 10MB) to control resource scanning behavior during POM change analysis.

* **Improvements**
  * Enhanced file scanning with binary file detection and better handling of oversized files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->