### PR TITLE
Fix #50 items 3+10: normalize path separators and remove rename detection

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -79,8 +79,6 @@ public class GitChangeDetector {
 
             try (DiffFormatter diffFormatter = new DiffFormatter(NullOutputStream.INSTANCE)) {
                 diffFormatter.setRepository(repository);
-                diffFormatter.setDetectRenames(true);
-
                 for (DiffEntry entry : diffFormatter.scan(baseCommit.getTree(), headCommit.getTree())) {
                     switch (entry.getChangeType()) {
                         case ADD:

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -106,6 +106,6 @@ class ModuleMapper {
         if (projectDir.equals(rootDir)) {
             return "";
         }
-        return rootDir.relativize(projectDir).toString();
+        return rootDir.relativize(projectDir).toString().replace('\\', '/');
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -128,7 +128,7 @@ class PomChangeAnalyzer {
         for (MavenProject project : allProjects) {
             Path pomPath = project.getFile().toPath().toAbsolutePath().normalize();
             Path relativePom = reactorRoot.toAbsolutePath().normalize().relativize(pomPath);
-            projectByPomPath.put(relativePom.toString(), project);
+            projectByPomPath.put(relativePom.toString().replace('\\', '/'), project);
         }
 
         // Build set of projects that have children in the reactor

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -110,7 +110,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             for (MavenProject project : allProjects) {
                 Path pomPath = project.getFile().toPath().toAbsolutePath().normalize();
                 Path relativePom = reactorRoot.toAbsolutePath().normalize().relativize(pomPath);
-                allPomPaths.add(relativePom.toString());
+                allPomPaths.add(relativePom.toString().replace('\\', '/'));
             }
 
             // Detect changes
@@ -996,7 +996,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .toAbsolutePath()
                 .normalize()
                 .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
-                .toString();
+                .toString()
+                .replace('\\', '/');
     }
 
     private void applyPerCategoryArgs(TrimResult trimResult, ScalpelConfiguration config) {


### PR DESCRIPTION
## Summary

Addresses items 3 and 10 from #50:

- **Item 3 — Path separators break module mapping on Windows:** `Path.relativize().toString()` produces `\`-separated paths on Windows, but Git always emits `/`-separated paths. String comparisons between these never match, causing `ModuleMapper` to miss nested modules and `PomChangeAnalyzer` to silently drop changed POM lookups. Fixed by appending `.replace('\\', '/')` to all 4 `relativize().toString()` call sites: `ModuleMapper.getRelativePath()`, `PomChangeAnalyzer.analyzeChanges()`, and two locations in `ScalpelLifecycleParticipant` (`allPomPaths` collection and `relativePath()` helper).

- **Item 10 — Remove redundant `setDetectRenames(true)`:** `getChangedFiles` already records both old and new paths for `RENAME` entries, which is exactly what an `ADD` + `DELETE` pair produces with rename detection off. Removing it avoids unnecessary similarity scoring and eliminates a dependence on the repository's `diff.renamelimit` setting.

## Test plan

- [x] All existing tests pass (216 tests: 81 in core, 135 in extension3)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)