### PR TITLE
Fix #50 item 7: bump report schema version from 1 to 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,13 @@ not as a replacement. It contains only directly affected modules (not upstream/d
 
 #### Report Format
 
+The report follows a versioned JSON schema. A [JSON Schema](core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json)
+is published alongside the code. The current version is **2**.
+
 ```json
 {
-  "version": "1",
-  "scalpelVersion": "0.1.0",
+  "version": "2",
+  "scalpelVersion": "0.3.10",
   "baseBranch": "origin/main",
   "fullBuildTriggered": false,
   "triggerFile": null,
@@ -123,6 +126,7 @@ not as a replacement. It contains only directly affected modules (not upstream/d
   "changedProperties": [],
   "changedManagedDependencies": [],
   "changedManagedPlugins": [],
+  "excludedUpstreamCount": 0,
   "affectedModules": [
     {
       "groupId": "com.example",
@@ -139,10 +143,30 @@ not as a replacement. It contains only directly affected modules (not upstream/d
       "reasons": ["TEST_CHANGE"],
       "category": "DIRECT",
       "sourceSet": "test"
+    },
+    {
+      "groupId": "com.example",
+      "artifactId": "module-c",
+      "path": "module-c",
+      "reasons": ["DOWNSTREAM_DEPENDENT"],
+      "category": "DOWNSTREAM",
+      "testsSkipped": true,
+      "testsSkippedReason": "EXCLUDED_DOWNSTREAM"
     }
   ]
 }
 ```
+
+**Schema version history:**
+
+| Version | Changes |
+|---------|---------|
+| `2` | Added `category`, `sourceSet`, `excludedUpstreamCount`, `testsSkipped`, `testsSkippedReason` |
+| `1` | Initial schema |
+
+**Compatibility:** new optional fields may be added within a major version. Consumers
+should ignore unknown fields. A version bump signals structural changes that existing
+consumers may need to handle.
 
 **Affected module reasons:**
 
@@ -154,10 +178,11 @@ not as a replacement. It contains only directly affected modules (not upstream/d
 | `TRANSITIVE_DEPENDENCY` | A changed managed dependency reaches this module transitively (compile/runtime scope) |
 | `TRANSITIVE_DEPENDENCY_TEST` | A changed managed dependency reaches this module transitively via test scope only |
 | `MANAGED_PLUGIN` | This module uses a plugin whose managed version changed |
-| `UPSTREAM_DEPENDENCY` | Included as an upstream dependency (via `alsoMake`) |
+| `UPSTREAM_DEPENDENCY` | *(deprecated)* Included as an upstream dependency (via `alsoMake`) |
 | `DOWNSTREAM_DEPENDENT` | Included as a downstream dependent (via `alsoMakeDependents`) |
 | `DOWNSTREAM_TEST` | Included as a downstream dependent via test-scoped dependency only |
 | `FORCE_BUILD` | This module was force-included via `forceBuildModules` |
+| `EXCLUDED_DOWNSTREAM` | Downstream module whose tests were skipped (see `testsSkippedReason`) |
 
 **Affected module source sets** (present on directly affected modules with source changes):
 
@@ -174,6 +199,14 @@ not as a replacement. It contains only directly affected modules (not upstream/d
 | `TRANSITIVE` | Affected by a changed managed dependency or plugin (not directly changed) |
 | `UPSTREAM` | Included as an upstream dependency (via `alsoMake`) |
 | `DOWNSTREAM` | Included as a downstream dependent (via `alsoMakeDependents`) |
+
+**Additional module fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `excludedUpstreamCount` | integer | *(top-level)* Number of upstream build-prerequisite modules excluded from `affectedModules` |
+| `testsSkipped` | boolean | Present and `true` when tests are skipped for this module |
+| `testsSkippedReason` | string | Why tests were skipped (e.g. `EXCLUDED_DOWNSTREAM`) |
 
 ## Source-Set-Aware Downstream Propagation
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -17,6 +17,15 @@ import java.util.List;
 
 public final class ScalpelReport {
 
+    /**
+     * Report schema version. Bump this whenever the report JSON structure changes
+     * (new fields, removed fields, or semantic changes to existing fields).
+     * <p>
+     * v1 → v2: added {@code category}, {@code sourceSet}, {@code excludedUpstreamCount},
+     *           {@code testsSkipped}, {@code testsSkippedReason}.
+     */
+    public static final String REPORT_VERSION = "2";
+
     public static final String REASON_SOURCE_CHANGE = "SOURCE_CHANGE";
     public static final String REASON_POM_CHANGE = "POM_CHANGE";
     public static final String REASON_TRANSITIVE_DEPENDENCY = "TRANSITIVE_DEPENDENCY";
@@ -191,7 +200,7 @@ public final class ScalpelReport {
     public String toJson() {
         StringBuilder sb = new StringBuilder();
         sb.append("{\n");
-        sb.append("  \"version\": \"1\",\n");
+        sb.append("  \"version\": ").append(jsonString(REPORT_VERSION)).append(",\n");
         sb.append("  \"scalpelVersion\": ")
                 .append(jsonString(Version.version()))
                 .append(",\n");

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://maveniverse.eu/schemas/scalpel-report-v2.json",
+  "title": "Scalpel Report",
+  "description": "JSON report produced by Scalpel (mode=report) describing which modules in a Maven multi-module reactor are affected by a git changeset.",
+  "type": "object",
+  "required": [
+    "version",
+    "scalpelVersion",
+    "baseBranch",
+    "fullBuildTriggered",
+    "triggerFile",
+    "changedFiles",
+    "changedProperties",
+    "changedManagedDependencies",
+    "changedManagedPlugins",
+    "excludedUpstreamCount",
+    "affectedModules"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "2",
+      "description": "Report schema version. '2' indicates the v2 format with category, sourceSet, excludedUpstreamCount, testsSkipped, and testsSkippedReason fields."
+    },
+    "scalpelVersion": {
+      "type": "string",
+      "description": "The version of the Scalpel extension that produced this report (e.g. '0.3.9')."
+    },
+    "baseBranch": {
+      "type": "string",
+      "description": "The base branch that was compared against (e.g. 'origin/main')."
+    },
+    "fullBuildTriggered": {
+      "type": "boolean",
+      "description": "True if a changed file matched a fullBuildTriggers pattern, causing a full reactor build."
+    },
+    "triggerFile": {
+      "type": ["string", "null"],
+      "description": "The first changed file that matched a fullBuildTriggers pattern, or null if no full build was triggered."
+    },
+    "changedFiles": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Git-relative paths of all files changed between baseBranch and HEAD."
+    },
+    "changedProperties": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Names of Maven properties whose values changed in a POM diff."
+    },
+    "changedManagedDependencies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Coordinates (groupId:artifactId) of managed dependencies whose version changed in the root POM."
+    },
+    "changedManagedPlugins": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Coordinates (groupId:artifactId) of managed plugins whose version or configuration changed in the root POM."
+    },
+    "excludedUpstreamCount": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of upstream (build-prerequisite) modules excluded from affectedModules. These modules are built because of dependency ordering but are not genuinely affected by the changeset."
+    },
+    "affectedModules": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/affectedModule" },
+      "description": "Modules affected by the changeset, with reasons and optional metadata."
+    }
+  },
+  "$defs": {
+    "affectedModule": {
+      "type": "object",
+      "required": ["groupId", "artifactId", "path", "reasons"],
+      "additionalProperties": false,
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Maven groupId of the affected module."
+        },
+        "artifactId": {
+          "type": "string",
+          "description": "Maven artifactId of the affected module."
+        },
+        "path": {
+          "type": "string",
+          "description": "Reactor-relative path of the module directory."
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "SOURCE_CHANGE",
+              "TEST_CHANGE",
+              "POM_CHANGE",
+              "TRANSITIVE_DEPENDENCY",
+              "TRANSITIVE_DEPENDENCY_TEST",
+              "MANAGED_PLUGIN",
+              "UPSTREAM_DEPENDENCY",
+              "DOWNSTREAM_DEPENDENT",
+              "DOWNSTREAM_TEST",
+              "FORCE_BUILD",
+              "EXCLUDED_DOWNSTREAM"
+            ]
+          },
+          "minItems": 1,
+          "description": "Why this module is included in the affected set."
+        },
+        "category": {
+          "type": "string",
+          "enum": ["DIRECT", "UPSTREAM", "DOWNSTREAM", "TRANSITIVE"],
+          "description": "How this module relates to the change: directly changed, upstream prerequisite, downstream dependent, or transitively affected via managed dependencies/plugins."
+        },
+        "sourceSet": {
+          "type": "string",
+          "enum": ["main", "test"],
+          "description": "Which source set triggered the change. Present on directly affected modules with source changes."
+        },
+        "testsSkipped": {
+          "type": "boolean",
+          "const": true,
+          "description": "Present and true when tests are skipped for this module. The reason is given in testsSkippedReason."
+        },
+        "testsSkippedReason": {
+          "type": "string",
+          "description": "Why tests were skipped on this module (e.g. 'EXCLUDED_DOWNSTREAM' for downstream modules not in the test scope)."
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -9,10 +9,12 @@ package eu.maveniverse.maven.scalpel.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -120,7 +122,7 @@ class ScalpelReportTest {
                 .build();
 
         String json = report.toJson();
-        assertTrue(json.contains("\"version\": \"1\""));
+        assertTrue(json.contains("\"version\": \"2\""));
         assertTrue(json.contains("\"fullBuildTriggered\": false"));
         assertTrue(json.contains("\"affectedModules\": []"));
         assertTrue(json.contains("\"changedFiles\": []"));
@@ -383,5 +385,86 @@ class ScalpelReportTest {
 
         String json = report.toJson();
         assertTrue(json.contains("path/with\\\"quotes.java"));
+    }
+
+    // ---------------------------------------------------------------
+    // Golden-file and schema tests
+    // ---------------------------------------------------------------
+
+    @Test
+    void toJson_matchesGoldenFile() throws IOException {
+        // Build a report that exercises every v2 field:
+        // category, sourceSet, excludedUpstreamCount, testsSkipped, testsSkippedReason
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(
+                        List.of("module-a/src/main/java/Foo.java", "module-b/src/test/java/BarTest.java", "pom.xml"))
+                .changedProperties(List.of("kafka.version"))
+                .changedManagedDependencies(List.of("org.apache.kafka:kafka-clients"))
+                .changedManagedPlugins(List.of("org.apache.maven.plugins:maven-compiler-plugin"))
+                .excludedUpstreamCount(2)
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE))
+                        .category(ScalpelReport.CATEGORY_DIRECT)
+                        .sourceSet("main")
+                        .build())
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example", "module-b", "module-b", List.of(ScalpelReport.REASON_TEST_CHANGE))
+                        .category(ScalpelReport.CATEGORY_DIRECT)
+                        .sourceSet("test")
+                        .build())
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example",
+                                "module-c",
+                                "module-c",
+                                List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT))
+                        .category(ScalpelReport.CATEGORY_DOWNSTREAM)
+                        .sourceSet("main")
+                        .testsSkippedReason(ScalpelReport.REASON_EXCLUDED_DOWNSTREAM)
+                        .build())
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example",
+                                "module-d",
+                                "module-d",
+                                List.of(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY))
+                        .category(ScalpelReport.CATEGORY_TRANSITIVE)
+                        .build())
+                .build();
+
+        String actual = report.toJson();
+
+        // The golden file uses a placeholder for scalpelVersion since it changes with every release.
+        // Replace the actual version with the placeholder before comparing.
+        String normalised =
+                actual.replaceFirst("\"scalpelVersion\": \"[^\"]*\"", "\"scalpelVersion\": \"<scalpelVersion>\"");
+
+        String expected;
+        try (InputStream is =
+                getClass().getResourceAsStream("/eu/maveniverse/maven/scalpel/core/golden-report-v2.json")) {
+            assertNotNull(is, "golden-report-v2.json must be on the test classpath");
+            expected = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        assertEquals(
+                expected,
+                normalised,
+                "Report JSON structure has changed — update the golden file and "
+                        + "bump REPORT_VERSION if the schema changed.");
+    }
+
+    @Test
+    void reportVersion_isTwo() {
+        assertEquals("2", ScalpelReport.REPORT_VERSION);
+    }
+
+    @Test
+    void jsonSchema_isOnClasspath() throws IOException {
+        try (InputStream is =
+                getClass().getResourceAsStream("/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json")) {
+            assertNotNull(is, "scalpel-report-v2.schema.json must be on the classpath");
+            String schema = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertTrue(schema.contains("\"const\": \"2\""), "schema must declare version 2");
+        }
     }
 }

--- a/core/src/test/resources/eu/maveniverse/maven/scalpel/core/golden-report-v2.json
+++ b/core/src/test/resources/eu/maveniverse/maven/scalpel/core/golden-report-v2.json
@@ -1,0 +1,47 @@
+{
+  "version": "2",
+  "scalpelVersion": "<scalpelVersion>",
+  "baseBranch": "origin/main",
+  "fullBuildTriggered": false,
+  "triggerFile": null,
+  "changedFiles": ["module-a/src/main/java/Foo.java", "module-b/src/test/java/BarTest.java", "pom.xml"],
+  "changedProperties": ["kafka.version"],
+  "changedManagedDependencies": ["org.apache.kafka:kafka-clients"],
+  "changedManagedPlugins": ["org.apache.maven.plugins:maven-compiler-plugin"],
+  "excludedUpstreamCount": 2,
+  "affectedModules": [
+    {
+      "groupId": "com.example",
+      "artifactId": "module-a",
+      "path": "module-a",
+      "reasons": ["SOURCE_CHANGE"],
+      "category": "DIRECT",
+      "sourceSet": "main"
+    },
+    {
+      "groupId": "com.example",
+      "artifactId": "module-b",
+      "path": "module-b",
+      "reasons": ["TEST_CHANGE"],
+      "category": "DIRECT",
+      "sourceSet": "test"
+    },
+    {
+      "groupId": "com.example",
+      "artifactId": "module-c",
+      "path": "module-c",
+      "reasons": ["DOWNSTREAM_DEPENDENT"],
+      "category": "DOWNSTREAM",
+      "sourceSet": "main",
+      "testsSkipped": true,
+      "testsSkippedReason": "EXCLUDED_DOWNSTREAM"
+    },
+    {
+      "groupId": "com.example",
+      "artifactId": "module-d",
+      "path": "module-d",
+      "reasons": ["TRANSITIVE_DEPENDENCY"],
+      "category": "TRANSITIVE"
+    }
+  ]
+}

--- a/it/extension3-its/src/it/bom-import/verify.groovy
+++ b/it/extension3-its/src/it/bom-import/verify.groovy
@@ -38,7 +38,7 @@ assert reportFile.exists() : "Report file should have been created"
 String json = reportFile.text
 def report = new groovy.json.JsonSlurper().parseText(json)
 
-assert report.version == '1' : "Report should have version 1"
+assert report.version == '2' : "Report should have version 2"
 assert report.fullBuildTriggered == false : "fullBuildTriggered should be false"
 assert report.changedManagedDependencies.contains('commons-lang:commons-lang') : "changedManagedDependencies should contain commons-lang"
 

--- a/it/extension3-its/src/it/report-mode/verify.groovy
+++ b/it/extension3-its/src/it/report-mode/verify.groovy
@@ -24,7 +24,7 @@ File reportFile = new File(basedir, 'target/scalpel-report.json')
 assert reportFile.exists() : "Report file should have been created at target/scalpel-report.json"
 
 String json = reportFile.text
-assert json.contains('"version": "1"') : "Report should contain version field"
+assert json.contains('"version": "2"') : "Report should contain version field"
 assert json.contains('"fullBuildTriggered": false') : "fullBuildTriggered should be false"
 assert json.contains('"affectedModules"') : "Report should contain affectedModules"
 assert json.contains('"module-b"') : "module-b should appear in the report as affected"

--- a/it/extension3-its/src/it/report-transitive/verify.groovy
+++ b/it/extension3-its/src/it/report-transitive/verify.groovy
@@ -38,7 +38,7 @@ assert reportFile.exists() : "Report file should have been created"
 String json = reportFile.text
 def report = new groovy.json.JsonSlurper().parseText(json)
 
-assert report.version == '1' : "Report should have version 1"
+assert report.version == '2' : "Report should have version 2"
 assert report.fullBuildTriggered == false : "fullBuildTriggered should be false"
 assert report.changedManagedDependencies.contains('commons-lang:commons-lang') : "changedManagedDependencies should contain commons-lang"
 

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
@@ -24,7 +24,7 @@ File reportFile = new File(basedir, 'target/scalpel-report.json')
 assert reportFile.exists() : "Report file should have been created at target/scalpel-report.json"
 
 String json = reportFile.text
-assert json.contains('"version": "1"') : "Report should contain version field"
+assert json.contains('"version": "2"') : "Report should contain version field"
 assert json.contains('"fullBuildTriggered": false') : "fullBuildTriggered should be false"
 
 // module-a should be directly affected with SOURCE_CHANGE


### PR DESCRIPTION
## Summary

- Bump report schema version from `"1"` to `"2"` via a new `REPORT_VERSION` constant
- Publish a JSON Schema (`scalpel-report-v2.schema.json`) documenting all v2 fields: `category`, `sourceSet`, `excludedUpstreamCount`, `testsSkipped`, `testsSkippedReason`
- Add golden-file test that fails when the report structure changes without updating the reference file
- Update README: v2 example, schema version history table, compatibility policy, link to schema

## Context

Addresses item 7 from #50: the report schema version was frozen at `"1"` while several fields were added (`category` in #30, `sourceSet` in #16, `excludedUpstreamCount` in #39, `testsSkipped`/`testsSkippedReason` in #47). Consumers like Camel (which parse the report with `jq`) had no way to tell versions apart.

## Test plan

- [x] Existing tests updated (`"version": "1"` → `"version": "2"`)
- [x] New `toJson_matchesGoldenFile` test ensures structural changes require explicit golden-file update
- [x] New `reportVersion_isTwo` test pins the version constant
- [x] New `jsonSchema_isOnClasspath` test verifies the schema resource is bundled
- [x] All 84 tests pass (`mvn test -B` in core module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)