### PR TITLE
chore: enable reproducible builds from source archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.mvn/maven-user.properties export-subst

--- a/.mvn/maven-user.properties
+++ b/.mvn/maven-user.properties
@@ -1,0 +1,3 @@
+# Fallback values for source archives (expanded by git archive via export-subst)
+nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
+nisse.jgit.date=$Format:%aI$

--- a/.mvn/maven-user.properties
+++ b/.mvn/maven-user.properties
@@ -1,3 +1,3 @@
 # Fallback values for source archives (expanded by git archive via export-subst)
 nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
-nisse.jgit.date=$Format:%aI$
+nisse.jgit.date=$Format:%cI$


### PR DESCRIPTION
## Summary

GitHub tag tarballs (and any `git archive` output) lack a `.git` directory, so nisse
can't derive the version or commit timestamp. This makes it impossible to rebuild
from a source archive — or to verify that published artifacts match their source.

This PR uses git's `export-subst` mechanism to solve both problems with zero ongoing
maintenance:

- `.gitattributes` marks `.mvn/maven-user.properties` for `export-subst`
- `.mvn/maven-user.properties` gains two `$Format:...$` placeholders for version and timestamp

**In a git checkout**: nisse resolves both properties from git history via JGit, overwriting
the literal `$Format:...$` strings. No behavior change.

**In a source archive** (GitHub tarball, `git archive`): git expands the placeholders
at archive time. Maven reads the pre-expanded values from `maven-user.properties`
directly. `./mvnw clean install` just works — no `-D` flags needed.

Follows the same pattern as [jline/jline3#2151](https://github.com/jline/jline3/pull/2151).

## Test plan

- [x] `./mvnw clean install -B -DskipTests` — BUILD SUCCESS
- [x] `./mvnw test -B` — BUILD SUCCESS
- [ ] Verify `git archive --prefix=scalpel/ HEAD | tar -xf -` produces expanded values in the tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved source archive metadata handling.
  * Added fallback values for version and archive date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->