### PR TITLE
Fix #43: Add includePaths option to complement excludePaths

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -28,6 +28,7 @@ public final class ScalpelConfiguration {
     public static final String DISABLE_ON_BRANCH = PREFIX + "disableOnBranch";
     public static final String DISABLE_ON_BASE_BRANCH = PREFIX + "disableOnBaseBranch";
     public static final String EXCLUDE_PATHS = PREFIX + "excludePaths";
+    public static final String INCLUDE_PATHS = PREFIX + "includePaths";
     public static final String DISABLE_TRIGGERS = PREFIX + "disableTriggers";
 
     public static final String DISABLE_ON_SELECTED_PROJECTS = PREFIX + "disableOnSelectedProjects";
@@ -65,6 +66,7 @@ public final class ScalpelConfiguration {
     private final List<String> disableOnBranch;
     private final List<String> disableOnBaseBranch;
     private final List<String> excludePaths;
+    private final List<String> includePaths;
     private final List<String> disableTriggers;
     private final boolean disableOnSelectedProjects;
     private final boolean fetchBaseBranch;
@@ -92,6 +94,7 @@ public final class ScalpelConfiguration {
             List<String> disableOnBranch,
             List<String> disableOnBaseBranch,
             List<String> excludePaths,
+            List<String> includePaths,
             List<String> disableTriggers,
             boolean disableOnSelectedProjects,
             boolean fetchBaseBranch,
@@ -117,6 +120,7 @@ public final class ScalpelConfiguration {
         this.disableOnBranch = disableOnBranch;
         this.disableOnBaseBranch = disableOnBaseBranch;
         this.excludePaths = excludePaths;
+        this.includePaths = includePaths;
         this.disableTriggers = disableTriggers;
         this.disableOnSelectedProjects = disableOnSelectedProjects;
         this.fetchBaseBranch = fetchBaseBranch;
@@ -149,6 +153,7 @@ public final class ScalpelConfiguration {
         List<String> disableOnBranch = parseList(resolve(system, user, DISABLE_ON_BRANCH, null));
         List<String> disableOnBaseBranch = parseList(resolve(system, user, DISABLE_ON_BASE_BRANCH, null));
         List<String> excludePaths = parseList(resolve(system, user, EXCLUDE_PATHS, null));
+        List<String> includePaths = parseList(resolve(system, user, INCLUDE_PATHS, null));
         List<String> disableTriggers = parseList(resolve(system, user, DISABLE_TRIGGERS, null));
         boolean disableOnSelectedProjects =
                 Boolean.parseBoolean(resolve(system, user, DISABLE_ON_SELECTED_PROJECTS, "false"));
@@ -195,6 +200,7 @@ public final class ScalpelConfiguration {
                 disableOnBranch,
                 disableOnBaseBranch,
                 excludePaths,
+                includePaths,
                 disableTriggers,
                 disableOnSelectedProjects,
                 fetchBaseBranch,
@@ -292,6 +298,10 @@ public final class ScalpelConfiguration {
         return excludePaths;
     }
 
+    public List<String> getIncludePaths() {
+        return includePaths;
+    }
+
     public List<String> getDisableTriggers() {
         return disableTriggers;
     }
@@ -381,6 +391,7 @@ public final class ScalpelConfiguration {
                 + ", disableOnBranch=" + disableOnBranch
                 + ", disableOnBaseBranch=" + disableOnBaseBranch
                 + ", excludePaths=" + excludePaths
+                + ", includePaths=" + includePaths
                 + ", disableTriggers=" + disableTriggers
                 + ", disableOnSelectedProjects=" + disableOnSelectedProjects
                 + ", fetchBaseBranch=" + fetchBaseBranch

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -201,6 +201,20 @@ class ScalpelConfigurationTest {
     }
 
     @Test
+    void includePaths_parsedAsList() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.includePaths", "extensions/**,extensions-core/**,tooling/**");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertEquals(List.of("extensions/**", "extensions-core/**", "tooling/**"), config.getIncludePaths());
+    }
+
+    @Test
+    void includePaths_defaultEmpty() {
+        ScalpelConfiguration config = defaultConfig();
+        assertTrue(config.getIncludePaths().isEmpty());
+    }
+
+    @Test
     void disableTriggers_parsedAsList() {
         Properties sys = new Properties();
         sys.setProperty("scalpel.disableTriggers", ".github/**,Jenkinsfile");
@@ -345,6 +359,7 @@ class ScalpelConfigurationTest {
         assertEquals("scalpel.disableOnBranch", ScalpelConfiguration.DISABLE_ON_BRANCH);
         assertEquals("scalpel.disableOnBaseBranch", ScalpelConfiguration.DISABLE_ON_BASE_BRANCH);
         assertEquals("scalpel.excludePaths", ScalpelConfiguration.EXCLUDE_PATHS);
+        assertEquals("scalpel.includePaths", ScalpelConfiguration.INCLUDE_PATHS);
         assertEquals("scalpel.disableTriggers", ScalpelConfiguration.DISABLE_TRIGGERS);
         assertEquals("scalpel.disableOnSelectedProjects", ScalpelConfiguration.DISABLE_ON_SELECTED_PROJECTS);
         assertEquals("scalpel.fetchBaseBranch", ScalpelConfiguration.FETCH_BASE_BRANCH);

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -140,13 +140,6 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 return;
             }
 
-            // Filter to only included paths (if configured)
-            changedFiles = filterIncludedPaths(changedFiles, config);
-            if (changedFiles.isEmpty()) {
-                logger.info("Scalpel: No changed files match includePaths filters, building all modules");
-                return;
-            }
-
             // Check full build triggers
             String triggerFile = findFullBuildTrigger(changedFiles, config);
             if (triggerFile != null) {
@@ -288,6 +281,45 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<MavenProject> allAffected = new LinkedHashSet<>(directlyAffected);
             allAffected.addAll(transitivelyAffected.keySet());
 
+            // Apply includePaths module filter: restrict affected modules by path while
+            // keeping full diff visibility for change detection and POM analysis above.
+            if (!config.getIncludePaths().isEmpty()) {
+                int beforeCount = allAffected.size();
+                List<PathMatcher> includeMatchers = new ArrayList<>();
+                for (String pattern : config.getIncludePaths()) {
+                    includeMatchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern));
+                }
+                directlyAffected.removeIf(p -> !matchesIncludePaths(p, includeMatchers, reactorRoot));
+                transitivelyAffected.keySet().removeIf(p -> !matchesIncludePaths(p, includeMatchers, reactorRoot));
+                testOnlyModules.retainAll(directlyAffected);
+                forceIncluded.retainAll(directlyAffected);
+
+                allAffected = new LinkedHashSet<>(directlyAffected);
+                allAffected.addAll(transitivelyAffected.keySet());
+
+                int removedCount = beforeCount - allAffected.size();
+                if (removedCount > 0) {
+                    logger.info("Scalpel: {} modules excluded by includePaths filters", removedCount);
+                }
+
+                if (allAffected.isEmpty()) {
+                    logger.info("Scalpel: No modules match includePaths filters");
+                    if (config.isModeReport()) {
+                        writeReport(
+                                config,
+                                reactorRoot,
+                                AnalysisContext.empty(
+                                        changedFiles,
+                                        changedProperties,
+                                        changedManagedDepGAs,
+                                        changedManagedPluginGAs));
+                    } else if (config.isModeSkipTests()) {
+                        skipTestsOnAll(allProjects);
+                    }
+                    return;
+                }
+            }
+
             // Write impacted module log if configured
             if (config.getImpactedLog() != null) {
                 writeImpactedLog(config, reactorRoot, allAffected);
@@ -383,28 +415,17 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         return filtered;
     }
 
-    private Set<String> filterIncludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
-        if (config.getIncludePaths().isEmpty()) {
-            return changedFiles;
-        }
-        List<PathMatcher> includeMatchers = new ArrayList<>();
-        for (String pattern : config.getIncludePaths()) {
-            includeMatchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern));
-        }
-        Set<String> filtered = new LinkedHashSet<>();
-        for (String file : changedFiles) {
-            for (PathMatcher matcher : includeMatchers) {
-                if (matcher.matches(Paths.get(file))) {
-                    filtered.add(file);
-                    break;
-                }
+    private boolean matchesIncludePaths(MavenProject project, List<PathMatcher> matchers, Path reactorRoot) {
+        String relPath = relativePath(reactorRoot, project);
+        Path modulePath = Paths.get(relPath);
+        for (PathMatcher matcher : matchers) {
+            // Match the module path directly (e.g., "module-a" matches pattern "module-a")
+            // or match a file within the module (e.g., "module-a/pom.xml" matches pattern "module-a/**")
+            if (matcher.matches(modulePath) || matcher.matches(modulePath.resolve("pom.xml"))) {
+                return true;
             }
         }
-        int excludedCount = changedFiles.size() - filtered.size();
-        if (excludedCount > 0) {
-            logger.info("Scalpel: {} files excluded by includePaths filters", excludedCount);
-        }
-        return filtered;
+        return false;
     }
 
     private String findFullBuildTrigger(Set<String> changedFiles, ScalpelConfiguration config) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -140,6 +140,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 return;
             }
 
+            // Filter to only included paths (if configured)
+            changedFiles = filterIncludedPaths(changedFiles, config);
+            if (changedFiles.isEmpty()) {
+                logger.info("Scalpel: No changed files match includePaths filters, building all modules");
+                return;
+            }
+
             // Check full build triggers
             String triggerFile = findFullBuildTrigger(changedFiles, config);
             if (triggerFile != null) {
@@ -372,6 +379,30 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         int excludedCount = changedFiles.size() - filtered.size();
         if (excludedCount > 0) {
             logger.info("Scalpel: {} files excluded by path filters", excludedCount);
+        }
+        return filtered;
+    }
+
+    private Set<String> filterIncludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
+        if (config.getIncludePaths().isEmpty()) {
+            return changedFiles;
+        }
+        List<PathMatcher> includeMatchers = new ArrayList<>();
+        for (String pattern : config.getIncludePaths()) {
+            includeMatchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern));
+        }
+        Set<String> filtered = new LinkedHashSet<>();
+        for (String file : changedFiles) {
+            for (PathMatcher matcher : includeMatchers) {
+                if (matcher.matches(Paths.get(file))) {
+                    filtered.add(file);
+                    break;
+                }
+            }
+        }
+        int excludedCount = changedFiles.size() - filtered.size();
+        if (excludedCount > 0) {
+            logger.info("Scalpel: {} files excluded by includePaths filters", excludedCount);
         }
         return filtered;
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -283,12 +283,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Apply includePaths module filter: restrict affected modules by path while
             // keeping full diff visibility for change detection and POM analysis above.
-            if (!config.getIncludePaths().isEmpty()) {
+            // The matchers are compiled once here and reused later in trim/report/skip-tests
+            // mode to also filter downstream expansions and managed-dep re-enabling.
+            List<PathMatcher> includeMatchers = compileGlobMatchers(config.getIncludePaths());
+            if (!includeMatchers.isEmpty()) {
                 int beforeCount = allAffected.size();
-                List<PathMatcher> includeMatchers = new ArrayList<>();
-                for (String pattern : config.getIncludePaths()) {
-                    includeMatchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern));
-                }
                 directlyAffected.removeIf(p -> !matchesIncludePaths(p, includeMatchers, reactorRoot));
                 transitivelyAffected.keySet().removeIf(p -> !matchesIncludePaths(p, includeMatchers, reactorRoot));
                 testOnlyModules.retainAll(directlyAffected);
@@ -355,15 +354,30 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     allAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
 
             if (config.isModeSkipTests()) {
-                applySkipTests(session, allProjects, trimResult, config, changedManagedDepGAs, changedManagedPluginGAs);
+                applySkipTests(
+                        session,
+                        allProjects,
+                        trimResult,
+                        config,
+                        changedManagedDepGAs,
+                        changedManagedPluginGAs,
+                        includeMatchers,
+                        reactorRoot);
             } else {
                 // trim mode: remove unaffected projects from reactor
+                List<MavenProject> buildSet = trimResult.getBuildSet();
+                if (!includeMatchers.isEmpty()) {
+                    // Filter downstream modules outside includePaths scope while keeping
+                    // upstream build prerequisites and directly/transitively affected modules
+                    Set<MavenProject> finalAllAffected = allAffected;
+                    buildSet = new ArrayList<>(buildSet);
+                    buildSet.removeIf(p -> !finalAllAffected.contains(p)
+                            && !trimResult.getUpstreamOnly().contains(p)
+                            && !matchesIncludePaths(p, includeMatchers, reactorRoot));
+                }
                 logger.info(
-                        "Scalpel: Building {} of {} modules: {}",
-                        trimResult.getBuildSet().size(),
-                        allProjects.size(),
-                        keys(trimResult.getBuildSet()));
-                session.setProjects(trimResult.getBuildSet());
+                        "Scalpel: Building {} of {} modules: {}", buildSet.size(), allProjects.size(), keys(buildSet));
+                session.setProjects(buildSet);
                 // Apply per-category args in trim mode
                 applyPerCategoryArgs(trimResult, config);
             }
@@ -387,13 +401,21 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         return false;
     }
 
-    private Set<String> filterExcludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
-        if (config.getExcludePaths().isEmpty()) {
-            return changedFiles;
+    private static List<PathMatcher> compileGlobMatchers(List<String> patterns) {
+        if (patterns.isEmpty()) {
+            return Collections.emptyList();
         }
-        List<PathMatcher> excludeMatchers = new ArrayList<>();
-        for (String pattern : config.getExcludePaths()) {
-            excludeMatchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern));
+        List<PathMatcher> matchers = new ArrayList<>(patterns.size());
+        for (String pattern : patterns) {
+            matchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern));
+        }
+        return matchers;
+    }
+
+    private Set<String> filterExcludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
+        List<PathMatcher> excludeMatchers = compileGlobMatchers(config.getExcludePaths());
+        if (excludeMatchers.isEmpty()) {
+            return changedFiles;
         }
         Set<String> filtered = new LinkedHashSet<>();
         for (String file : changedFiles) {
@@ -506,7 +528,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             TrimResult trimResult,
             ScalpelConfiguration config,
             Set<String> changedManagedDepGAs,
-            Set<String> changedManagedPluginGAs) {
+            Set<String> changedManagedPluginGAs,
+            List<PathMatcher> includeMatchers,
+            Path reactorRoot) {
 
         Set<MavenProject> buildSetLookup = new LinkedHashSet<>(trimResult.getBuildSet());
         List<MavenProject> testProjects = new ArrayList<>();
@@ -545,6 +569,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         for (MavenProject project : allProjects) {
             if (buildSetLookup.contains(project)) {
                 continue; // Already handled above
+            }
+
+            // Skip tests on modules outside includePaths scope — managed dep/plugin
+            // re-enabling should not override the user's includePaths restriction
+            if (!includeMatchers.isEmpty() && !matchesIncludePaths(project, includeMatchers, reactorRoot)) {
+                project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
+                skippedProjects.add(project);
+                continue;
             }
 
             // Check effective build plugins against changed managed plugins
@@ -871,8 +903,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Path reactorRoot,
             Set<MavenProject> downstreamProjects,
             String reason) {
+        List<PathMatcher> includeMatchers = compileGlobMatchers(config.getIncludePaths());
         for (MavenProject project : downstreamProjects) {
             if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
+                // Skip downstream modules outside includePaths scope
+                if (!includeMatchers.isEmpty() && !matchesIncludePaths(project, includeMatchers, reactorRoot)) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Excluding downstream module {} from report (outside includePaths)", key(project));
+                    }
+                    continue;
+                }
                 String path = relativePath(reactorRoot, project);
                 String testsSkippedReason =
                         matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1780,6 +1780,176 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void reportMode_includePathsFiltersChangedFiles() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        changedFiles.add("module-b/src/main/java/Bar.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(modulePresent(json, "module-a"), "module-a should be in report (matches includePaths)");
+        assertFalse(modulePresent(json, "module-b"), "module-b should NOT be in report (does not match includePaths)");
+    }
+
+    @Test
+    void reportMode_includePathsMultiplePatterns() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b", "module-c");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+        String moduleCPom = simpleChildPom("module-c");
+        writePom(root, "module-c/pom.xml", moduleCPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
+        moduleC.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleC);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        changedFiles.add("module-b/src/main/java/Bar.java");
+        changedFiles.add("module-c/src/main/java/Baz.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**,module-c/**");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(modulePresent(json, "module-a"), "module-a should be in report");
+        assertFalse(modulePresent(json, "module-b"), "module-b should NOT be in report");
+        assertTrue(modulePresent(json, "module-c"), "module-c should be in report");
+    }
+
+    @Test
+    void reportMode_includePathsNotSetIncludesAll() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        changedFiles.add("module-b/src/main/java/Bar.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        // No includePaths set — all files should be included
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(modulePresent(json, "module-a"), "module-a should be in report");
+        assertTrue(modulePresent(json, "module-b"), "module-b should be in report");
+    }
+
+    @Test
+    void reportMode_includePathsCombinedWithExcludePaths() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        changedFiles.add("module-a/README.md");
+        changedFiles.add("module-b/src/main/java/Bar.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        // Include only module-a paths, but exclude .md files
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**");
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "**/*.md");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(modulePresent(json, "module-a"), "module-a should be in report (Foo.java matched)");
+        assertFalse(modulePresent(json, "module-b"), "module-b should NOT be in report (not in includePaths)");
+        assertFalse(json.contains("README.md"), "README.md should be excluded");
+    }
+
+    @Test
     void reportMode_disableTriggerCausesFullBuild() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1780,7 +1780,7 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
-    void reportMode_includePathsFiltersChangedFiles() throws Exception {
+    void reportMode_includePathsFiltersModules() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 
@@ -1893,7 +1893,7 @@ class ScalpelLifecycleParticipantTest {
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
-        // No includePaths set — all files should be included
+        // No includePaths set — all modules should be included
         MavenSession session = createSimpleSession(root, allProjects, "report");
 
         participant.afterProjectsRead(session);
@@ -1935,7 +1935,7 @@ class ScalpelLifecycleParticipantTest {
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "report");
-        // Include only module-a paths, but exclude .md files
+        // Include only module-a modules, but exclude .md files from change detection
         session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**");
         session.getSystemProperties().setProperty("scalpel.excludePaths", "**/*.md");
 
@@ -1947,6 +1947,138 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(modulePresent(json, "module-a"), "module-a should be in report (Foo.java matched)");
         assertFalse(modulePresent(json, "module-b"), "module-b should NOT be in report (not in includePaths)");
         assertFalse(json.contains("README.md"), "README.md should be excluded");
+    }
+
+    @Test
+    void reportMode_includePathsPreservesFullDiffVisibility() throws Exception {
+        // Parent POM in a subdirectory changes a managed dependency version.
+        // module-a uses that dependency and should be detected as directly affected,
+        // even though the POM change (parent/pom.xml) is outside the includePaths scope.
+        // This verifies that includePaths filters MODULES, not changed files.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String rootPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>root</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>parent</module><module>module-a</module><module>module-b</module></modules>
+                </project>
+                """;
+        writePom(root, "pom.xml", rootPom);
+
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <lib.version>1.0</lib.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>org.example</groupId>
+                      <artifactId>managed-lib</artifactId>
+                      <version>${lib.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
+        String newParentPom = oldParentPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
+        writePom(root, "parent/pom.xml", newParentPom);
+
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencies>
+                    <dependency><groupId>org.example</groupId><artifactId>managed-lib</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                </project>
+                """;
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject rootProject = createProject("com.example", "root", "1.0", root, "pom.xml", rootPom);
+        rootProject.getModel().setPackaging("pom");
+        MavenProject parentProject =
+                createProject("com.example", "parent", "1.0", root, "parent/pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        parentProject.setParent(rootProject);
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(rootProject, parentProject, moduleA, moduleB);
+
+        // Only parent/pom.xml changed — outside the includePaths scope
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("parent/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("parent/pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
+        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenReturn(emptyResolution);
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "report");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        sysProps.setProperty("scalpel.includePaths", "module-a/**");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+        when(session.getRepositorySession()).thenReturn(mock(RepositorySystemSession.class));
+        ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
+        when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
+        when(graph.getSortedProjects()).thenReturn(allProjects);
+        when(session.getProjectDependencyGraph()).thenReturn(graph);
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // module-a should be in the report: detected as affected by the parent POM change
+        // (managed dependency version change), even though the POM change is outside includePaths
+        assertTrue(
+                modulePresent(json, "module-a"),
+                "module-a should be in report (POM change outside scope still propagates)");
+
+        // module-b should NOT be in report (not affected by the managed dep change, not in includePaths)
+        assertFalse(modulePresent(json, "module-b"), "module-b should NOT be in report");
+
+        // parent should NOT be in report (filtered by includePaths)
+        assertFalse(modulePresent(json, "parent"), "parent should NOT be in report (outside includePaths)");
     }
 
     @Test

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2082,6 +2082,87 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void trimMode_includePathsFiltersReactor() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        changedFiles.add("module-b/src/main/java/Bar.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**");
+
+        participant.afterProjectsRead(session);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<MavenProject>> captor = ArgumentCaptor.forClass(List.class);
+        verify(session).setProjects(captor.capture());
+        List<MavenProject> trimmed = captor.getValue();
+        assertTrue(trimmed.contains(moduleA), "module-a should be in trimmed reactor (matches includePaths)");
+        assertFalse(trimmed.contains(moduleB), "module-b should NOT be in trimmed reactor (outside includePaths)");
+    }
+
+    @Test
+    void skipTestsMode_includePathsFiltersModules() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        changedFiles.add("module-b/src/main/java/Bar.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**");
+
+        participant.afterProjectsRead(session);
+
+        // module-b is affected by source changes but excluded by includePaths,
+        // so it should have tests skipped
+        assertTrue(
+                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+                "module-b should have tests skipped (outside includePaths)");
+    }
+
+    @Test
     void reportMode_disableTriggerCausesFullBuild() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -2160,6 +2161,101 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(
                 "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
                 "module-b should have tests skipped (outside includePaths)");
+    }
+
+    @Test
+    void trimMode_includePathsExcludesDownstreamOutsideScope() throws Exception {
+        // module-a has source changes and matches includePaths.
+        // module-b depends on module-a (downstream) but is outside includePaths.
+        // The trimmed reactor should NOT include module-b.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        // Set up dependency graph: module-b is downstream of module-a
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        ProjectDependencyGraph graph = session.getProjectDependencyGraph();
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**");
+
+        participant.afterProjectsRead(session);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<MavenProject>> captor = ArgumentCaptor.forClass(List.class);
+        verify(session).setProjects(captor.capture());
+        List<MavenProject> trimmed = captor.getValue();
+        assertTrue(trimmed.contains(moduleA), "module-a should be in trimmed reactor (matches includePaths)");
+        assertFalse(
+                trimmed.contains(moduleB),
+                "module-b should NOT be in trimmed reactor (downstream but outside includePaths)");
+    }
+
+    @Test
+    void reportMode_includePathsExcludesDownstreamOutsideScope() throws Exception {
+        // module-a has source changes and matches includePaths.
+        // module-b depends on module-a (downstream) but is outside includePaths.
+        // The report should NOT include module-b.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        // Set up dependency graph: module-b is downstream of module-a
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        ProjectDependencyGraph graph = session.getProjectDependencyGraph();
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(modulePresent(json, "module-a"), "module-a should be in report (matches includePaths)");
+        assertFalse(
+                modulePresent(json, "module-b"),
+                "module-b should NOT be in report (downstream but outside includePaths)");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `scalpel.includePaths` property that filters **modules by their path** after all change detection and impact analysis is complete
- Unlike `excludePaths` (which filters changed *files* before analysis), `includePaths` preserves full diff visibility — POM changes, managed dependency propagation, and full-build triggers outside the include scope still work correctly
- Supports comma-separated glob patterns, e.g. `-Dscalpel.includePaths=extensions/**,tooling/**`
- When not set, all affected modules are included (preserving existing behavior)
- Works across all three modes: trim, skip-tests, and report

## Changes

- **`ScalpelConfiguration`**: Added `INCLUDE_PATHS` constant, `includePaths` field, parsing, getter, and toString
- **`ScalpelLifecycleParticipant`**: Added module-level `includePaths` filtering applied after `directlyAffected` and `transitivelyAffected` computation, with `matchesIncludePaths()` helper that matches module paths against glob patterns (with `pom.xml` fallback for `**` patterns)
- **Tests**: Added `includePaths` parsing tests in `ScalpelConfigurationTest` and 7 integration tests in `ScalpelLifecycleParticipantTest` covering:
  - Single pattern filtering (report mode)
  - Multiple comma-separated patterns (report mode)
  - Default behavior — no includePaths = include all (report mode)
  - Combination with excludePaths (report mode)
  - Full diff visibility preservation — parent POM changes outside include scope propagate to modules inside (report mode)
  - Reactor trimming with includePaths (trim mode)
  - Test skipping with includePaths (skip-tests mode)

## Test plan

- [x] Unit tests for `includePaths` parsing in `ScalpelConfigurationTest`
- [x] Integration test: single `includePaths` pattern filters modules correctly
- [x] Integration test: multiple patterns include correct modules
- [x] Integration test: no `includePaths` includes all modules (backward compatible)
- [x] Integration test: `includePaths` combined with `excludePaths` works correctly
- [x] Integration test: transitive changes from outside include scope propagate correctly
- [x] Integration test: trim mode narrows reactor to included modules
- [x] Integration test: skip-tests mode skips tests on excluded modules
- [x] Full reactor build passes (130 tests, 0 failures)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `scalpel.includePaths` configuration option to limit processing to modules matching one or more path patterns.
  * Supports comma-separated glob patterns across report, trim, and skip-tests modes.
  * Matching modules remain eligible for processing while non-matching modules are excluded.
  * When no paths match, reporting and test execution are handled gracefully.

* **Tests**
  * Added coverage for include-path filtering, defaults, multiple patterns, exclusions, and parent POM changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->