### PR TITLE
docs: document includePaths and correct the GIB comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ set, so a module outside the scope can still re-enter the build as an upstream p
 `trim` mode, or still run its tests as a dependent in `skip-tests` mode. If no module matches,
 `trim` falls back to a full build and `skip-tests` skips tests everywhere.
 
-Patterns are matched against the module directory. Use a trailing `/**` (e.g. `module-a/**`) to
+Patterns are matched against the module directory or its `pom.xml` path. Use a trailing `/**` (e.g. `module-a/**`) to
 cover a module together with its submodules; a bare `module-a` matches only that module and not
 its children.
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ All properties can be set via `-D` on the command line or in `.mvn/maven.config`
 | `scalpel.alsoMakeDependents` | `true` | Include downstream dependents of affected modules (trim mode) |
 | `scalpel.fullBuildTriggers` | `.mvn/**` | Comma-separated glob patterns; if a changed file matches, a full build is triggered |
 | `scalpel.excludePaths` | *(none)* | Comma-separated glob patterns; changed files matching these are ignored |
+| `scalpel.includePaths` | *(none)* | Comma-separated glob patterns; narrows the affected set to matching modules rather than filtering changed files |
 | `scalpel.disableTriggers` | *(none)* | Comma-separated glob patterns; if any changed file matches, Scalpel is disabled entirely |
 | `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report (report mode), relative to reactor root |
 | `scalpel.impactedLog` | *(none)* | Write impacted module paths to this file (one per line) |
@@ -295,8 +296,8 @@ build. You can customize this with comma-separated glob patterns:
 
 ## Path Filtering
 
-Scalpel provides three levels of path-based control over change detection. All use
-comma-separated glob patterns:
+Scalpel provides three file-level filters over change detection, plus a module-level scope
+described below. All use comma-separated glob patterns:
 
 - **`scalpel.excludePaths`** — Ignore matching files from change detection. Use this for files
   that shouldn't trigger rebuilds (documentation, editor config, etc.):
@@ -315,6 +316,24 @@ comma-separated glob patterns:
 
 These filters are applied in order: disable triggers are checked first, then excluded paths are
 removed, then full build triggers are checked on the remaining files.
+
+Separately, **`scalpel.includePaths`** scopes *modules* rather than files, and is applied after the
+three filters above. It narrows the affected set to modules whose path matches, which is useful for
+scoping a CI job to one area of a large reactor:
+
+```bash
+-Dscalpel.includePaths=frontend/**,shared/**
+```
+
+Because it acts on modules, change detection still sees the whole diff. `includePaths` narrows the
+*affected set*, and each mode then applies its usual upstream and downstream rules to that narrowed
+set, so a module outside the scope can still re-enter the build as an upstream prerequisite in
+`trim` mode, or still run its tests as a dependent in `skip-tests` mode. If no module matches,
+`trim` falls back to a full build and `skip-tests` skips tests everywhere.
+
+Patterns are matched against the module directory. Use a trailing `/**` (e.g. `module-a/**`) to
+cover a module together with its submodules; a bare `module-a` matches only that module and not
+its children.
 
 ## Force-Build Modules
 
@@ -543,12 +562,13 @@ change a library, its downstream dependents *should* be rebuilt to catch breakag
 this need can set `scalpel.alsoMakeDependents=false` for a quick local cycle, or use
 `scalpel.enabled=false` to bypass Scalpel entirely.
 
-**`includePathsMatching`.** GIB supports an include-only path filter (only files matching the
-regex count as changes). Scalpel only has `excludePaths`. In practice, the two are interchangeable
-— if you want only `.java` files to trigger rebuilds, exclude everything else. More importantly,
-Scalpel's semantic POM analysis handles the main case where GIB users need path filtering:
-cosmetic POM changes (reformatting, reordering) don't trigger rebuilds in Scalpel, so there's
-no need to filter `pom.xml` changes via path patterns.
+**`includePathsMatching`.** GIB supports an include-only filter on *changed files* (only files
+matching the regex count as changes). Scalpel has no file-level include filter; use `excludePaths`
+to ignore everything you don't care about instead. `scalpel.includePaths` is not a substitute: it
+scopes which *modules* Scalpel treats as affected, leaving change detection on the full diff. More
+importantly, Scalpel's semantic POM analysis handles the main case where GIB users need path
+filtering: cosmetic POM changes (reformatting, reordering) don't trigger rebuilds in Scalpel, so
+there's no need to filter `pom.xml` changes via path patterns.
 
 **`disableBranchComparison`.** GIB can skip branch comparison entirely and detect changes based
 solely on uncommitted/untracked files — useful for IDE-like workflows where you want "what have
@@ -630,7 +650,7 @@ decisions. If Scalpel's analysis is wrong, your escape hatches are `forceBuildMo
 | `gib.failOnError` | `scalpel.failSafe` | Inverted semantics (`failSafe=true` ≈ `failOnError=false`) |
 | `gib.buildUpstreamMode` | *(no equivalent)* | Scalpel always uses the full impacted set |
 | `gib.excludeDownstreamModulesPackagedAs` | *(no equivalent)* | Use `forceBuildModules` or CI scripting |
-| `gib.includePathsMatching` | *(no equivalent)* | Use `excludePaths` to ignore unwanted files |
+| `gib.includePathsMatching` | *(no equivalent)* | File-level include filter; use `excludePaths` inversely. Not `scalpel.includePaths`, which is module-scoped |
 | `gib.disableBranchComparison` | *(no equivalent)* | Use `uncommitted`/`untracked` without setting `baseBranch` |
 | `gib.loadImpactedDependenciesFrom` | *(no equivalent)* | |
 | `gib.logImpactedFormat` | *(no equivalent)* | JSON report contains GAV information |


### PR DESCRIPTION
## Problem

The README states in two places that Scalpel has no include-only path filter:

- "**`includePathsMatching`.** GIB supports an include-only path filter ... Scalpel only has `excludePaths`."
- `| gib.includePathsMatching | *(no equivalent)* | Use excludePaths to ignore unwanted files |`

Both are inaccurate since 34533e6 (#43) added `scalpel.includePaths`. That commit did not touch the README, so the property has been shipped and undocumented since then.

## The subtlety

The obvious correction would be to map `gib.includePathsMatching` onto `scalpel.includePaths`, but that would replace one wrong claim with another. They are different features:

- `excludePaths` filters **changed files** (`filterExcludedPaths`)
- `includePaths` filters **modules** (`matchesIncludePaths`)
- GIB's `includePathsMatching` is a **changed-file** filter

The existing test says so directly, in `ScalpelLifecycleParticipantTest.reportMode_includePathsPreservesFullDiffVisibility`:

> This verifies that includePaths filters MODULES, not changed files.

So Scalpel genuinely has no file-level include filter, and the original conclusion was right even though the stated reason was wrong. This PR keeps the conclusion and fixes the reasoning.

## Changes

- Adds `scalpel.includePaths` to the Configuration table, where it was missing entirely.
- Documents it in Path Filtering, including the behaviour I could verify in the code: it narrows the affected set, each mode then applies its usual upstream/downstream rules (so a module outside the scope can re-enter as an upstream prerequisite in `trim`, or still run tests as a dependent in `skip-tests`), and if nothing matches, `trim` falls back to a full build while `skip-tests` skips tests everywhere.
- Notes the `module-a` vs `module-a/**` distinction, since a bare pattern does not match submodules.
- Updates the section opener, which said "three levels of path-based control over change detection" and would otherwise now be inaccurate on both counts.
- Corrects the two GIB claims without asserting a false equivalence.

Documentation only, no code changes.

## Possible follow-ups, happy to do these separately if wanted

- `scalpel.skipTestsForDownstreamModules` (#14) and `scalpel.maxResourceFileSize` (#34) are also undocumented in the Configuration table, so `includePaths` was one of three rather than a one-off.
- A test asserting that every `scalpel.*` constant in `ScalpelConfiguration` has a README table row would stop this recurring. It would fail today on the two properties above, so it seemed like your call rather than something to slip into this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the `scalpel.includePaths` module-scoping configuration property.
  * Clarified file-level filtering versus module-level scoping.
  * Added guidance on matching behavior, mode-specific re-entry, and no-match fallback behavior.
  * Updated comparison guidance to clarify supported filtering capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->