### PR TITLE
Fix #45: catch JGitInternalException in failSafe error handler

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -19,6 +19,7 @@ import javax.inject.Singleton;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.lib.ObjectId;
@@ -154,7 +155,7 @@ public class GitChangeDetector {
             uncommitted.addAll(status.getMissing());
             uncommitted.addAll(status.getConflicting());
             untracked.addAll(status.getUntracked());
-        } catch (GitAPIException e) {
+        } catch (GitAPIException | JGitInternalException e) {
             throw new IOException("Failed to get git status", e);
         }
         logger.debug("Uncommitted files: {}", uncommitted);
@@ -176,7 +177,7 @@ public class GitChangeDetector {
         logger.info("Scalpel: Fetching {} from {}", branch, remote);
         try (Git git = new Git(repository)) {
             git.fetch().setRemote(remote).setRefSpecs(new RefSpec(refspec)).call();
-        } catch (GitAPIException e) {
+        } catch (GitAPIException | JGitInternalException e) {
             throw new IOException("Failed to fetch " + baseBranch, e);
         }
     }

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -23,6 +23,7 @@ import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
@@ -179,7 +180,7 @@ public class ScalpelCore {
             return new ChangeDetectionResult(changedFiles, oldPomContents);
         } catch (ScalpelException e) {
             throw e;
-        } catch (IOException e) {
+        } catch (IOException | JGitInternalException e) {
             return handleError(config, "Error during change detection", e);
         } finally {
             repository.close();

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -112,7 +112,7 @@ public class ScalpelCore {
                 if (baseId == null) {
                     try {
                         gitChangeDetector.fetchBranch(repository, baseBranch);
-                    } catch (IOException e) {
+                    } catch (IOException | JGitInternalException e) {
                         if (config.isFailSafe()) {
                             logger.warn(
                                     "Scalpel: Failed to fetch {}, building all modules: {}",

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -283,7 +283,7 @@ class ScalpelCoreTest {
     };
 
     @Test
-    void detectChanges_failSafe_catchesRuntimeException() throws Exception {
+    void detectChanges_failSafe_catchesJGitInternalException() throws Exception {
         try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
             Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
             git.add().addFilepattern("file.txt").call();
@@ -307,7 +307,7 @@ class ScalpelCoreTest {
     }
 
     @Test
-    void detectChanges_failSafeDisabled_throwsOnRuntimeException() throws Exception {
+    void detectChanges_failSafeDisabled_throwsOnJGitInternalException() throws Exception {
         try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
             Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
             git.add().addFilepattern("file.txt").call();

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -20,6 +21,10 @@ import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.JGitInternalException;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
@@ -266,6 +271,63 @@ class ScalpelCoreTest {
             String readOldPom = new String(result.getOldPomContents().get("pom.xml"), StandardCharsets.UTF_8);
             assertTrue(readOldPom.contains("1.0"), "Old POM should contain original version");
             assertFalse(readOldPom.contains("2.0"), "Old POM should not contain new version");
+        }
+    }
+
+    private static final GitChangeDetector THROWING_DETECTOR = new GitChangeDetector() {
+        @Override
+        public ObjectId findMergeBase(Repository repository, String baseBranch, String head) {
+            throw new JGitInternalException(
+                    "Missing unknown abc123", new MissingObjectException(ObjectId.zeroId(), "commit"));
+        }
+    };
+
+    @Test
+    void detectChanges_failSafe_catchesRuntimeException() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(tempDir.resolve("new.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new.txt").call();
+            git.commit().setMessage("change").call();
+
+            ScalpelCore core = new ScalpelCore(THROWING_DETECTOR);
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.failSafe", "true");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
+
+            assertNull(result, "failSafe should return null (build all) on RuntimeException");
+        }
+    }
+
+    @Test
+    void detectChanges_failSafeDisabled_throwsOnRuntimeException() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(tempDir.resolve("new.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new.txt").call();
+            git.commit().setMessage("change").call();
+
+            ScalpelCore core = new ScalpelCore(THROWING_DETECTOR);
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.failSafe", "false");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            assertThrows(
+                    ScalpelException.class,
+                    () -> core.detectChanges(tempDir, config, Set.of()),
+                    "Should throw ScalpelException when failSafe is disabled");
         }
     }
 }


### PR DESCRIPTION
## Summary

`ScalpelCore.detectChanges()` catches `IOException` for failSafe handling, but JGit throws `JGitInternalException` (a `RuntimeException`) when it encounters missing objects in shallow clones. This exception bypasses the failSafe handler and propagates as a Maven `InternalErrorException`, crashing the build instead of degrading gracefully.

Widen the catch to include `JGitInternalException` specifically (not all `RuntimeException`, to avoid masking programming errors in Scalpel's own code).

## Root cause

In GitHub Actions, `actions/checkout` with `fetch-depth: 1` produces a shallow clone. When Scalpel's `GitChangeDetector` walks the commit graph via JGit's high-level API (`StatusCommand.call()`, `FetchCommand.call()`), JGit wraps `MissingObjectException` in `JGitInternalException`. The existing `catch (IOException e)` only handles the low-level API path where `MissingObjectException` propagates directly as a checked exception.

## Changes

- `ScalpelCore.java`: widen catch from `IOException` to `IOException | JGitInternalException`
- `ScalpelCoreTest.java`: two new tests verifying failSafe behavior on `JGitInternalException` (returns null when `failSafe=true`, throws `ScalpelException` when `failSafe=false`)

## Evidence

Discovered in the Apicurio Registry CI pipeline. Stack trace from runs [30422483753](https://github.com/Apicurio/apicurio-registry/actions/runs/30422483753) and [30404525927](https://github.com/Apicurio/apicurio-registry/actions/runs/30404525927):

```
[ERROR] Internal error: org.eclipse.jgit.api.errors.JGitInternalException: Missing unknown 3d911c...
Caused by: org.eclipse.jgit.errors.MissingObjectException: Missing unknown 3d911c...
```

Fixes #45.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection robustness by treating internal Git failures the same as other I/O-style errors.
  * Enhanced fail-safe behavior: when enabled, detection now returns no changes instead of interrupting processing.
  * When fail-safe is disabled, errors continue to surface as before to preserve standard error behavior.
* **Tests**
  * Added coverage for fail-safe vs. exception behavior under internal Git failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->