### PR TITLE
Fix #47: keep test-compile for skipped modules whose test-jars are consumed in-reactor

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -123,7 +123,12 @@ class ReactorTrimmer {
         return new TrimResult(result, directlyAffected, upstreamOnly, downstreamOnly, downstreamTestOnly);
     }
 
-    private boolean hasTestJarDependency(MavenProject downstream, MavenProject upstream) {
+    /**
+     * Returns true if {@code downstream} has a direct {@code <type>test-jar</type>} dependency
+     * on {@code upstream}. Package-private so {@link ScalpelLifecycleParticipant} can reuse this
+     * check when deciding whether a skip-test candidate's test-compile must be preserved.
+     */
+    boolean hasTestJarDependency(MavenProject downstream, MavenProject upstream) {
         String groupId = upstream.getGroupId();
         String artifactId = upstream.getArtifactId();
         for (Dependency dep : downstream.getDependencies()) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private static final String MAVEN_TEST_SKIP = "maven.test.skip";
+    private static final String SKIP_TESTS = "skipTests";
     private static final String GLOB_PREFIX = "glob:";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -600,12 +601,69 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         // Apply per-category args
         applyPerCategoryArgs(trimResult, config);
 
+        // Softening must have the last word on maven.test.skip/skipTests: it runs after
+        // applyPerCategoryArgs so user-configured upstreamArgs/downstreamArgs cannot
+        // reintroduce the #47 failure on a consumed test-jar producer.
+        Set<MavenProject> softenedProjects = softenTestJarProducers(testProjects, skippedProjects);
+
         logger.info(
-                "Scalpel: Testing {} of {} modules, skipping tests on {} modules: {}",
+                "Scalpel: Testing {}, {} compile-only (test-jar producers), skipping tests on {} of {} modules: {}",
                 testProjects.size(),
-                allProjects.size(),
+                softenedProjects.size(),
                 skippedProjects.size(),
+                allProjects.size(),
                 keys(skippedProjects));
+    }
+
+    /**
+     * Modules slated for a full test skip (maven.test.skip=true) also skip test-compile, which
+     * suppresses their test-jar. If some other module that will still run tests (directly, or
+     * because it was already softened by a previous pass) depends on that test-jar
+     * (&lt;type&gt;test-jar&lt;/type&gt;), its test-compile would fail looking for classes that
+     * were never built. Soften those producers: drop maven.test.skip and use skipTests=true
+     * instead, which only disables the surefire/failsafe execution while leaving test-compile
+     * (and jar:test-jar) intact. Softening a producer can itself depend on another skipped
+     * producer's test-jar (chained test-jar consumers), so this iterates to a fixpoint.
+     */
+    private Set<MavenProject> softenTestJarProducers(
+            List<MavenProject> testProjects, List<MavenProject> skippedProjects) {
+        Set<MavenProject> compilingTests = new LinkedHashSet<>(testProjects);
+        Set<MavenProject> softenedProjects = new LinkedHashSet<>();
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            for (MavenProject candidate : skippedProjects) {
+                if (softenedProjects.contains(candidate)) {
+                    continue;
+                }
+                for (MavenProject consumer : compilingTests) {
+                    if (reactorTrimmer.hasTestJarDependency(consumer, candidate)) {
+                        candidate.getProperties().remove(MAVEN_TEST_SKIP);
+                        candidate.getProperties().setProperty(SKIP_TESTS, "true");
+                        softenedProjects.add(candidate);
+                        compilingTests.add(candidate);
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Scalpel: Keeping test-compile for {} because its test-jar is consumed"
+                                            + " in-reactor by {} (softened: skipTests=true instead of"
+                                            + " maven.test.skip=true)",
+                                    key(candidate),
+                                    key(consumer));
+                        }
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+        }
+        skippedProjects.removeAll(softenedProjects);
+        if (!softenedProjects.isEmpty()) {
+            logger.info(
+                    "Scalpel: {} modules had test-compile restored for in-reactor test-jar consumers: {}",
+                    softenedProjects.size(),
+                    keys(softenedProjects));
+        }
+        return softenedProjects;
     }
 
     private boolean usesChangedPlugin(MavenProject project, Set<String> changedPluginGAs) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -636,13 +636,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 if (softenedProjects.contains(candidate)) {
                     continue;
                 }
-                for (MavenProject consumer : compilingTests) {
+                // Iterate a snapshot: compilingTests grows in the loop body as softened producers
+                // become potential consumers for later candidates, and mutating the live set during
+                // iteration would throw ConcurrentModificationException.
+                for (MavenProject consumer : new ArrayList<>(compilingTests)) {
                     if (reactorTrimmer.hasTestJarDependency(consumer, candidate)) {
                         candidate.getProperties().remove(MAVEN_TEST_SKIP);
                         candidate.getProperties().setProperty(SKIP_TESTS, "true");
                         softenedProjects.add(candidate);
-                        // Safe despite iterating compilingTests: the break below exits before the
-                        // iterator can advance, so no ConcurrentModificationException.
                         compilingTests.add(candidate);
                         if (logger.isDebugEnabled()) {
                             logger.debug(

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -641,6 +641,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         candidate.getProperties().remove(MAVEN_TEST_SKIP);
                         candidate.getProperties().setProperty(SKIP_TESTS, "true");
                         softenedProjects.add(candidate);
+                        // Safe despite iterating compilingTests: the break below exits before the
+                        // iterator can advance, so no ConcurrentModificationException.
                         compilingTests.add(candidate);
                         if (logger.isDebugEnabled()) {
                             logger.debug(

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1004,13 +1004,7 @@ class ScalpelLifecycleParticipantTest {
         depOnB.setArtifactId("module-b");
         depOnB.setVersion("1.0");
         moduleA.getDependencies().add(depOnB);
-        Dependency depOnCommonTestJar = new Dependency();
-        depOnCommonTestJar.setGroupId("com.example");
-        depOnCommonTestJar.setArtifactId("module-common");
-        depOnCommonTestJar.setVersion("1.0");
-        depOnCommonTestJar.setType("test-jar");
-        depOnCommonTestJar.setScope("test");
-        moduleA.getDependencies().add(depOnCommonTestJar);
+        addTestJarDependency(moduleA, "module-common");
 
         List<MavenProject> allProjects = List.of(parentProject, moduleCommon, moduleA, moduleB);
 
@@ -1072,21 +1066,9 @@ class ScalpelLifecycleParticipantTest {
         moduleX.setParent(parentProject);
 
         // module-b consumes module-a's test-jar; module-x consumes module-b's test-jar.
-        Dependency depBOnATestJar = new Dependency();
-        depBOnATestJar.setGroupId("com.example");
-        depBOnATestJar.setArtifactId("module-a");
-        depBOnATestJar.setVersion("1.0");
-        depBOnATestJar.setType("test-jar");
-        depBOnATestJar.setScope("test");
-        moduleB.getDependencies().add(depBOnATestJar);
+        addTestJarDependency(moduleB, "module-a");
 
-        Dependency depXOnBTestJar = new Dependency();
-        depXOnBTestJar.setGroupId("com.example");
-        depXOnBTestJar.setArtifactId("module-b");
-        depXOnBTestJar.setVersion("1.0");
-        depXOnBTestJar.setType("test-jar");
-        depXOnBTestJar.setScope("test");
-        moduleX.getDependencies().add(depXOnBTestJar);
+        addTestJarDependency(moduleX, "module-b");
 
         // Reactor (and sortedProjects) order places module-a before module-b before module-x,
         // which drives the order candidates are visited within skippedProjects.
@@ -1149,13 +1131,7 @@ class ScalpelLifecycleParticipantTest {
 
         // module-c consumes module-p's test-jar even though module-p has no build-graph relation
         // to module-c.
-        Dependency depCOnPTestJar = new Dependency();
-        depCOnPTestJar.setGroupId("com.example");
-        depCOnPTestJar.setArtifactId("module-p");
-        depCOnPTestJar.setVersion("1.0");
-        depCOnPTestJar.setType("test-jar");
-        depCOnPTestJar.setScope("test");
-        moduleC.getDependencies().add(depCOnPTestJar);
+        addTestJarDependency(moduleC, "module-p");
 
         List<MavenProject> allProjects = List.of(parentProject, moduleC, moduleP);
 
@@ -3175,6 +3151,16 @@ class ScalpelLifecycleParticipantTest {
                 </artifactId><version>1.0</version></dependency></dependencies>
                 </project>
                 """;
+    }
+
+    private static void addTestJarDependency(MavenProject consumer, String artifactId) {
+        Dependency dep = new Dependency();
+        dep.setGroupId("com.example");
+        dep.setArtifactId(artifactId);
+        dep.setVersion("1.0");
+        dep.setType("test-jar");
+        dep.setScope("test");
+        consumer.getDependencies().add(dep);
     }
 
     private void writePom(Path root, String relativePath, String content) throws Exception {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -968,6 +968,219 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void skipTestsMode_softensTestSkipForInReactorTestJarConsumer() throws Exception {
+        // module-b is the changed module and depends on module-common's main jar only, so
+        // module-common becomes upstream-only (skip-test candidate with skipTestsForUpstream).
+        // module-a depends on module-b (so it stays in the "will run tests" set as a downstream
+        // module) and also consumes module-common's test-jar. If module-common got
+        // maven.test.skip=true, its test-compile (and therefore its test-jar) would be
+        // suppressed, breaking module-a. Scalpel must soften module-common to skipTests=true
+        // instead, which only skips the surefire/failsafe execution.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-common", "module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleCommonPom = simpleChildPom("module-common");
+        writePom(root, "module-common/pom.xml", moduleCommonPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-common");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleCommon =
+                createProject("com.example", "module-common", "1.0", root, "module-common/pom.xml", moduleCommonPom);
+        moduleCommon.setParent(parentProject);
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        // module-a depends on module-b (compile) and on module-common's test-jar (test scope)
+        Dependency depOnB = new Dependency();
+        depOnB.setGroupId("com.example");
+        depOnB.setArtifactId("module-b");
+        depOnB.setVersion("1.0");
+        moduleA.getDependencies().add(depOnB);
+        Dependency depOnCommonTestJar = new Dependency();
+        depOnCommonTestJar.setGroupId("com.example");
+        depOnCommonTestJar.setArtifactId("module-common");
+        depOnCommonTestJar.setVersion("1.0");
+        depOnCommonTestJar.setType("test-jar");
+        depOnCommonTestJar.setScope("test");
+        moduleA.getDependencies().add(depOnCommonTestJar);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleCommon, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-b/src/main/java/Bar.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForUpstream", "true");
+        ProjectDependencyGraph graph = session.getProjectDependencyGraph();
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of(moduleA));
+        when(graph.getUpstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of(moduleCommon));
+        when(graph.getUpstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB, moduleCommon));
+
+        participant.afterProjectsRead(session);
+
+        assertFalse(
+                "true".equals(moduleCommon.getProperties().getProperty("maven.test.skip")),
+                "module-common must NOT have maven.test.skip=true (its test-jar is consumed in-reactor)");
+        assertTrue(
+                "true".equals(moduleCommon.getProperties().getProperty("skipTests")),
+                "module-common should have skipTests=true (softened skip)");
+        assertFalse(
+                "true".equals(moduleA.getProperties().getProperty("maven.test.skip")),
+                "module-a should run tests (it is a test-jar consumer, not a skip candidate)");
+    }
+
+    @Test
+    void skipTestsMode_softensChainedTestJarProducersViaFixpointIteration() throws Exception {
+        // module-x is the changed module (directly affected, runs tests).
+        // module-b is upstream-only (skip candidate) and its test-jar is consumed by module-x.
+        // module-a is upstream-only (skip candidate) and its test-jar is consumed by module-b.
+        // module-a is ordered BEFORE module-b in the reactor (and therefore in skippedProjects),
+        // so on the first while-pass module-b has not been softened yet when module-a is
+        // checked, and module-a is NOT softened; only the second pass (after module-b is
+        // softened) can soften module-a. A single-pass implementation would leave module-a with
+        // maven.test.skip=true, which would break module-b's test-compile.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b", "module-x");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+        String moduleXPom = simpleChildPom("module-x");
+        writePom(root, "module-x/pom.xml", moduleXPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        MavenProject moduleX = createProject("com.example", "module-x", "1.0", root, "module-x/pom.xml", moduleXPom);
+        moduleX.setParent(parentProject);
+
+        // module-b consumes module-a's test-jar; module-x consumes module-b's test-jar.
+        Dependency depBOnATestJar = new Dependency();
+        depBOnATestJar.setGroupId("com.example");
+        depBOnATestJar.setArtifactId("module-a");
+        depBOnATestJar.setVersion("1.0");
+        depBOnATestJar.setType("test-jar");
+        depBOnATestJar.setScope("test");
+        moduleB.getDependencies().add(depBOnATestJar);
+
+        Dependency depXOnBTestJar = new Dependency();
+        depXOnBTestJar.setGroupId("com.example");
+        depXOnBTestJar.setArtifactId("module-b");
+        depXOnBTestJar.setVersion("1.0");
+        depXOnBTestJar.setType("test-jar");
+        depXOnBTestJar.setScope("test");
+        moduleX.getDependencies().add(depXOnBTestJar);
+
+        // Reactor (and sortedProjects) order places module-a before module-b before module-x,
+        // which drives the order candidates are visited within skippedProjects.
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleX);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-x/src/main/java/Baz.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        session.getSystemProperties().setProperty("scalpel.skipTestsForUpstream", "true");
+        ProjectDependencyGraph graph = session.getProjectDependencyGraph();
+        // module-a and module-b are both (transitively) upstream of the changed module-x.
+        when(graph.getUpstreamProjects(eq(moduleX), anyBoolean())).thenReturn(List.of(moduleB, moduleA));
+
+        participant.afterProjectsRead(session);
+
+        assertFalse(
+                "true".equals(moduleA.getProperties().getProperty("maven.test.skip")),
+                "module-a must NOT have maven.test.skip=true (its test-jar is consumed in-reactor via "
+                        + "module-b, only reachable on the second fixpoint pass)");
+        assertTrue(
+                "true".equals(moduleA.getProperties().getProperty("skipTests")),
+                "module-a should have skipTests=true (softened skip, second fixpoint pass)");
+        assertFalse(
+                "true".equals(moduleB.getProperties().getProperty("maven.test.skip")),
+                "module-b must NOT have maven.test.skip=true (its test-jar is consumed in-reactor by module-x)");
+        assertTrue(
+                "true".equals(moduleB.getProperties().getProperty("skipTests")),
+                "module-b should have skipTests=true (softened skip, first fixpoint pass)");
+    }
+
+    @Test
+    void skipTestsMode_softensTestJarProducerOutsideBuildSet() throws Exception {
+        // module-c is the changed module (directly affected, in includePaths scope).
+        // module-p has no reactor dependency relation to module-c (not upstream/downstream), so
+        // it never enters trimResult.getBuildSet() at all: it is only visited by the SECOND loop
+        // in applySkipTests (over allProjects, skipping buildSet members), where it gets skipped
+        // because it falls outside includePaths scope. module-c still consumes module-p's
+        // test-jar, so softenTestJarProducers must reach into that second-loop population and
+        // soften module-p, not just first-loop (buildSet) candidates.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-c", "module-p");
+        writePom(root, "pom.xml", parentPom);
+        String moduleCPom = simpleChildPom("module-c");
+        writePom(root, "module-c/pom.xml", moduleCPom);
+        String modulePPom = simpleChildPom("module-p");
+        writePom(root, "module-p/pom.xml", modulePPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleC = createProject("com.example", "module-c", "1.0", root, "module-c/pom.xml", moduleCPom);
+        moduleC.setParent(parentProject);
+        MavenProject moduleP = createProject("com.example", "module-p", "1.0", root, "module-p/pom.xml", modulePPom);
+        moduleP.setParent(parentProject);
+
+        // module-c consumes module-p's test-jar even though module-p has no build-graph relation
+        // to module-c.
+        Dependency depCOnPTestJar = new Dependency();
+        depCOnPTestJar.setGroupId("com.example");
+        depCOnPTestJar.setArtifactId("module-p");
+        depCOnPTestJar.setVersion("1.0");
+        depCOnPTestJar.setType("test-jar");
+        depCOnPTestJar.setScope("test");
+        moduleC.getDependencies().add(depCOnPTestJar);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleC, moduleP);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-c/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "skip-tests");
+        // module-p is outside includePaths scope; module-c is not, so it stays directly affected.
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-c/**");
+
+        participant.afterProjectsRead(session);
+
+        assertFalse(
+                "true".equals(moduleP.getProperties().getProperty("maven.test.skip")),
+                "module-p must NOT have maven.test.skip=true (its test-jar is consumed in-reactor by "
+                        + "module-c, even though module-p is outside the trimmed build set)");
+        assertTrue(
+                "true".equals(moduleP.getProperties().getProperty("skipTests")),
+                "module-p should have skipTests=true (softened skip reached from the second loop population)");
+    }
+
+    @Test
     void reportMode_forceBuildModulesIncludesMatching() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);

--- a/it/extension3-its/src/it/skip-tests-test-jar/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/skip-tests-test-jar/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/skip-tests-test-jar/invoker.properties
+++ b/it/extension3-its/src/it/skip-tests-test-jar/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = package -Dscalpel.baseBranch=base -Dscalpel.mode=skip-tests -Dscalpel.skipTestsForUpstream=true

--- a/it/extension3-its/src/it/skip-tests-test-jar/module-a/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-test-jar/module-a/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skipteststestjar</groupId>
+        <artifactId>skip-tests-test-jar</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <!-- Downstream of module-b (so its own tests run when module-b changes), and an in-reactor
+         consumer of module-common's test-jar. If module-common's test-compile is suppressed by
+         maven.test.skip, module-common's test-jar will be missing TestSupport and this module's
+         test-compile will fail with "cannot find symbol: class TestSupport". -->
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.skipteststestjar</groupId>
+            <artifactId>module-b</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.skipteststestjar</groupId>
+            <artifactId>module-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.13.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/skip-tests-test-jar/module-a/src/test/java/UsesTestSupportTest.java
+++ b/it/extension3-its/src/it/skip-tests-test-jar/module-a/src/test/java/UsesTestSupportTest.java
@@ -1,0 +1,10 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class UsesTestSupportTest {
+    @Test
+    void usesTestSupportFromModuleCommon() {
+        assertEquals("hello", TestSupport.hello());
+    }
+}

--- a/it/extension3-its/src/it/skip-tests-test-jar/module-b/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-test-jar/module-b/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skipteststestjar</groupId>
+        <artifactId>skip-tests-test-jar</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <!-- The module changed by setup.groovy. Depends on module-common's main jar only. -->
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.skipteststestjar</groupId>
+            <artifactId>module-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/skip-tests-test-jar/module-common/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-test-jar/module-common/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.skipteststestjar</groupId>
+        <artifactId>skip-tests-test-jar</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-common</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <!-- Produces a test-jar consumed in-reactor by module-a. Scalpel's skip-tests mode must
+         not suppress this module's test-compile via maven.test.skip, or the test-jar built
+         below will be empty and module-a's test-compile will fail (see scalpel#47). -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/it/extension3-its/src/it/skip-tests-test-jar/module-common/src/main/java/Common.java
+++ b/it/extension3-its/src/it/skip-tests-test-jar/module-common/src/main/java/Common.java
@@ -1,0 +1,2 @@
+public class Common {
+}

--- a/it/extension3-its/src/it/skip-tests-test-jar/module-common/src/test/java/TestSupport.java
+++ b/it/extension3-its/src/it/skip-tests-test-jar/module-common/src/test/java/TestSupport.java
@@ -1,0 +1,5 @@
+public class TestSupport {
+    public static String hello() {
+        return "hello";
+    }
+}

--- a/it/extension3-its/src/it/skip-tests-test-jar/pom.xml
+++ b/it/extension3-its/src/it/skip-tests-test-jar/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.skipteststestjar</groupId>
+    <artifactId>skip-tests-test-jar</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
+    </properties>
+
+    <modules>
+        <module>module-common</module>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/it/extension3-its/src/it/skip-tests-test-jar/setup.groovy
+++ b/it/extension3-its/src/it/skip-tests-test-jar/setup.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// module-a depends on module-b (compile) and on module-common's test-jar (test scope).
+// module-b depends on module-common's main jar only.
+// Change source in module-b only: module-common becomes upstream-only (via alsoMake), and
+// with skipTestsForUpstream=true it is a skip-test candidate. Since module-a's test-compile
+// consumes module-common's test-jar, module-common's skip must be softened (skipTests=true)
+// instead of maven.test.skip=true, or module-a's test-compile fails (scalpel#47).
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Only change module-b source
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Bar.java').text = 'public class Bar {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension3-its/src/it/skip-tests-test-jar/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-test-jar/verify.groovy
@@ -36,8 +36,8 @@ assert softenedLine != null : "Expected the aggregate summary to report module-c
 // download output can interleave arbitrarily many lines within a section, so bound by the next
 // section header rather than a fixed line count.
 def sectionText = { int sectionStart ->
-    int nextSection = (sectionStart + 1..<lines.size()).find { i -> lines[i].contains('[INFO] --- ') } ?: lines.size() - 1
-    lines[sectionStart..nextSection].join('\n')
+    int nextSection = (sectionStart + 1..<lines.size()).find { i -> lines[i].contains('[INFO] --- ') } ?: lines.size()
+    lines[sectionStart..<nextSection].join('\n')
 }
 
 // module-common's surefire execution itself should be skipped (proves skipTests=true took

--- a/it/extension3-its/src/it/skip-tests-test-jar/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-test-jar/verify.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+List<String> lines = buildLog.readLines()
+String log = buildLog.text
+
+// Scalpel should be activated in skip-tests mode
+assert log.contains('Scalpel') : "Expected Scalpel to be activated"
+assert log.contains('mode=skip-tests') : "Expected skip-tests mode"
+
+// The underlying reactor build must succeed: module-a's test-compile must not fail looking
+// for classes that were never compiled in module-common's (skip-tested) test-jar.
+assert log.contains('BUILD SUCCESS') : "Expected BUILD SUCCESS, got:\n$log"
+
+// module-b should be directly affected (source changed)
+def directlyAffectedLine = lines.find { it.contains('directly affected') }
+assert directlyAffectedLine != null : "Expected 'directly affected' log line"
+assert directlyAffectedLine.contains('module-b') : "module-b should be directly affected"
+
+// module-common's skip must be softened: maven.test.skip=true would have suppressed its
+// test-compile (and left its test-jar without TestSupport); the fix keeps test-compile alive
+// and skips only the surefire/failsafe execution via skipTests=true instead. The per-candidate
+// softening detail is logged at debug (not visible here); the aggregate INFO summary is what's
+// checked in default (non-debug) build output.
+def softenedLine = lines.find { it.contains('test-compile restored') && it.contains('module-common') }
+assert softenedLine != null : "Expected the aggregate summary to report module-common's test-compile was restored (softened), got:\n$log"
+
+// Returns the log lines belonging to the plugin execution section starting at sectionStart
+// (a "--- goal ... ---" header line), up to (excluding) the next such header. Plugin artifact
+// download output can interleave arbitrarily many lines within a section, so bound by the next
+// section header rather than a fixed line count.
+def sectionText = { int sectionStart ->
+    int nextSection = (sectionStart + 1..<lines.size()).find { i -> lines[i].contains('[INFO] --- ') } ?: lines.size() - 1
+    lines[sectionStart..nextSection].join('\n')
+}
+
+// module-common's surefire execution itself should be skipped (proves skipTests=true took
+// effect, as opposed to maven.test.skip which would skip test-compile too)
+int commonSurefireIdx = lines.findIndexOf { it.contains('surefire') && it.contains(':test') && it.contains('@ module-common') }
+assert commonSurefireIdx >= 0 : "Expected a surefire execution section for module-common, got:\n$log"
+def commonSurefireSection = sectionText(commonSurefireIdx)
+assert commonSurefireSection.contains('Tests are skipped') : "Expected module-common's surefire execution to be skipped, got:\n$commonSurefireSection"
+
+// module-common's test-jar must have been produced (test-compile was preserved)
+assert log.contains('test-jar) @ module-common') : "Expected module-common's test-jar to be built, got:\n$log"
+
+// module-a's test must have actually compiled and run (it is a downstream module, not
+// skip-tested, and its test-compile depends on module-common's test-jar being populated)
+int aSurefireIdx = lines.findIndexOf { it.contains('surefire') && it.contains(':test') && it.contains('@ module-a') }
+assert aSurefireIdx >= 0 : "Expected a surefire execution section for module-a, got:\n$log"
+def aSurefireSection = sectionText(aSurefireIdx)
+assert aSurefireSection.contains('Tests run: 1, Failures: 0, Errors: 0') : "Expected module-a's test to run and pass, got:\n$aSurefireSection"


### PR DESCRIPTION
Fixes #47.

## Mechanism

`applySkipTests()` implements skip decisions with `maven.test.skip=true`, which the Compiler Plugin also honors, so a skipped module's test-compile never runs and its `maven-jar-plugin:test-jar` artifact is never produced. Any module still running tests that consumes that test-jar in-reactor (`<type>test-jar</type>`) then fails dependency resolution. In the real-world case that motivated #47 (Apicurio Registry's shadow evaluation), one skipped producer failed all shards at once, accounting for 91% of the observed Scalpel-side failures.

## Remedy

A fix-up pass (`softenTestJarProducers`) runs after the skip partition: for skip candidates whose test-jar is consumed by any module that will compile tests, the skip is softened from `maven.test.skip=true` to `skipTests=true`: test-compile and test-jar packaging still happen, only Surefire/Failsafe execution is skipped, so the optimization is preserved. The pass iterates to a fixpoint so chained producers (A's test-jar consumed by B's tests, B's by a test-runner) are handled, and it considers skip candidates from both populations (trim build set and outside it). `ReactorTrimmer.hasTestJarDependency` is reused (promoted to package-private) rather than duplicating the check.

Softening deliberately runs after `applyPerCategoryArgs` so user-configured `upstreamArgs`/`downstreamArgs` cannot reintroduce the failure on a consumed producer (comment in code states the invariant). The summary log now reports the third bucket: `Testing X, N compile-only (test-jar producers), skipping tests on Z of Y`.

## Tests

- New IT `skip-tests-test-jar` (module-common producing a test-jar, module-a consuming it with a real JUnit test, module-b as the changed module): written red-first against the unpatched code, where it reproduces the exact production failure (`Could not find artifact ...module-common:jar:tests`); green with the fix, asserting build success, producer executions skipped, consumer tests ran.
- Unit tests including two fixpoint guards: a 3-module chain ordered so only a second iteration can soften the first producer (verified to fail under a single-pass regression), and a producer outside the trim build set.
- Full `./mvnw clean verify -e -B -P run-its`: 23/23 ITs, extension3 135/135 unit tests, BUILD SUCCESS.

## Known inherited limitation (out of scope)

`hasTestJarDependency` matches the canonical `<type>test-jar</type>` form only, not the equivalent `<classifier>tests</classifier><type>jar</type>` spelling: pre-existing behavior, unchanged here, noted in the commit body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved skip-tests mode for projects that consume test JARs.
  * Producer modules remain available for test compilation while test execution stays skipped.
  * Added support for chained and out-of-scope test JAR dependencies.

* **Tests**
  * Added unit and integration coverage for test JAR creation, dependency propagation, reactor completion, and downstream test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->