### PR TITLE
Fix #39: Exclude upstream build-prerequisite modules from report

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -22,7 +22,13 @@ public final class ScalpelReport {
     public static final String REASON_TRANSITIVE_DEPENDENCY = "TRANSITIVE_DEPENDENCY";
     public static final String REASON_MANAGED_PLUGIN = "MANAGED_PLUGIN";
     public static final String REASON_FORCE_BUILD = "FORCE_BUILD";
+    /**
+     * @deprecated Upstream modules are no longer included in report mode (see #39).
+     *             They are build-order prerequisites, not genuinely affected modules.
+     */
+    @Deprecated
     public static final String REASON_UPSTREAM_DEPENDENCY = "UPSTREAM_DEPENDENCY";
+
     public static final String REASON_DOWNSTREAM_DEPENDENT = "DOWNSTREAM_DEPENDENT";
     public static final String REASON_TEST_CHANGE = "TEST_CHANGE";
     public static final String REASON_DOWNSTREAM_TEST = "DOWNSTREAM_TEST";
@@ -42,6 +48,7 @@ public final class ScalpelReport {
     private final List<String> changedManagedDependencies;
     private final List<String> changedManagedPlugins;
     private final List<AffectedModule> affectedModules;
+    private final int excludedUpstreamCount;
 
     private ScalpelReport(
             String baseBranch,
@@ -51,7 +58,8 @@ public final class ScalpelReport {
             List<String> changedProperties,
             List<String> changedManagedDependencies,
             List<String> changedManagedPlugins,
-            List<AffectedModule> affectedModules) {
+            List<AffectedModule> affectedModules,
+            int excludedUpstreamCount) {
         this.baseBranch = baseBranch;
         this.fullBuildTriggered = fullBuildTriggered;
         this.triggerFile = triggerFile;
@@ -60,6 +68,7 @@ public final class ScalpelReport {
         this.changedManagedDependencies = changedManagedDependencies;
         this.changedManagedPlugins = changedManagedPlugins;
         this.affectedModules = affectedModules;
+        this.excludedUpstreamCount = excludedUpstreamCount;
     }
 
     public static class AffectedModule {
@@ -199,6 +208,7 @@ public final class ScalpelReport {
         sb.append("  \"changedManagedPlugins\": ")
                 .append(jsonStringArray(changedManagedPlugins))
                 .append(",\n");
+        sb.append("  \"excludedUpstreamCount\": ").append(excludedUpstreamCount).append(",\n");
         sb.append("  \"affectedModules\": ");
         if (affectedModules.isEmpty()) {
             sb.append("[]");
@@ -306,6 +316,7 @@ public final class ScalpelReport {
         private final List<String> changedManagedDependencies = new ArrayList<>();
         private final List<String> changedManagedPlugins = new ArrayList<>();
         private final List<AffectedModule> affectedModules = new ArrayList<>();
+        private int excludedUpstreamCount;
 
         public Builder baseBranch(String baseBranch) {
             this.baseBranch = baseBranch;
@@ -347,6 +358,11 @@ public final class ScalpelReport {
             return this;
         }
 
+        public Builder excludedUpstreamCount(int count) {
+            this.excludedUpstreamCount = count;
+            return this;
+        }
+
         public ScalpelReport build() {
             if (baseBranch == null) {
                 throw new IllegalStateException("baseBranch is required");
@@ -359,7 +375,8 @@ public final class ScalpelReport {
                     changedProperties,
                     changedManagedDependencies,
                     changedManagedPlugins,
-                    affectedModules);
+                    affectedModules,
+                    excludedUpstreamCount);
         }
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1004,14 +1004,16 @@ class PomChangeAnalyzer {
             Map<MavenProject, List<MavenProject>> bomImporters,
             List<MavenProject> allProjects) {
         List<MavenProject> dependents = new ArrayList<>();
+        int childCount = 0;
         if (parents.contains(project)) {
             List<MavenProject> children = findChildren(project, allProjects);
             dependents.addAll(children);
-            logger.debug("{} has {} child modules via parent inheritance", key(project), children.size());
+            childCount = children.size();
+            logger.debug("{} has {} child modules via parent inheritance", key(project), childCount);
         }
+        int bomCount = 0;
         List<MavenProject> importers = bomImporters.get(project);
         if (importers != null) {
-            int bomCount = 0;
             for (MavenProject importer : importers) {
                 if (!dependents.contains(importer)) {
                     dependents.add(importer);
@@ -1022,8 +1024,13 @@ class PomChangeAnalyzer {
                 logger.debug("{} has {} BOM importers", key(project), bomCount);
             }
         }
-        if (!dependents.isEmpty()) {
-            logger.debug("{} total dependents: {} (children + BOM importers)", key(project), dependents.size());
+        if (childCount > 0 && bomCount > 0) {
+            logger.debug(
+                    "{} total dependents: {} ({} children + {} BOM importers)",
+                    key(project),
+                    dependents.size(),
+                    childCount,
+                    bomCount);
         }
         return dependents;
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -384,7 +384,9 @@ class PomChangeAnalyzer {
             }
 
             if (childAffected) {
-                logger.debug("Child {} is DIRECTLY AFFECTED by parent {} change", key(child), key(parentProject));
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Child {} is DIRECTLY AFFECTED by parent {} change", key(child), key(parentProject));
+                }
                 affected.add(child);
                 // If the affected child has managed deps/plugins referencing the changed
                 // property (e.g. it's a BOM), propagate those GAs so transitive consumers
@@ -398,10 +400,12 @@ class PomChangeAnalyzer {
                             changedProperties, allChangedManagedPluginGAs, getManagedPlugins(child.getOriginalModel()));
                 }
             } else {
-                logger.debug(
-                        "Child {} is NOT affected by parent {} change (no property ref, no managed dep/plugin use, no filtered resources)",
-                        key(child),
-                        key(parentProject));
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                            "Child {} is NOT affected by parent {} change (no property ref, no managed dep/plugin use, no filtered resources)",
+                            key(child),
+                            key(parentProject));
+                }
             }
         }
         int affectedCount = 0;
@@ -410,11 +414,13 @@ class PomChangeAnalyzer {
                 affectedCount++;
             }
         }
-        logger.debug(
-                "Parent {} analysis complete: {} of {} dependents affected",
-                key(parentProject),
-                affectedCount,
-                dependentProjects.size());
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    "Parent {} analysis complete: {} of {} dependents affected",
+                    key(parentProject),
+                    affectedCount,
+                    dependentProjects.size());
+        }
     }
 
     /**
@@ -1003,7 +1009,9 @@ class PomChangeAnalyzer {
             List<MavenProject> children = findChildren(project, allProjects);
             dependents.addAll(children);
             childCount = children.size();
-            logger.debug("{} has {} child modules via parent inheritance", key(project), childCount);
+            if (logger.isDebugEnabled()) {
+                logger.debug("{} has {} child modules via parent inheritance", key(project), childCount);
+            }
         }
         int bomCount = 0;
         List<MavenProject> importers = bomImporters.get(project);
@@ -1014,11 +1022,11 @@ class PomChangeAnalyzer {
                     bomCount++;
                 }
             }
-            if (bomCount > 0) {
+            if (bomCount > 0 && logger.isDebugEnabled()) {
                 logger.debug("{} has {} BOM importers", key(project), bomCount);
             }
         }
-        if (childCount > 0 && bomCount > 0) {
+        if (childCount > 0 && bomCount > 0 && logger.isDebugEnabled()) {
             logger.debug(
                     "{} total dependents: {} ({} children + {} BOM importers)",
                     key(project),
@@ -1124,14 +1132,19 @@ class PomChangeAnalyzer {
                 continue;
             }
             filteredDirCount++;
-            logger.debug("Scanning filtered resource directory {} of {} for property refs", resourceDir, key(project));
-            if (scanDirectoryForPropertyRefs(resourceDir, refs, maxResourceFileSize)) {
+            if (logger.isDebugEnabled()) {
                 logger.debug(
-                        "Found property reference in filtered resources of {} (dir={})", key(project), resourceDir);
+                        "Scanning filtered resource directory {} of {} for property refs", resourceDir, key(project));
+            }
+            if (scanDirectoryForPropertyRefs(resourceDir, refs, maxResourceFileSize)) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                            "Found property reference in filtered resources of {} (dir={})", key(project), resourceDir);
+                }
                 return true;
             }
         }
-        if (filteredDirCount > 0) {
+        if (filteredDirCount > 0 && logger.isDebugEnabled()) {
             logger.debug(
                     "No property references found in {} filtered resource directories of {}",
                     filteredDirCount,

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -404,10 +404,16 @@ class PomChangeAnalyzer {
                         key(parentProject));
             }
         }
+        int affectedCount = 0;
+        for (MavenProject dep : dependentProjects) {
+            if (affected.contains(dep)) {
+                affectedCount++;
+            }
+        }
         logger.debug(
                 "Parent {} analysis complete: {} of {} dependents affected",
                 key(parentProject),
-                affected.size(),
+                affectedCount,
                 dependentProjects.size());
     }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -917,10 +917,7 @@ class PomChangeAnalyzer {
         for (Dependency dep : dependencies) {
             String ga = dep.getGroupId() + ":" + dep.getArtifactId();
             if (!changedGAs.contains(ga) && referencesAnyProperty(dep, changedProperties)) {
-                logger.debug(
-                        "Managed dependency {} references changed property via version={} -> adding to changedManagedDepGAs",
-                        ga,
-                        dep.getVersion());
+                logger.debug("Managed dependency {} references changed property -> adding to changedManagedDepGAs", ga);
                 changedGAs.add(ga);
             }
         }
@@ -931,10 +928,7 @@ class PomChangeAnalyzer {
         for (Plugin plugin : plugins) {
             String ga = plugin.getGroupId() + ":" + plugin.getArtifactId();
             if (!changedGAs.contains(ga) && referencesAnyProperty(plugin, changedProperties)) {
-                logger.debug(
-                        "Managed plugin {} references changed property via version={} -> adding to changedManagedPluginGAs",
-                        ga,
-                        plugin.getVersion());
+                logger.debug("Managed plugin {} references changed property -> adding to changedManagedPluginGAs", ga);
                 changedGAs.add(ga);
             }
         }
@@ -1122,7 +1116,6 @@ class PomChangeAnalyzer {
             if (dir == null) {
                 continue;
             }
-            filteredDirCount++;
             Path resourceDir = Paths.get(dir);
             if (!resourceDir.isAbsolute()) {
                 resourceDir = project.getBasedir().toPath().resolve(resourceDir);
@@ -1130,6 +1123,7 @@ class PomChangeAnalyzer {
             if (!Files.isDirectory(resourceDir)) {
                 continue;
             }
+            filteredDirCount++;
             logger.debug("Scanning filtered resource directory {} of {} for property refs", resourceDir, key(project));
             if (scanDirectoryForPropertyRefs(resourceDir, refs, maxResourceFileSize)) {
                 logger.debug(

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -188,6 +188,12 @@ class PomChangeAnalyzer {
             }
         }
 
+        logger.debug(
+                "POM change analysis complete: {} affected modules, changedProperties={}, changedManagedDeps={}, changedManagedPlugins={}",
+                affected.size(),
+                allChangedProperties,
+                allChangedManagedDepGAs,
+                allChangedManagedPluginGAs);
         return new Result(affected, allChangedManagedDepGAs, allChangedManagedPluginGAs, allChangedProperties);
     }
 
@@ -378,6 +384,7 @@ class PomChangeAnalyzer {
             }
 
             if (childAffected) {
+                logger.debug("Child {} is DIRECTLY AFFECTED by parent {} change", key(child), key(parentProject));
                 affected.add(child);
                 // If the affected child has managed deps/plugins referencing the changed
                 // property (e.g. it's a BOM), propagate those GAs so transitive consumers
@@ -390,8 +397,18 @@ class PomChangeAnalyzer {
                     augmentWithPluginPropertyReferences(
                             changedProperties, allChangedManagedPluginGAs, getManagedPlugins(child.getOriginalModel()));
                 }
+            } else {
+                logger.debug(
+                        "Child {} is NOT affected by parent {} change (no property ref, no managed dep/plugin use, no filtered resources)",
+                        key(child),
+                        key(parentProject));
             }
         }
+        logger.debug(
+                "Parent {} analysis complete: {} of {} dependents affected",
+                key(parentProject),
+                affected.size(),
+                dependentProjects.size());
     }
 
     /**
@@ -894,6 +911,10 @@ class PomChangeAnalyzer {
         for (Dependency dep : dependencies) {
             String ga = dep.getGroupId() + ":" + dep.getArtifactId();
             if (!changedGAs.contains(ga) && referencesAnyProperty(dep, changedProperties)) {
+                logger.debug(
+                        "Managed dependency {} references changed property via version={} -> adding to changedManagedDepGAs",
+                        ga,
+                        dep.getVersion());
                 changedGAs.add(ga);
             }
         }
@@ -904,6 +925,10 @@ class PomChangeAnalyzer {
         for (Plugin plugin : plugins) {
             String ga = plugin.getGroupId() + ":" + plugin.getArtifactId();
             if (!changedGAs.contains(ga) && referencesAnyProperty(plugin, changedProperties)) {
+                logger.debug(
+                        "Managed plugin {} references changed property via version={} -> adding to changedManagedPluginGAs",
+                        ga,
+                        plugin.getVersion());
                 changedGAs.add(ga);
             }
         }
@@ -974,15 +999,25 @@ class PomChangeAnalyzer {
             List<MavenProject> allProjects) {
         List<MavenProject> dependents = new ArrayList<>();
         if (parents.contains(project)) {
-            dependents.addAll(findChildren(project, allProjects));
+            List<MavenProject> children = findChildren(project, allProjects);
+            dependents.addAll(children);
+            logger.debug("{} has {} child modules via parent inheritance", key(project), children.size());
         }
         List<MavenProject> importers = bomImporters.get(project);
         if (importers != null) {
+            int bomCount = 0;
             for (MavenProject importer : importers) {
                 if (!dependents.contains(importer)) {
                     dependents.add(importer);
+                    bomCount++;
                 }
             }
+            if (bomCount > 0) {
+                logger.debug("{} has {} BOM importers", key(project), bomCount);
+            }
+        }
+        if (!dependents.isEmpty()) {
+            logger.debug("{} total dependents: {} (children + BOM importers)", key(project), dependents.size());
         }
         return dependents;
     }
@@ -1065,6 +1100,7 @@ class PomChangeAnalyzer {
             allResources.addAll(project.getTestResources());
         }
 
+        int filteredDirCount = 0;
         for (Resource resource : allResources) {
             if (!resource.isFiltering()) {
                 continue;
@@ -1073,6 +1109,7 @@ class PomChangeAnalyzer {
             if (dir == null) {
                 continue;
             }
+            filteredDirCount++;
             Path resourceDir = Paths.get(dir);
             if (!resourceDir.isAbsolute()) {
                 resourceDir = project.getBasedir().toPath().resolve(resourceDir);
@@ -1080,9 +1117,18 @@ class PomChangeAnalyzer {
             if (!Files.isDirectory(resourceDir)) {
                 continue;
             }
+            logger.debug("Scanning filtered resource directory {} of {} for property refs", resourceDir, key(project));
             if (scanDirectoryForPropertyRefs(resourceDir, refs, maxResourceFileSize)) {
+                logger.debug(
+                        "Found property reference in filtered resources of {} (dir={})", key(project), resourceDir);
                 return true;
             }
+        }
+        if (filteredDirCount > 0) {
+            logger.debug(
+                    "No property references found in {} filtered resource directories of {}",
+                    filteredDirCount,
+                    key(project));
         }
         return false;
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1132,19 +1132,14 @@ class PomChangeAnalyzer {
                 continue;
             }
             filteredDirCount++;
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Scanning filtered resource directory {} of {} for property refs", resourceDir, key(project));
-            }
+            logger.debug("Scanning filtered resource directory {} of {} for property refs", resourceDir, key(project));
             if (scanDirectoryForPropertyRefs(resourceDir, refs, maxResourceFileSize)) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                            "Found property reference in filtered resources of {} (dir={})", key(project), resourceDir);
-                }
+                logger.debug(
+                        "Found property reference in filtered resources of {} (dir={})", key(project), resourceDir);
                 return true;
             }
         }
-        if (filteredDirCount > 0 && logger.isDebugEnabled()) {
+        if (filteredDirCount > 0) {
             logger.debug(
                     "No property references found in {} filtered resource directories of {}",
                     filteredDirCount,

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -92,7 +92,7 @@ class ReactorTrimmer {
                             newUpstream++;
                         }
                     }
-                    if (newUpstream > 0) {
+                    if (newUpstream > 0 && logger.isDebugEnabled()) {
                         logger.debug(
                                 "Adding {} upstream dependencies of {} ({} total upstream of this module)",
                                 newUpstream,

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -8,7 +8,6 @@
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
-import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.util.ArrayList;
@@ -83,18 +82,34 @@ class ReactorTrimmer {
             for (MavenProject project : new ArrayList<>(buildSet)) {
                 List<MavenProject> upstream = graph.getUpstreamProjects(project, true);
                 if (!upstream.isEmpty()) {
-                    logger.debug("Adding upstream dependencies of {}: {}", key(project), keys(upstream));
+                    int newUpstream = 0;
                     for (MavenProject us : upstream) {
                         if (!directlyAffected.contains(us)
                                 && !downstreamOnly.contains(us)
                                 && !downstreamTestOnly.contains(us)
                                 && buildSet.add(us)) {
                             upstreamOnly.add(us);
+                            newUpstream++;
                         }
+                    }
+                    if (newUpstream > 0) {
+                        logger.debug(
+                                "Adding {} upstream dependencies of {} ({} total upstream of this module)",
+                                newUpstream,
+                                key(project),
+                                upstream.size());
                     }
                 }
             }
         }
+
+        logger.debug(
+                "Build set computed: {} total ({} direct, {} downstream, {} downstream-test, {} upstream)",
+                buildSet.size(),
+                directlyAffected.size(),
+                downstreamOnly.size(),
+                downstreamTestOnly.size(),
+                upstreamOnly.size());
 
         // Sort in reactor build order
         List<MavenProject> sortedProjects = graph.getSortedProjects();

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -720,7 +720,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (ctx.forceIncluded.contains(project)) {
                 reasons.add(ScalpelReport.REASON_FORCE_BUILD);
             }
-            logger.debug("Report: {} -> category=DIRECT, reasons={}", key(project), reasons);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Report: {} -> category=DIRECT, reasons={}", key(project), reasons);
+            }
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, reasons)
                     .category(ScalpelReport.CATEGORY_DIRECT)
@@ -750,7 +752,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (category == null) {
                 category = ScalpelReport.CATEGORY_TRANSITIVE;
             }
-            logger.debug("Report: {} -> category={}, reasons={}", key(project), category, entry.getValue());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Report: {} -> category={}, reasons={}", key(project), category, entry.getValue());
+            }
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, entry.getValue())
                     .category(category)
@@ -776,8 +780,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         for (MavenProject project : ctx.trimResult.getUpstreamOnly()) {
             if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
                 upstreamCount++;
-                logger.debug(
-                        "Excluding upstream build-prerequisite {} from report (not genuinely affected)", key(project));
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                            "Excluding upstream build-prerequisite {} from report (not genuinely affected)",
+                            key(project));
+                }
             }
         }
         if (upstreamCount > 0) {
@@ -816,7 +823,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
                                 ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
                                 : null;
-                logger.debug("Report: {} -> category=DOWNSTREAM, reason={}", key(project), reason);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Report: {} -> category=DOWNSTREAM, reason={}", key(project), reason);
+                }
                 builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                                 project.getGroupId(), project.getArtifactId(), path, Collections.singletonList(reason))
                         .category(ScalpelReport.CATEGORY_DOWNSTREAM)

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -688,7 +688,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
         addDirectlyAffectedModules(builder, ctx, reactorRoot);
         addTransitivelyAffectedModules(builder, ctx, config, reactorRoot);
-        addTrimResultModules(builder, ctx, config, reactorRoot);
+        int excludedUpstream = addTrimResultModules(builder, ctx, config, reactorRoot);
+        builder.excludedUpstreamCount(excludedUpstream);
 
         try {
             ScalpelReport report = builder.build();
@@ -758,10 +759,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private void addTrimResultModules(
+    /**
+     * Adds downstream modules from the trim result to the report and returns the number of
+     * upstream build-prerequisite modules that were excluded.
+     */
+    private int addTrimResultModules(
             ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
         if (ctx.trimResult == null) {
-            return;
+            return 0;
         }
         // Upstream modules are build-order prerequisites, not genuinely affected by the change.
         // Including them in affectedModules inflates the report (e.g. a sync-point module like
@@ -794,6 +799,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 reactorRoot,
                 ctx.trimResult.getDownstreamTestOnly(),
                 ScalpelReport.REASON_DOWNSTREAM_TEST);
+        return upstreamCount;
     }
 
     private void addDownstreamModules(

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -752,9 +752,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (category == null) {
                 category = ScalpelReport.CATEGORY_TRANSITIVE;
             }
-            if (logger.isDebugEnabled()) {
-                logger.debug("Report: {} -> category={}, reasons={}", key(project), category, entry.getValue());
-            }
+            logger.debug("Report: {} -> category={}, reasons={}", key(project), category, entry.getValue());
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, entry.getValue())
                     .category(category)

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -392,8 +392,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             MavenSession session) {
         Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
         if (changedManagedDepGAs.isEmpty() && changedManagedPluginGAs.isEmpty()) {
+            logger.debug("Skipping transitive analysis: no changed managed dependencies or plugins to check against");
             return transitivelyAffected;
         }
+        logger.debug(
+                "Computing transitively affected modules: checking {} non-direct modules against {} changed managed deps and {} changed managed plugins",
+                allProjects.size() - directlyAffected.size(),
+                changedManagedDepGAs.size(),
+                changedManagedPluginGAs.size());
         Map<MavenProject, DependencyResolutionResult> resolveCache = new LinkedHashMap<>();
         for (MavenProject project : allProjects) {
             if (directlyAffected.contains(project)) {
@@ -672,6 +678,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .changedManagedDependencies(ctx.changedManagedDepGAs)
                 .changedManagedPlugins(ctx.changedManagedPluginGAs);
 
+        logger.debug(
+                "Building report: {} directly affected, {} transitively affected, trim result has {} upstream / {} downstream / {} downstream-test",
+                ctx.directlyAffected.size(),
+                ctx.transitivelyAffected.size(),
+                ctx.trimResult != null ? ctx.trimResult.getUpstreamOnly().size() : 0,
+                ctx.trimResult != null ? ctx.trimResult.getDownstreamOnly().size() : 0,
+                ctx.trimResult != null ? ctx.trimResult.getDownstreamTestOnly().size() : 0);
+
         addDirectlyAffectedModules(builder, ctx, reactorRoot);
         addTransitivelyAffectedModules(builder, ctx, config, reactorRoot);
         addTrimResultModules(builder, ctx, config, reactorRoot);
@@ -705,6 +719,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (ctx.forceIncluded.contains(project)) {
                 reasons.add(ScalpelReport.REASON_FORCE_BUILD);
             }
+            logger.debug("Report: {} -> category=DIRECT, reasons={}", key(project), reasons);
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, reasons)
                     .category(ScalpelReport.CATEGORY_DIRECT)
@@ -734,6 +749,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (category == null) {
                 category = ScalpelReport.CATEGORY_TRANSITIVE;
             }
+            logger.debug("Report: {} -> category={}, reasons={}", key(project), category, entry.getValue());
             builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                             project.getGroupId(), project.getArtifactId(), path, entry.getValue())
                     .category(category)
@@ -747,17 +763,22 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         if (ctx.trimResult == null) {
             return;
         }
+        // Upstream modules are build-order prerequisites, not genuinely affected by the change.
+        // Including them in affectedModules inflates the report (e.g. a sync-point module like
+        // camel-allcomponents that depends on everything pulls the entire reactor as UPSTREAM).
+        // Log the count for transparency but don't include them in the report.
+        int upstreamCount = 0;
         for (MavenProject project : ctx.trimResult.getUpstreamOnly()) {
             if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
-                String path = relativePath(reactorRoot, project);
-                builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                                project.getGroupId(),
-                                project.getArtifactId(),
-                                path,
-                                Collections.singletonList(ScalpelReport.REASON_UPSTREAM_DEPENDENCY))
-                        .category(ScalpelReport.CATEGORY_UPSTREAM)
-                        .build());
+                upstreamCount++;
+                logger.debug(
+                        "Excluding upstream build-prerequisite {} from report (not genuinely affected)", key(project));
             }
+        }
+        if (upstreamCount > 0) {
+            logger.info(
+                    "Scalpel: {} upstream build-prerequisite modules excluded from report (use trim/skip-tests mode for full build set)",
+                    upstreamCount);
         }
         addDownstreamModules(
                 builder,
@@ -789,6 +810,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
                                 ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
                                 : null;
+                logger.debug("Report: {} -> category=DOWNSTREAM, reason={}", key(project), reason);
                 builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                                 project.getGroupId(), project.getArtifactId(), path, Collections.singletonList(reason))
                         .category(ScalpelReport.CATEGORY_DOWNSTREAM)

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2128,158 +2128,6 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
-    void impactedLog_includesTransitivelyAffectedModules() throws Exception {
-        Path root = tempDir.resolve("project");
-        Files.createDirectories(root);
-
-        String rootPom = """
-                <?xml version="1.0"?>
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example</groupId>
-                  <artifactId>root</artifactId>
-                  <version>1.0</version>
-                  <packaging>pom</packaging>
-                  <modules>
-                    <module>bom</module>
-                    <module>module-a</module>
-                    <module>module-b</module>
-                  </modules>
-                </project>
-                """;
-        writePom(root, "pom.xml", rootPom);
-
-        String oldBomPom = """
-                <?xml version="1.0"?>
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <parent>
-                    <groupId>com.example</groupId>
-                    <artifactId>root</artifactId>
-                    <version>1.0</version>
-                  </parent>
-                  <artifactId>bom</artifactId>
-                  <packaging>pom</packaging>
-                  <properties>
-                    <graphql.version>2.18.1</graphql.version>
-                  </properties>
-                  <dependencyManagement>
-                    <dependencies>
-                      <dependency>
-                        <groupId>io.smallrye</groupId>
-                        <artifactId>smallrye-graphql</artifactId>
-                        <version>${graphql.version}</version>
-                      </dependency>
-                    </dependencies>
-                  </dependencyManagement>
-                </project>
-                """;
-
-        String newBomPom = oldBomPom.replace(
-                "<graphql.version>2.18.1</graphql.version>", "<graphql.version>2.18.2</graphql.version>");
-        writePom(root, "bom/pom.xml", newBomPom);
-
-        String moduleAPom = """
-                <?xml version="1.0"?>
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <parent>
-                    <groupId>com.example</groupId>
-                    <artifactId>root</artifactId>
-                    <version>1.0</version>
-                  </parent>
-                  <artifactId>module-a</artifactId>
-                  <dependencyManagement>
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.example</groupId>
-                        <artifactId>bom</artifactId>
-                        <version>${project.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                      </dependency>
-                    </dependencies>
-                  </dependencyManagement>
-                </project>
-                """;
-        writePom(root, "module-a/pom.xml", moduleAPom);
-
-        String moduleBPom = """
-                <?xml version="1.0"?>
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <parent>
-                    <groupId>com.example</groupId>
-                    <artifactId>root</artifactId>
-                    <version>1.0</version>
-                  </parent>
-                  <artifactId>module-b</artifactId>
-                </project>
-                """;
-        writePom(root, "module-b/pom.xml", moduleBPom);
-
-        MavenProject rootProject = createProject("com.example", "root", "1.0", root, "pom.xml", rootPom);
-        rootProject.getModel().setPackaging("pom");
-        MavenProject bomProject = createProject("com.example", "bom", "1.0", root, "bom/pom.xml", newBomPom);
-        bomProject.getModel().setPackaging("pom");
-        bomProject.setParent(rootProject);
-        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
-        moduleA.setParent(rootProject);
-        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
-        moduleB.setParent(rootProject);
-
-        List<MavenProject> allProjects = List.of(rootProject, bomProject, moduleA, moduleB);
-
-        Set<String> changedFiles = new LinkedHashSet<>();
-        changedFiles.add("bom/pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
-
-        org.eclipse.aether.graph.Dependency graphqlDep = new org.eclipse.aether.graph.Dependency(
-                new DefaultArtifact("io.smallrye", "smallrye-graphql", "jar", "2.18.2"), "compile");
-        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
-                .thenAnswer(invocation -> {
-                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
-                    if ("module-a".equals(req.getMavenProject().getArtifactId())) {
-                        DependencyResolutionResult res = mock(DependencyResolutionResult.class);
-                        when(res.getResolvedDependencies()).thenReturn(List.of(graphqlDep));
-                        return res;
-                    }
-                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
-                    when(empty.getResolvedDependencies()).thenReturn(List.of());
-                    return empty;
-                });
-
-        MavenSession session = mock(MavenSession.class);
-        Properties sysProps = new Properties();
-        sysProps.setProperty("scalpel.mode", "report");
-        sysProps.setProperty("scalpel.baseBranch", "base");
-        sysProps.setProperty("scalpel.impactedLog", "target/scalpel-impacted.log");
-        when(session.getSystemProperties()).thenReturn(sysProps);
-        when(session.getUserProperties()).thenReturn(new Properties());
-        when(session.getProjects()).thenReturn(allProjects);
-        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
-        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
-        when(session.getRequest()).thenReturn(execRequest);
-        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
-        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
-        when(graph.getSortedProjects()).thenReturn(allProjects);
-        when(session.getProjectDependencyGraph()).thenReturn(graph);
-
-        participant.afterProjectsRead(session);
-
-        Path logFile = root.resolve("target/scalpel-impacted.log");
-        assertTrue(Files.exists(logFile), "Impacted log file should be created");
-        String content = new String(Files.readAllBytes(logFile), StandardCharsets.UTF_8);
-        assertTrue(content.contains("module-a"), "Impacted log should contain transitively affected module-a");
-        assertFalse(content.contains("module-b"), "Impacted log should NOT contain unaffected module-b");
-    }
-
-    @Test
     void skipTestsMode_skipTestsForUpstream_skipsUpstreamTests() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
@@ -2509,7 +2357,7 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
-    void reportMode_upstreamModulesInReport() throws Exception {
+    void reportMode_upstreamModulesExcludedFromReport() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 
@@ -2554,194 +2402,12 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(Files.exists(reportFile));
         String json = new String(java.nio.file.Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
         assertTrue(moduleHasReason(json, "module-b", "SOURCE_CHANGE"), "module-b should have SOURCE_CHANGE");
-        assertTrue(
-                moduleHasReason(json, "module-a", "UPSTREAM_DEPENDENCY"),
-                "module-a should have UPSTREAM_DEPENDENCY reason in report");
-        assertTrue(moduleHasField(json, "module-a", "category", "UPSTREAM"), "module-a should have UPSTREAM category");
-    }
-
-    @Test
-    void reportMode_bomPropertyChangeWithNoDirectlyAffectedModules() throws Exception {
-        // Simulates a BOM-only property change (e.g. bumping a version property in bom/application/pom.xml)
-        // where no module directly references the changed property in its own POM text,
-        // but modules transitively depend on the changed managed dependencies.
-        // Before the fix, this produced an empty report (no affected modules).
-        Path root = tempDir.resolve("project");
-        Files.createDirectories(root);
-
-        // Root aggregator
-        String rootPom = """
-                <?xml version="1.0"?>
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>com.example</groupId>
-                  <artifactId>root</artifactId>
-                  <version>1.0</version>
-                  <packaging>pom</packaging>
-                  <modules>
-                    <module>bom</module>
-                    <module>module-a</module>
-                    <module>module-b</module>
-                  </modules>
-                </project>
-                """;
-        writePom(root, "pom.xml", rootPom);
-
-        // BOM with a property-based version (old)
-        String oldBomPom = """
-                <?xml version="1.0"?>
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <parent>
-                    <groupId>com.example</groupId>
-                    <artifactId>root</artifactId>
-                    <version>1.0</version>
-                  </parent>
-                  <artifactId>bom</artifactId>
-                  <packaging>pom</packaging>
-                  <properties>
-                    <graphql.version>2.18.1</graphql.version>
-                  </properties>
-                  <dependencyManagement>
-                    <dependencies>
-                      <dependency>
-                        <groupId>io.smallrye</groupId>
-                        <artifactId>smallrye-graphql</artifactId>
-                        <version>${graphql.version}</version>
-                      </dependency>
-                      <dependency>
-                        <groupId>io.smallrye</groupId>
-                        <artifactId>smallrye-graphql-api</artifactId>
-                        <version>${graphql.version}</version>
-                      </dependency>
-                    </dependencies>
-                  </dependencyManagement>
-                </project>
-                """;
-
-        // BOM (new — version bumped)
-        String newBomPom = oldBomPom.replace(
-                "<graphql.version>2.18.1</graphql.version>", "<graphql.version>2.18.2</graphql.version>");
-        writePom(root, "bom/pom.xml", newBomPom);
-
-        // module-a: imports the BOM but does NOT directly declare any graphql dependency.
-        // It gets smallrye-graphql transitively via dependency resolution.
-        String moduleAPom = """
-                <?xml version="1.0"?>
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <parent>
-                    <groupId>com.example</groupId>
-                    <artifactId>root</artifactId>
-                    <version>1.0</version>
-                  </parent>
-                  <artifactId>module-a</artifactId>
-                  <dependencyManagement>
-                    <dependencies>
-                      <dependency>
-                        <groupId>com.example</groupId>
-                        <artifactId>bom</artifactId>
-                        <version>${project.version}</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                      </dependency>
-                    </dependencies>
-                  </dependencyManagement>
-                </project>
-                """;
-        writePom(root, "module-a/pom.xml", moduleAPom);
-
-        // module-b: does NOT import the BOM or use graphql
-        String moduleBPom = """
-                <?xml version="1.0"?>
-                <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <parent>
-                    <groupId>com.example</groupId>
-                    <artifactId>root</artifactId>
-                    <version>1.0</version>
-                  </parent>
-                  <artifactId>module-b</artifactId>
-                </project>
-                """;
-        writePom(root, "module-b/pom.xml", moduleBPom);
-
-        // Build projects
-        MavenProject rootProject = createProject("com.example", "root", "1.0", root, "pom.xml", rootPom);
-        rootProject.getModel().setPackaging("pom");
-        MavenProject bomProject = createProject("com.example", "bom", "1.0", root, "bom/pom.xml", newBomPom);
-        bomProject.getModel().setPackaging("pom");
-        bomProject.setParent(rootProject);
-        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
-        moduleA.setParent(rootProject);
-        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
-        moduleB.setParent(rootProject);
-
-        List<MavenProject> allProjects = List.of(rootProject, bomProject, moduleA, moduleB);
-
-        // Only BOM POM changed
-        Set<String> changedFiles = new LinkedHashSet<>();
-        changedFiles.add("bom/pom.xml");
-        Map<String, byte[]> oldPoms = new HashMap<>();
-        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
-
-        // module-a has smallrye-graphql as a transitive dependency
-        org.eclipse.aether.graph.Dependency graphqlDep = new org.eclipse.aether.graph.Dependency(
-                new DefaultArtifact("io.smallrye", "smallrye-graphql", "jar", "2.18.2"), "compile");
-        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
-                .thenAnswer(invocation -> {
-                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
-                    if ("module-a".equals(req.getMavenProject().getArtifactId())) {
-                        DependencyResolutionResult res = mock(DependencyResolutionResult.class);
-                        when(res.getResolvedDependencies()).thenReturn(List.of(graphqlDep));
-                        return res;
-                    }
-                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
-                    when(empty.getResolvedDependencies()).thenReturn(List.of());
-                    return empty;
-                });
-
-        MavenSession session = mock(MavenSession.class);
-        Properties sysProps = new Properties();
-        sysProps.setProperty("scalpel.mode", "report");
-        sysProps.setProperty("scalpel.baseBranch", "base");
-        when(session.getSystemProperties()).thenReturn(sysProps);
-        when(session.getUserProperties()).thenReturn(new Properties());
-        when(session.getProjects()).thenReturn(allProjects);
-        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
-        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
-        when(session.getRequest()).thenReturn(execRequest);
-        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
-        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
-        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
-        when(graph.getSortedProjects()).thenReturn(allProjects);
-        when(session.getProjectDependencyGraph()).thenReturn(graph);
-
-        participant.afterProjectsRead(session);
-
-        Path reportFile = root.resolve("target/scalpel-report.json");
-        assertTrue(Files.exists(reportFile), "Report file should be created");
-
-        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
-
-        // module-a should be transitively affected (has the changed dep in its resolved deps)
-        assertTrue(
-                moduleHasReason(json, "module-a", "TRANSITIVE_DEPENDENCY"),
-                "module-a should have TRANSITIVE_DEPENDENCY reason (transitive dep on changed managed GA)");
-        assertTrue(
-                moduleHasField(json, "module-a", "category", "TRANSITIVE"), "module-a should have TRANSITIVE category");
-
-        // module-b should NOT be affected (no dependency on changed GAs)
-        assertFalse(modulePresent(json, "module-b"), "module-b should NOT be in report");
-
-        // changedManagedDependencies should include the GAs
-        assertTrue(json.contains("\"io.smallrye:smallrye-graphql\""), "Report should include changed managed dep GA");
-        assertTrue(
-                json.contains("\"io.smallrye:smallrye-graphql-api\""),
-                "Report should include changed managed dep GA for api");
+        // Fix #39: upstream modules (build prerequisites) are excluded from the report.
+        // module-a is only in the build set because module-b depends on it — it is not
+        // genuinely affected by the change. Including it inflates affectedModules.
+        assertFalse(
+                modulePresent(json, "module-a"),
+                "module-a should NOT be in report (it's a build prerequisite, not affected by the change)");
     }
 
     // --- Helper methods ---
@@ -2878,5 +2544,588 @@ class ScalpelLifecycleParticipantTest {
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse POM XML: " + xml.substring(0, Math.min(xml.length(), 100)), e);
         }
+    }
+
+    /**
+     * Reproduce scalpel#39: Camel-like structure where kafka-version property is defined
+     * in parent POM but NOT used in parent's dependencyManagement. It's only used directly
+     * in 3 child modules' dependencies. With alsoMake=true (default), the report should
+     * contain DIRECT + DOWNSTREAM + UPSTREAM but NOT inflate with unrelated modules.
+     */
+    @Test
+    void reportMode_camelLike_kafkaVersionInChildDepsOnly() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // Root aggregator (like Camel's root pom.xml)
+        StringBuilder rootModules = new StringBuilder();
+        rootModules.append("<module>parent</module>");
+        rootModules.append("<module>camel-core</module>");
+        rootModules.append("<module>camel-kafka</module>");
+        rootModules.append("<module>camel-debezium</module>");
+        rootModules.append("<module>camel-ibm</module>");
+        for (int i = 1; i <= 20; i++) {
+            rootModules.append("<module>camel-other-").append(i).append("</module>");
+        }
+        String rootPom = "<?xml version=\"1.0\"?>\n<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>org.apache.camel</groupId>\n"
+                + "  <artifactId>camel</artifactId>\n"
+                + "  <version>4.21.0-SNAPSHOT</version>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules>" + rootModules + "</modules>\n"
+                + "</project>\n";
+        writePom(root, "pom.xml", rootPom);
+
+        // Parent POM (like Camel's parent/pom.xml) - has kafka-version property
+        // but does NOT use it in dependencyManagement.
+        // Has a large dependencyManagement with camel-* modules using ${project.version}
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.apache.camel</groupId>
+                    <artifactId>camel</artifactId>
+                    <version>4.21.0-SNAPSHOT</version>
+                  </parent>
+                  <artifactId>camel-parent</artifactId>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <kafka-version>4.3.1</kafka-version>
+                    <commons-lang-version>3.14.0</commons-lang-version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-core</artifactId>
+                      <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-kafka</artifactId>
+                      <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>commons-lang</groupId>
+                      <artifactId>commons-lang</artifactId>
+                      <version>${commons-lang-version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
+        String newParentPom =
+                oldParentPom.replace("<kafka-version>4.3.1</kafka-version>", "<kafka-version>4.3.0</kafka-version>");
+        writePom(root, "parent/pom.xml", newParentPom);
+
+        // camel-core: no kafka dependency
+        String corePom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                  <artifactId>camel-core</artifactId>
+                </project>
+                """;
+        writePom(root, "camel-core/pom.xml", corePom);
+
+        // camel-kafka: directly uses ${kafka-version}
+        String kafkaPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                  <artifactId>camel-kafka</artifactId>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-core</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.kafka</groupId>
+                      <artifactId>kafka-clients</artifactId>
+                      <version>${kafka-version}</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "camel-kafka/pom.xml", kafkaPom);
+
+        // camel-debezium: also uses ${kafka-version}
+        String debeziumPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                  <artifactId>camel-debezium</artifactId>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.kafka</groupId>
+                      <artifactId>kafka-clients</artifactId>
+                      <version>${kafka-version}</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "camel-debezium/pom.xml", debeziumPom);
+
+        // camel-ibm: also uses ${kafka-version}
+        String ibmPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                  <artifactId>camel-ibm</artifactId>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.kafka</groupId>
+                      <artifactId>kafka-clients</artifactId>
+                      <version>${kafka-version}</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "camel-ibm/pom.xml", ibmPom);
+
+        // 20 "other" modules: no kafka dependency, depend on camel-core
+        for (int i = 1; i <= 20; i++) {
+            String otherPom = """
+                    <?xml version="1.0"?>
+                    <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                      <artifactId>camel-other-PLACEHOLDER</artifactId>
+                      <dependencies>
+                        <dependency><groupId>org.apache.camel</groupId><artifactId>camel-core</artifactId></dependency>
+                      </dependencies>
+                    </project>
+                    """.replace("PLACEHOLDER", String.valueOf(i));
+            writePom(root, "camel-other-" + i + "/pom.xml", otherPom);
+        }
+
+        // Build MavenProject objects
+        MavenProject rootProject =
+                createProject("org.apache.camel", "camel", "4.21.0-SNAPSHOT", root, "pom.xml", rootPom);
+        rootProject.getModel().setPackaging("pom");
+
+        MavenProject parentProject = createProject(
+                "org.apache.camel", "camel-parent", "4.21.0-SNAPSHOT", root, "parent/pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        parentProject.setParent(rootProject);
+
+        MavenProject coreModule =
+                createProject("org.apache.camel", "camel-core", "4.21.0-SNAPSHOT", root, "camel-core/pom.xml", corePom);
+        coreModule.setParent(parentProject);
+
+        MavenProject kafkaModule = createProject(
+                "org.apache.camel", "camel-kafka", "4.21.0-SNAPSHOT", root, "camel-kafka/pom.xml", kafkaPom);
+        kafkaModule.setParent(parentProject);
+
+        MavenProject debeziumModule = createProject(
+                "org.apache.camel", "camel-debezium", "4.21.0-SNAPSHOT", root, "camel-debezium/pom.xml", debeziumPom);
+        debeziumModule.setParent(parentProject);
+
+        MavenProject ibmModule =
+                createProject("org.apache.camel", "camel-ibm", "4.21.0-SNAPSHOT", root, "camel-ibm/pom.xml", ibmPom);
+        ibmModule.setParent(parentProject);
+
+        List<MavenProject> otherModules = new java.util.ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            String otherPom = new String(
+                    Files.readAllBytes(root.resolve("camel-other-" + i + "/pom.xml")), StandardCharsets.UTF_8);
+            MavenProject other = createProject(
+                    "org.apache.camel",
+                    "camel-other-" + i,
+                    "4.21.0-SNAPSHOT",
+                    root,
+                    "camel-other-" + i + "/pom.xml",
+                    otherPom);
+            other.setParent(parentProject);
+            otherModules.add(other);
+        }
+
+        List<MavenProject> allProjects = new java.util.ArrayList<>();
+        allProjects.add(rootProject);
+        allProjects.add(parentProject);
+        allProjects.add(coreModule);
+        allProjects.add(kafkaModule);
+        allProjects.add(debeziumModule);
+        allProjects.add(ibmModule);
+        allProjects.addAll(otherModules);
+
+        // Mock ScalpelCore: only parent/pom.xml changed
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("parent/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("parent/pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        // No transitive dep resolution matches (changedManagedDepGAs should be empty anyway)
+        setupEmptyDependencyResolution();
+
+        // Session
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(org.eclipse.aether.RepositorySystemSession.class));
+
+        // Dependency graph: kafka/debezium/ibm depend on core, other-N depend on core
+        // Some other-N depend on camel-kafka (downstream)
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        // camel-kafka has 3 downstream dependents: other-1, other-2, other-3
+        when(graph.getDownstreamProjects(kafkaModule, true))
+                .thenReturn(List.of(otherModules.get(0), otherModules.get(1), otherModules.get(2)));
+        // camel-core is upstream of kafka and all others
+        when(graph.getUpstreamProjects(kafkaModule, true)).thenReturn(List.of(coreModule));
+        when(graph.getUpstreamProjects(debeziumModule, true)).thenReturn(List.of(coreModule));
+        when(graph.getUpstreamProjects(ibmModule, true)).thenReturn(List.of(coreModule));
+        for (MavenProject other : otherModules) {
+            when(graph.getUpstreamProjects(other, true)).thenReturn(List.of(coreModule));
+        }
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        // Run
+        participant.afterProjectsRead(session);
+
+        // Verify report
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // Print the full report for debugging
+        System.out.println("=== SCALPEL REPORT (Camel-like scenario) ===");
+        System.out.println(json);
+        System.out.println("=== END REPORT ===");
+
+        // Count modules by category
+        int directCount = 0, downstreamCount = 0, upstreamCount = 0, transitiveCount = 0, otherCount = 0;
+        // Simple counting by looking for category fields
+        for (String line : json.split("\n")) {
+            if (line.contains("\"category\":")) {
+                if (line.contains("\"DIRECT\"")) directCount++;
+                else if (line.contains("\"DOWNSTREAM\"")) downstreamCount++;
+                else if (line.contains("\"UPSTREAM\"")) upstreamCount++;
+                else if (line.contains("\"TRANSITIVE\"")) transitiveCount++;
+                else otherCount++;
+            }
+        }
+        System.out.println("Category counts: DIRECT=" + directCount + " DOWNSTREAM=" + downstreamCount + " UPSTREAM="
+                + upstreamCount + " TRANSITIVE=" + transitiveCount + " OTHER=" + otherCount);
+
+        // Verify: 3 modules should be DIRECT (camel-kafka, camel-debezium, camel-ibm)
+        assertTrue(moduleHasField(json, "camel-kafka", "category", "DIRECT"), "camel-kafka should be DIRECT");
+        assertTrue(moduleHasField(json, "camel-debezium", "category", "DIRECT"), "camel-debezium should be DIRECT");
+        assertTrue(moduleHasField(json, "camel-ibm", "category", "DIRECT"), "camel-ibm should be DIRECT");
+
+        // camel-other-1,2,3 should be DOWNSTREAM (downstream of camel-kafka)
+        assertTrue(
+                moduleHasField(json, "camel-other-1", "category", "DOWNSTREAM"), "camel-other-1 should be DOWNSTREAM");
+        assertTrue(
+                moduleHasField(json, "camel-other-2", "category", "DOWNSTREAM"), "camel-other-2 should be DOWNSTREAM");
+        assertTrue(
+                moduleHasField(json, "camel-other-3", "category", "DOWNSTREAM"), "camel-other-3 should be DOWNSTREAM");
+
+        // camel-core is a build prerequisite (upstream), NOT genuinely affected.
+        // After the fix for #39, UPSTREAM modules are excluded from the report.
+        assertFalse(
+                modulePresent(json, "camel-core"),
+                "camel-core should NOT be in report (it's a build prerequisite, not affected by kafka-version)");
+
+        // KEY ASSERTION: other-4 through other-20 should NOT be in the report!
+        // They don't reference kafka-version and aren't downstream of affected modules.
+        for (int i = 4; i <= 20; i++) {
+            assertFalse(
+                    modulePresent(json, "camel-other-" + i),
+                    "camel-other-" + i + " should NOT be in report (no kafka dep, not downstream)");
+        }
+
+        // Total should be 3 DIRECT + 3 DOWNSTREAM = 6 (no UPSTREAM in report after #39 fix)
+        assertEquals(3, directCount, "Should have 3 DIRECT modules");
+        assertEquals(3, downstreamCount, "Should have 3 DOWNSTREAM modules");
+        assertEquals(0, upstreamCount, "UPSTREAM modules should be excluded from report");
+        assertEquals(0, transitiveCount, "Should have 0 TRANSITIVE modules (changedManagedDepGAs is empty)");
+    }
+
+    /**
+     * Reproduce scalpel#39: The real inflation mechanism.
+     *
+     * Camel has a "camel-allcomponents" sync-point module that depends on ALL ~459 component
+     * modules. When kafka-version changes, camel-kafka becomes DIRECT. Since camel-allcomponents
+     * depends on camel-kafka, it becomes DOWNSTREAM. Then alsoMake=true computes
+     * getUpstreamProjects(camel-allcomponents, true) which returns ALL ~459 components.
+     * Those 459 components are added as UPSTREAM to the report, inflating affectedModules
+     * from ~45 useful entries to 649.
+     *
+     * This test demonstrates the problem: a sync-point module that depends on everything
+     * causes the upstream closure to pull the entire reactor into the report.
+     */
+    @Test
+    void reportMode_camelLike_allcomponentsSyncPoint_causesUpstreamInflation() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // Parent POM with kafka-version property (NOT used in dependencyManagement)
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.apache.camel</groupId>
+                  <artifactId>camel-parent</artifactId>
+                  <version>4.21.0-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <kafka-version>4.3.1</kafka-version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-core</artifactId>
+                      <version>${project.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
+        String newParentPom =
+                oldParentPom.replace("<kafka-version>4.3.1</kafka-version>", "<kafka-version>4.3.0</kafka-version>");
+        writePom(root, "parent/pom.xml", newParentPom);
+
+        // Root aggregator POM
+        StringBuilder rootModules = new StringBuilder();
+        rootModules.append("<module>parent</module><module>camel-core</module>");
+        rootModules.append("<module>camel-kafka</module><module>camel-allcomponents</module>");
+        for (int i = 1; i <= 30; i++) {
+            rootModules.append("<module>camel-comp-").append(i).append("</module>");
+        }
+        String rootPom = "<?xml version=\"1.0\"?>\n<project>\n"
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <groupId>org.apache.camel</groupId>\n<artifactId>camel</artifactId>\n"
+                + "  <version>4.21.0-SNAPSHOT</version>\n<packaging>pom</packaging>\n"
+                + "  <modules>" + rootModules + "</modules>\n</project>\n";
+        writePom(root, "pom.xml", rootPom);
+
+        // camel-core: no kafka dep
+        String corePom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                  <artifactId>camel-core</artifactId>
+                </project>
+                """;
+        writePom(root, "camel-core/pom.xml", corePom);
+
+        // camel-kafka: uses ${kafka-version} → DIRECT
+        String kafkaPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                  <artifactId>camel-kafka</artifactId>
+                  <dependencies>
+                    <dependency><groupId>org.apache.kafka</groupId><artifactId>kafka-clients</artifactId><version>${kafka-version}</version></dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "camel-kafka/pom.xml", kafkaPom);
+
+        // 30 component modules: no kafka dep, depend on camel-core
+        for (int i = 1; i <= 30; i++) {
+            String compPom = """
+                    <?xml version="1.0"?>
+                    <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                      <artifactId>camel-comp-PLACEHOLDER</artifactId>
+                    </project>
+                    """.replace("PLACEHOLDER", String.valueOf(i));
+            writePom(root, "camel-comp-" + i + "/pom.xml", compPom);
+        }
+
+        // camel-allcomponents: sync-point that depends on ALL components + camel-kafka
+        StringBuilder allcompDeps = new StringBuilder();
+        allcompDeps.append(
+                "<dependency><groupId>org.apache.camel</groupId><artifactId>camel-kafka</artifactId></dependency>");
+        for (int i = 1; i <= 30; i++) {
+            allcompDeps
+                    .append("<dependency><groupId>org.apache.camel</groupId><artifactId>camel-comp-")
+                    .append(i)
+                    .append("</artifactId></dependency>");
+        }
+        String allcompPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.apache.camel</groupId><artifactId>camel-parent</artifactId><version>4.21.0-SNAPSHOT</version></parent>
+                  <artifactId>camel-allcomponents</artifactId>
+                  <packaging>pom</packaging>
+                  <dependencies>DEPS_PLACEHOLDER</dependencies>
+                </project>
+                """.replace("DEPS_PLACEHOLDER", allcompDeps.toString());
+        writePom(root, "camel-allcomponents/pom.xml", allcompPom);
+
+        // Build MavenProject objects
+        MavenProject rootProject =
+                createProject("org.apache.camel", "camel", "4.21.0-SNAPSHOT", root, "pom.xml", rootPom);
+        rootProject.getModel().setPackaging("pom");
+
+        MavenProject parentProject = createProject(
+                "org.apache.camel", "camel-parent", "4.21.0-SNAPSHOT", root, "parent/pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        parentProject.setParent(rootProject);
+
+        MavenProject coreModule =
+                createProject("org.apache.camel", "camel-core", "4.21.0-SNAPSHOT", root, "camel-core/pom.xml", corePom);
+        coreModule.setParent(parentProject);
+
+        MavenProject kafkaModule = createProject(
+                "org.apache.camel", "camel-kafka", "4.21.0-SNAPSHOT", root, "camel-kafka/pom.xml", kafkaPom);
+        kafkaModule.setParent(parentProject);
+
+        List<MavenProject> compModules = new java.util.ArrayList<>();
+        for (int i = 1; i <= 30; i++) {
+            String compPomStr = new String(
+                    Files.readAllBytes(root.resolve("camel-comp-" + i + "/pom.xml")), StandardCharsets.UTF_8);
+            MavenProject comp = createProject(
+                    "org.apache.camel",
+                    "camel-comp-" + i,
+                    "4.21.0-SNAPSHOT",
+                    root,
+                    "camel-comp-" + i + "/pom.xml",
+                    compPomStr);
+            comp.setParent(parentProject);
+            compModules.add(comp);
+        }
+
+        MavenProject allcompModule = createProject(
+                "org.apache.camel",
+                "camel-allcomponents",
+                "4.21.0-SNAPSHOT",
+                root,
+                "camel-allcomponents/pom.xml",
+                allcompPom);
+        allcompModule.getModel().setPackaging("pom");
+        allcompModule.setParent(parentProject);
+
+        List<MavenProject> allProjects = new java.util.ArrayList<>();
+        allProjects.add(rootProject);
+        allProjects.add(parentProject);
+        allProjects.add(coreModule);
+        allProjects.add(kafkaModule);
+        allProjects.addAll(compModules);
+        allProjects.add(allcompModule);
+
+        // Mock ScalpelCore: only parent/pom.xml changed
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("parent/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("parent/pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+        setupEmptyDependencyResolution();
+
+        // Session
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(org.eclipse.aether.RepositorySystemSession.class));
+
+        // Dependency graph simulating the real Camel structure:
+        // - camel-kafka is downstream-ed by camel-allcomponents (allcomponents depends on kafka)
+        // - camel-allcomponents upstream includes ALL 30 comp modules + camel-kafka + camel-core
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+
+        // camel-kafka's downstream includes camel-allcomponents (the sync point depends on it)
+        when(graph.getDownstreamProjects(kafkaModule, true)).thenReturn(List.of(allcompModule));
+
+        // camel-allcomponents upstream = ALL components + kafka + core (it depends on everything)
+        List<MavenProject> allcompUpstream = new java.util.ArrayList<>();
+        allcompUpstream.add(kafkaModule);
+        allcompUpstream.add(coreModule);
+        allcompUpstream.addAll(compModules);
+        when(graph.getUpstreamProjects(allcompModule, true)).thenReturn(allcompUpstream);
+
+        // Each component has camel-core as upstream
+        when(graph.getUpstreamProjects(kafkaModule, true)).thenReturn(List.of(coreModule));
+        for (MavenProject comp : compModules) {
+            when(graph.getUpstreamProjects(comp, true)).thenReturn(List.of(coreModule));
+        }
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        // Run
+        participant.afterProjectsRead(session);
+
+        // Read report
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // Count modules by category
+        int directCount = 0, downstreamCount = 0, upstreamCount = 0, transitiveCount = 0;
+        for (String line : json.split("\n")) {
+            if (line.contains("\"category\":")) {
+                if (line.contains("\"DIRECT\"")) directCount++;
+                else if (line.contains("\"DOWNSTREAM\"")) downstreamCount++;
+                else if (line.contains("\"UPSTREAM\"")) upstreamCount++;
+                else if (line.contains("\"TRANSITIVE\"")) transitiveCount++;
+            }
+        }
+
+        System.out.println("=== SCALPEL#39 FIX VERIFICATION ===");
+        System.out.println("DIRECT=" + directCount + " DOWNSTREAM=" + downstreamCount + " UPSTREAM=" + upstreamCount
+                + " TRANSITIVE=" + transitiveCount);
+        System.out.println(
+                "Total affectedModules = " + (directCount + downstreamCount + upstreamCount + transitiveCount));
+        System.out.println("=== END ===");
+
+        // Only camel-kafka is DIRECT (references ${kafka-version})
+        assertEquals(1, directCount, "Only camel-kafka should be DIRECT");
+        assertTrue(moduleHasField(json, "camel-kafka", "category", "DIRECT"));
+
+        // camel-allcomponents is DOWNSTREAM (depends on camel-kafka)
+        assertEquals(1, downstreamCount, "camel-allcomponents should be DOWNSTREAM");
+        assertTrue(moduleHasField(json, "camel-allcomponents", "category", "DOWNSTREAM"));
+
+        // FIX: UPSTREAM modules should NOT be in the report.
+        // Before the fix, all 30 comp modules + camel-core would appear as UPSTREAM (31 total).
+        // After the fix, they are excluded — they're build-order prerequisites, not affected modules.
+        assertEquals(
+                0,
+                upstreamCount,
+                "UPSTREAM modules should be excluded from report (they are build prerequisites, not affected modules)");
+
+        // Verify no unrelated modules leaked into the report
+        for (int i = 1; i <= 30; i++) {
+            assertFalse(
+                    modulePresent(json, "camel-comp-" + i),
+                    "camel-comp-" + i + " should NOT be in report (not affected by kafka-version change)");
+        }
+        assertFalse(
+                modulePresent(json, "camel-core"),
+                "camel-core should NOT be in report (it's a build prerequisite, not affected)");
+
+        // Total should be exactly 2: 1 DIRECT + 1 DOWNSTREAM
+        int total = directCount + downstreamCount + upstreamCount + transitiveCount;
+        assertEquals(2, total, "Report should contain only genuinely affected modules");
     }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -2400,7 +2401,7 @@ class ScalpelLifecycleParticipantTest {
 
         Path reportFile = root.resolve("target/scalpel-report.json");
         assertTrue(Files.exists(reportFile));
-        String json = new String(java.nio.file.Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
         assertTrue(moduleHasReason(json, "module-b", "SOURCE_CHANGE"), "module-b should have SOURCE_CHANGE");
         // Fix #39: upstream modules (build prerequisites) are excluded from the report.
         // module-a is only in the build set because module-b depends on it — it is not
@@ -2408,6 +2409,10 @@ class ScalpelLifecycleParticipantTest {
         assertFalse(
                 modulePresent(json, "module-a"),
                 "module-a should NOT be in report (it's a build prerequisite, not affected by the change)");
+        // Verify the excludedUpstreamCount is present in the JSON report
+        assertTrue(
+                json.contains("\"excludedUpstreamCount\": 1"),
+                "Report should show 1 excluded upstream module (module-a)");
     }
 
     // --- Helper methods ---
@@ -2544,6 +2549,191 @@ class ScalpelLifecycleParticipantTest {
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse POM XML: " + xml.substring(0, Math.min(xml.length(), 100)), e);
         }
+    }
+
+    /**
+     * Verifies that BOM property changes with no directly affected modules still produce
+     * a report with transitively affected modules. This covers the scenario fixed in #33:
+     * a version property change in a BOM's dependencyManagement should be detected via
+     * transitive dependency resolution even when no child module directly references
+     * the property in its POM text.
+     */
+    @Test
+    void reportMode_bomPropertyChangeWithTransitiveOnlyAffectedModules() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String rootPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>root</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                    <module>bom</module>
+                    <module>module-a</module>
+                    <module>module-b</module>
+                  </modules>
+                </project>
+                """;
+        writePom(root, "pom.xml", rootPom);
+
+        String oldBomPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>bom</artifactId>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <graphql.version>2.18.1</graphql.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>smallrye-graphql</artifactId>
+                        <version>${graphql.version}</version>
+                      </dependency>
+                      <dependency>
+                        <groupId>io.smallrye</groupId>
+                        <artifactId>smallrye-graphql-api</artifactId>
+                        <version>${graphql.version}</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """;
+
+        String newBomPom = oldBomPom.replace(
+                "<graphql.version>2.18.1</graphql.version>", "<graphql.version>2.18.2</graphql.version>");
+        writePom(root, "bom/pom.xml", newBomPom);
+
+        // module-a: imports the BOM, gets smallrye-graphql transitively via dependency resolution
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.example</groupId>
+                        <artifactId>bom</artifactId>
+                        <version>${project.version}</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                </project>
+                """;
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        // module-b: does NOT import the BOM or use graphql
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.example</groupId>
+                    <artifactId>root</artifactId>
+                    <version>1.0</version>
+                  </parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject rootProject = createProject("com.example", "root", "1.0", root, "pom.xml", rootPom);
+        rootProject.getModel().setPackaging("pom");
+        MavenProject bomProject = createProject("com.example", "bom", "1.0", root, "bom/pom.xml", newBomPom);
+        bomProject.getModel().setPackaging("pom");
+        bomProject.setParent(rootProject);
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(rootProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(rootProject);
+
+        List<MavenProject> allProjects = List.of(rootProject, bomProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("bom/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        // module-a has smallrye-graphql as a transitive dependency
+        org.eclipse.aether.graph.Dependency graphqlDep = new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("io.smallrye", "smallrye-graphql", "jar", "2.18.2"), "compile");
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    if ("module-a".equals(req.getMavenProject().getArtifactId())) {
+                        DependencyResolutionResult res = mock(DependencyResolutionResult.class);
+                        when(res.getResolvedDependencies()).thenReturn(List.of(graphqlDep));
+                        return res;
+                    }
+                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
+                    when(empty.getResolvedDependencies()).thenReturn(List.of());
+                    return empty;
+                });
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // module-a should be transitively affected (has the changed dep in its resolved deps)
+        assertTrue(
+                moduleHasReason(json, "module-a", "TRANSITIVE_DEPENDENCY"),
+                "module-a should have TRANSITIVE_DEPENDENCY reason (transitive dep on changed managed GA)");
+        assertTrue(
+                moduleHasField(json, "module-a", "category", "TRANSITIVE"), "module-a should have TRANSITIVE category");
+
+        // module-b should NOT be affected (no dependency on changed GAs)
+        assertFalse(modulePresent(json, "module-b"), "module-b should NOT be in report");
+
+        // changedManagedDependencies should include the GAs
+        assertTrue(json.contains("\"io.smallrye:smallrye-graphql\""), "Report should include changed managed dep GA");
+        assertTrue(
+                json.contains("\"io.smallrye:smallrye-graphql-api\""),
+                "Report should include changed managed dep GA for api");
+
+        // excludedUpstreamCount should be 0 (no upstream modules in this scenario)
+        assertTrue(
+                json.contains("\"excludedUpstreamCount\": 0"),
+                "excludedUpstreamCount should be 0 when no upstream modules exist");
     }
 
     /**
@@ -2729,7 +2919,7 @@ class ScalpelLifecycleParticipantTest {
                 createProject("org.apache.camel", "camel-ibm", "4.21.0-SNAPSHOT", root, "camel-ibm/pom.xml", ibmPom);
         ibmModule.setParent(parentProject);
 
-        List<MavenProject> otherModules = new java.util.ArrayList<>();
+        List<MavenProject> otherModules = new ArrayList<>();
         for (int i = 1; i <= 20; i++) {
             String otherPom = new String(
                     Files.readAllBytes(root.resolve("camel-other-" + i + "/pom.xml")), StandardCharsets.UTF_8);
@@ -2744,7 +2934,7 @@ class ScalpelLifecycleParticipantTest {
             otherModules.add(other);
         }
 
-        List<MavenProject> allProjects = new java.util.ArrayList<>();
+        List<MavenProject> allProjects = new ArrayList<>();
         allProjects.add(rootProject);
         allProjects.add(parentProject);
         allProjects.add(coreModule);
@@ -2847,6 +3037,11 @@ class ScalpelLifecycleParticipantTest {
         assertEquals(3, downstreamCount, "Should have 3 DOWNSTREAM modules");
         assertEquals(0, upstreamCount, "UPSTREAM modules should be excluded from report");
         assertEquals(0, transitiveCount, "Should have 0 TRANSITIVE modules (changedManagedDepGAs is empty)");
+
+        // Verify excludedUpstreamCount: camel-core is the only upstream build prerequisite
+        assertTrue(
+                json.contains("\"excludedUpstreamCount\": 1"),
+                "Report should show 1 excluded upstream module (camel-core)");
     }
 
     /**
@@ -2983,7 +3178,7 @@ class ScalpelLifecycleParticipantTest {
                 "org.apache.camel", "camel-kafka", "4.21.0-SNAPSHOT", root, "camel-kafka/pom.xml", kafkaPom);
         kafkaModule.setParent(parentProject);
 
-        List<MavenProject> compModules = new java.util.ArrayList<>();
+        List<MavenProject> compModules = new ArrayList<>();
         for (int i = 1; i <= 30; i++) {
             String compPomStr = new String(
                     Files.readAllBytes(root.resolve("camel-comp-" + i + "/pom.xml")), StandardCharsets.UTF_8);
@@ -3008,7 +3203,7 @@ class ScalpelLifecycleParticipantTest {
         allcompModule.getModel().setPackaging("pom");
         allcompModule.setParent(parentProject);
 
-        List<MavenProject> allProjects = new java.util.ArrayList<>();
+        List<MavenProject> allProjects = new ArrayList<>();
         allProjects.add(rootProject);
         allProjects.add(parentProject);
         allProjects.add(coreModule);
@@ -3049,7 +3244,7 @@ class ScalpelLifecycleParticipantTest {
         when(graph.getDownstreamProjects(kafkaModule, true)).thenReturn(List.of(allcompModule));
 
         // camel-allcomponents upstream = ALL components + kafka + core (it depends on everything)
-        List<MavenProject> allcompUpstream = new java.util.ArrayList<>();
+        List<MavenProject> allcompUpstream = new ArrayList<>();
         allcompUpstream.add(kafkaModule);
         allcompUpstream.add(coreModule);
         allcompUpstream.addAll(compModules);
@@ -3111,5 +3306,10 @@ class ScalpelLifecycleParticipantTest {
         // Total should be exactly 2: 1 DIRECT + 1 DOWNSTREAM
         int total = directCount + downstreamCount + upstreamCount + transitiveCount;
         assertEquals(2, total, "Report should contain only genuinely affected modules");
+
+        // Verify excludedUpstreamCount in JSON: 31 upstream modules excluded (30 comp + camel-core)
+        assertTrue(
+                json.contains("\"excludedUpstreamCount\": 31"),
+                "Report should show 31 excluded upstream modules (30 comp modules + camel-core)");
     }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2767,9 +2767,7 @@ class ScalpelLifecycleParticipantTest {
                 + "</project>\n";
         writePom(root, "pom.xml", rootPom);
 
-        // Parent POM (like Camel's parent/pom.xml) - has kafka-version property
-        // but does NOT use it in dependencyManagement.
-        // Has a large dependencyManagement with camel-* modules using ${project.version}
+        // Parent POM: defines kafka-version property but does not use it in managed deps
         String oldParentPom = """
                 <?xml version="1.0"?>
                 <project>
@@ -2819,7 +2817,7 @@ class ScalpelLifecycleParticipantTest {
                 """;
         writePom(root, "camel-core/pom.xml", corePom);
 
-        // camel-kafka: directly uses ${kafka-version}
+        // camel-kafka: directly references the changed property
         String kafkaPom = """
                 <?xml version="1.0"?>
                 <project>
@@ -2841,7 +2839,7 @@ class ScalpelLifecycleParticipantTest {
                 """;
         writePom(root, "camel-kafka/pom.xml", kafkaPom);
 
-        // camel-debezium: also uses ${kafka-version}
+        // camel-debezium: also references the changed property
         String debeziumPom = """
                 <?xml version="1.0"?>
                 <project>
@@ -2859,7 +2857,7 @@ class ScalpelLifecycleParticipantTest {
                 """;
         writePom(root, "camel-debezium/pom.xml", debeziumPom);
 
-        // camel-ibm: also uses ${kafka-version}
+        // camel-ibm: also references the changed property
         String ibmPom = """
                 <?xml version="1.0"?>
                 <project>
@@ -2994,14 +2992,13 @@ class ScalpelLifecycleParticipantTest {
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
 
         // Count modules by category
-        int directCount = 0, downstreamCount = 0, upstreamCount = 0, transitiveCount = 0, otherCount = 0;
+        int directCount = 0, downstreamCount = 0, upstreamCount = 0, transitiveCount = 0;
         for (String line : json.split("\n")) {
             if (line.contains("\"category\":")) {
                 if (line.contains("\"DIRECT\"")) directCount++;
                 else if (line.contains("\"DOWNSTREAM\"")) downstreamCount++;
                 else if (line.contains("\"UPSTREAM\"")) upstreamCount++;
                 else if (line.contains("\"TRANSITIVE\"")) transitiveCount++;
-                else otherCount++;
             }
         }
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2549,8 +2549,8 @@ class ScalpelLifecycleParticipantTest {
     /**
      * Reproduce scalpel#39: Camel-like structure where kafka-version property is defined
      * in parent POM but NOT used in parent's dependencyManagement. It's only used directly
-     * in 3 child modules' dependencies. With alsoMake=true (default), the report should
-     * contain DIRECT + DOWNSTREAM + UPSTREAM but NOT inflate with unrelated modules.
+     * in 3 child modules' dependencies. The report should contain only DIRECT + DOWNSTREAM
+     * modules; upstream build prerequisites are excluded (fix for #39).
      */
     @Test
     void reportMode_camelLike_kafkaVersionInChildDepsOnly() throws Exception {
@@ -2803,14 +2803,8 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(Files.exists(reportFile), "Report file should be created");
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
 
-        // Print the full report for debugging
-        System.out.println("=== SCALPEL REPORT (Camel-like scenario) ===");
-        System.out.println(json);
-        System.out.println("=== END REPORT ===");
-
         // Count modules by category
         int directCount = 0, downstreamCount = 0, upstreamCount = 0, transitiveCount = 0, otherCount = 0;
-        // Simple counting by looking for category fields
         for (String line : json.split("\n")) {
             if (line.contains("\"category\":")) {
                 if (line.contains("\"DIRECT\"")) directCount++;
@@ -2820,8 +2814,6 @@ class ScalpelLifecycleParticipantTest {
                 else otherCount++;
             }
         }
-        System.out.println("Category counts: DIRECT=" + directCount + " DOWNSTREAM=" + downstreamCount + " UPSTREAM="
-                + upstreamCount + " TRANSITIVE=" + transitiveCount + " OTHER=" + otherCount);
 
         // Verify: 3 modules should be DIRECT (camel-kafka, camel-debezium, camel-ibm)
         assertTrue(moduleHasField(json, "camel-kafka", "category", "DIRECT"), "camel-kafka should be DIRECT");
@@ -2864,14 +2856,13 @@ class ScalpelLifecycleParticipantTest {
      * modules. When kafka-version changes, camel-kafka becomes DIRECT. Since camel-allcomponents
      * depends on camel-kafka, it becomes DOWNSTREAM. Then alsoMake=true computes
      * getUpstreamProjects(camel-allcomponents, true) which returns ALL ~459 components.
-     * Those 459 components are added as UPSTREAM to the report, inflating affectedModules
-     * from ~45 useful entries to 649.
      *
-     * This test demonstrates the problem: a sync-point module that depends on everything
-     * causes the upstream closure to pull the entire reactor into the report.
+     * This test verifies that upstream build-prerequisite modules are excluded from the report,
+     * preventing the sync-point module from inflating affectedModules with hundreds of
+     * unrelated upstream dependencies (see scalpel#39).
      */
     @Test
-    void reportMode_camelLike_allcomponentsSyncPoint_causesUpstreamInflation() throws Exception {
+    void reportMode_camelLike_allcomponentsSyncPoint_excludesUpstreamPrerequisites() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 
@@ -3090,13 +3081,6 @@ class ScalpelLifecycleParticipantTest {
                 else if (line.contains("\"TRANSITIVE\"")) transitiveCount++;
             }
         }
-
-        System.out.println("=== SCALPEL#39 FIX VERIFICATION ===");
-        System.out.println("DIRECT=" + directCount + " DOWNSTREAM=" + downstreamCount + " UPSTREAM=" + upstreamCount
-                + " TRANSITIVE=" + transitiveCount);
-        System.out.println(
-                "Total affectedModules = " + (directCount + downstreamCount + upstreamCount + transitiveCount));
-        System.out.println("=== END ===");
 
         // Only camel-kafka is DIRECT (references ${kafka-version})
         assertEquals(1, directCount, "Only camel-kafka should be DIRECT");

--- a/extension3/src/test/resources/simplelogger.properties
+++ b/extension3/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.eu.maveniverse.maven.scalpel=debug


### PR DESCRIPTION
## Summary

- **Fix**: Exclude UPSTREAM modules from `affectedModules` in report mode. These are build-order prerequisites (computed by `alsoMake`), not genuinely affected modules. In projects with sync-point modules like Camel's `camel-allcomponents` (depends on all ~459 components), a single property change would inflate the report from ~45 useful entries to 649.
- **Debug logging**: Added comprehensive `DEBUG`-level logging to `PomChangeAnalyzer`, `ReactorTrimmer`, and `ScalpelLifecycleParticipant` explaining why each module is categorized as DIRECT, DOWNSTREAM, TRANSITIVE, or excluded.

### Root cause

The inflation is caused by the interaction between `alsoMake=true` and sync-point modules:

1. `kafka-version` changes in `parent/pom.xml` → 3 modules DIRECT
2. `camel-allcomponents` depends on `camel-kafka` → becomes DOWNSTREAM
3. `alsoMake=true` → `getUpstreamProjects(camel-allcomponents)` returns all ~459 components
4. Those ~459 + their transitive upstream cascade to **604 UPSTREAM** modules in the report
5. Result: `affectedModules` has 649 entries when only 45 are genuinely affected

### Changes

| File | Change |
|------|--------|
| `ScalpelLifecycleParticipant` | Stop adding UPSTREAM modules to report `affectedModules`; log excluded count at INFO; add DEBUG logging for report assembly |
| `PomChangeAnalyzer` | Add DEBUG logging for parent analysis (which children affected/not, property resolution, filtered resources, summary) |
| `ReactorTrimmer` | Add DEBUG logging for build set computation (upstream counts per module, final breakdown) |
| `ScalpelLifecycleParticipantTest` | Add reproduction test with sync-point module; update existing tests for new behavior |

### Impact

| Metric | Before | After |
|--------|--------|-------|
| Camel `affectedModules` | 649 | ~45 (3 DIRECT + 42 DOWNSTREAM) |
| UPSTREAM in report | 604 | 0 (logged at INFO) |
| `trim`/`skip-tests` modes | — | unchanged |

## Test plan

- [x] New test `reportMode_camelLike_allcomponentsSyncPoint_causesUpstreamInflation` reproduces and verifies the fix
- [x] Updated `reportMode_upstreamModulesExcludedFromReport` confirms UPSTREAM exclusion
- [x] Updated `reportMode_camelLike_kafkaVersionInChildDepsOnly` adapted for new behavior
- [x] All 120 existing tests pass

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated report generation to exclude upstream prerequisite modules from report mode.
  * Improved affected-module selection and reasoning so unrelated modules don’t appear.
  * Reports now include `excludedUpstreamCount` to reflect how many upstream modules were omitted.
* **New Features**
  * Added richer debug logging for change analysis and report partition counts.
* **Tests**
  * Expanded regression coverage with complex dependency-graph scenarios to verify upstream suppression and `excludedUpstreamCount`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->