### PR TITLE
Fix #39: Exclude .mvn/ from source mapping, add testsSkipped boolean

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -235,7 +235,11 @@ public final class ScalpelReport {
         sb.append("      \"reasons\": ").append(jsonStringArray(m.reasons));
         appendOptionalField(sb, "category", m.category);
         appendOptionalField(sb, "sourceSet", m.sourceSet);
-        appendOptionalField(sb, "testsSkippedReason", m.testsSkippedReason);
+        if (m.testsSkippedReason != null) {
+            sb.append(",\n");
+            sb.append("      \"testsSkipped\": true");
+            appendOptionalField(sb, "testsSkippedReason", m.testsSkippedReason);
+        }
         sb.append("\n");
         sb.append("    }");
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -150,11 +150,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Separate POM changes from source changes
+            // .mvn/ files are Maven build infrastructure (extensions.xml, maven.config, jvm.config)
+            // and should not be mapped to the root module as source changes — doing so would
+            // make the root DIRECT and cascade every reactor module as DOWNSTREAM.
             Set<String> pomChanges = new LinkedHashSet<>();
             Set<String> sourceChanges = new LinkedHashSet<>();
             for (String file : changedFiles) {
                 if (file.endsWith("/pom.xml") || file.equals("pom.xml")) {
                     pomChanges.add(file);
+                } else if (file.startsWith(".mvn/")) {
+                    logger.debug("Ignoring build infrastructure file: {}", file);
                 } else {
                     sourceChanges.add(file);
                 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3309,4 +3309,133 @@ class ScalpelLifecycleParticipantTest {
                 json.contains("\"excludedUpstreamCount\": 31"),
                 "Report should show 31 excluded upstream modules (30 comp modules + camel-core)");
     }
+
+    @Test
+    void reportMode_mvnExtensionsXmlDoesNotInflateRootModule() throws Exception {
+        // Reproduces issue #39 (reopened): changing .mvn/extensions.xml should NOT cause
+        // the root module to be flagged as DIRECT (SOURCE_CHANGE), which would cascade
+        // ALL reactor modules as DOWNSTREAM.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        // Change both .mvn/extensions.xml AND a real source file in module-a
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add(".mvn/extensions.xml");
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        // Override default fullBuildTriggers (.mvn/**) — same as CI config
+        session.getSystemProperties().setProperty("scalpel.fullBuildTriggers", "");
+
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of(moduleA, moduleB));
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // .mvn/extensions.xml should still appear in changedFiles (for transparency)
+        assertTrue(json.contains(".mvn/extensions.xml"), "changedFiles should include .mvn/extensions.xml");
+
+        // module-a should be DIRECT (real source change)
+        assertTrue(moduleHasField(json, "module-a", "category", "DIRECT"), "module-a should be DIRECT");
+        assertTrue(moduleHasReason(json, "module-a", "SOURCE_CHANGE"), "module-a should have SOURCE_CHANGE reason");
+
+        // module-b should be DOWNSTREAM (depends on module-a)
+        assertTrue(moduleHasField(json, "module-b", "category", "DOWNSTREAM"), "module-b should be DOWNSTREAM");
+
+        // KEY: root/parent module should NOT be in the report — .mvn/ files are build
+        // infrastructure and should not flag the root module as SOURCE_CHANGE
+        assertFalse(
+                modulePresent(json, "parent"),
+                "parent/root module should NOT be DIRECT — .mvn/ files are build infrastructure");
+    }
+
+    @Test
+    void reportMode_testsSkippedBooleanPresentWhenReasonSet() throws Exception {
+        // Verifies that the report JSON includes a "testsSkipped": true boolean
+        // alongside "testsSkippedReason" for easier CI parsing (jq .testsSkipped == true).
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
+
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // module-b should have both testsSkipped boolean and testsSkippedReason string
+        String moduleBBlock = extractModuleBlock(json, "module-b");
+        assertTrue(moduleBBlock != null, "module-b should be in the report");
+        assertTrue(
+                moduleBBlock.contains("\"testsSkipped\": true"),
+                "module-b should have testsSkipped=true boolean for jq compatibility");
+        assertTrue(
+                moduleBBlock.contains("\"testsSkippedReason\": \"EXCLUDED_DOWNSTREAM\""),
+                "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM");
+
+        // module-a should NOT have testsSkipped (it's DIRECT, not excluded downstream)
+        String moduleABlock = extractModuleBlock(json, "module-a");
+        assertTrue(moduleABlock != null, "module-a should be in the report");
+        assertFalse(moduleABlock.contains("\"testsSkipped\""), "module-a should NOT have testsSkipped (it's DIRECT)");
+    }
 }


### PR DESCRIPTION
## Summary

- **Fix 1**: `.mvn/` files (extensions.xml, maven.config, jvm.config) are Maven build infrastructure, not module source. When `fullBuildTriggers` is overridden to exclude `.mvn/**` (as Camel CI does), these files were still mapped to the root module as `SOURCE_CHANGE` by `ModuleMapper`, causing **all** reactor modules to cascade as `DOWNSTREAM` (670 instead of 45).
- **Fix 2**: The report JSON had `testsSkippedReason` (string) but no `testsSkipped` (boolean). CI scripts using `jq '.testsSkipped == true'` found 0 matches because the field did not exist.

### Before → After (Apache Camel, `kafka-version` change + scalpel upgrade in `.mvn/extensions.xml`)

| Metric | Before | After |
|--------|--------|-------|
| Total `affectedModules` | **670** (4 DIRECT + 666 DOWNSTREAM) | **45** (3 DIRECT + 42 DOWNSTREAM) |
| Root module inflation | `camel` flagged as DIRECT (SOURCE_CHANGE from `.mvn/extensions.xml`) | `.mvn/` files silently skipped |
| `testsSkipped` boolean | absent → `jq` sees `null` | `true` when `testsSkippedReason` is set |
| `Downstream skipped` count | 0 (jq `.testsSkipped == true` never matched) | 6 (correct) |

### Changes

| File | Change |
|------|--------|
| `ScalpelLifecycleParticipant` | Skip `.mvn/` files when separating POM vs source changes (they remain in `changedFiles` for transparency/triggers) |
| `ScalpelReport` | Emit `"testsSkipped": true` in JSON when `testsSkippedReason` is non-null |
| `ScalpelLifecycleParticipantTest` | Two new tests: `.mvn/` inflation prevention, `testsSkipped` boolean presence |

## Test plan

- [x] New test `reportMode_mvnExtensionsXmlDoesNotInflateRootModule` — `.mvn/extensions.xml` + source change, root module NOT flagged
- [x] New test `reportMode_testsSkippedBooleanPresentWhenReasonSet` — `testsSkipped: true` present alongside `testsSkippedReason`
- [x] All 123 existing tests pass
- [x] Verified on real Apache Camel reactor (~670 modules): 45 affected, 6 downstream skipped

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report output now includes an explicit `testsSkipped` flag for modules where tests were skipped.
  * Changes under `.mvn/` are now shown without being treated as source-impacting changes.

* **Bug Fixes**
  * Prevented build-infrastructure file changes from incorrectly marking the root project as affected.
  * Improved module impact reporting so downstream results are categorized more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->