### PR TITLE
Fix #50 item 2: failSafe does not catch unchecked exceptions

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -180,7 +180,7 @@ public class ScalpelCore {
             return new ChangeDetectionResult(changedFiles, oldPomContents);
         } catch (ScalpelException e) {
             throw e;
-        } catch (IOException | JGitInternalException e) {
+        } catch (Exception e) {
             return handleError(config, "Error during change detection", e);
         } finally {
             repository.close();

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -330,4 +330,63 @@ class ScalpelCoreTest {
                     "Should throw ScalpelException when failSafe is disabled");
         }
     }
+
+    /**
+     * Detector that throws an unchecked IllegalArgumentException (simulates RevisionSyntaxException).
+     */
+    private static final GitChangeDetector UNCHECKED_THROWING_DETECTOR = new GitChangeDetector() {
+        @Override
+        public ObjectId findMergeBase(Repository repository, String baseBranch, String head) {
+            throw new IllegalArgumentException("Bad revision syntax: @{-99}");
+        }
+    };
+
+    @Test
+    void detectChanges_failSafe_catchesUncheckedExceptions() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(tempDir.resolve("new.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new.txt").call();
+            git.commit().setMessage("change").call();
+
+            ScalpelCore core = new ScalpelCore(UNCHECKED_THROWING_DETECTOR);
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.failSafe", "true");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
+
+            assertNull(result, "failSafe should return null (build all) on unchecked exception");
+        }
+    }
+
+    @Test
+    void detectChanges_failSafeDisabled_throwsOnUncheckedExceptions() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(tempDir.resolve("new.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new.txt").call();
+            git.commit().setMessage("change").call();
+
+            ScalpelCore core = new ScalpelCore(UNCHECKED_THROWING_DETECTOR);
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.failSafe", "false");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            assertThrows(
+                    ScalpelException.class,
+                    () -> core.detectChanges(tempDir, config, Set.of()),
+                    "Should throw ScalpelException when failSafe is disabled");
+        }
+    }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -79,8 +79,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
-        ScalpelConfiguration config =
-                ScalpelConfiguration.fromProperties(session.getSystemProperties(), session.getUserProperties());
+        ScalpelConfiguration config;
+        try {
+            config = ScalpelConfiguration.fromProperties(session.getSystemProperties(), session.getUserProperties());
+        } catch (Exception e) {
+            // Default for failSafe is true; if config parsing fails we cannot check the flag,
+            // so default to the safe behaviour: warn and let the build proceed normally.
+            logger.warn("Scalpel: Error parsing configuration, building all modules: {}", e.getMessage());
+            logger.debug("Configuration parsing error details", e);
+            return;
+        }
 
         String version = Version.version();
 
@@ -384,6 +392,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
         } catch (ScalpelException e) {
+            throw new MavenExecutionException("Scalpel: " + e.getMessage(), e);
+        } catch (Exception e) {
+            if (config.isFailSafe()) {
+                logger.warn("Scalpel: Unexpected error, building all modules: {}", e.getMessage());
+                logger.debug("Unexpected error details", e);
+                return;
+            }
             throw new MavenExecutionException("Scalpel: " + e.getMessage(), e);
         }
     }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.execution.ProjectDependencyGraph;
@@ -4115,5 +4117,110 @@ class ScalpelLifecycleParticipantTest {
         String moduleABlock = extractModuleBlock(json, "module-a");
         assertTrue(moduleABlock != null, "module-a should be in the report");
         assertFalse(moduleABlock.contains("\"testsSkipped\""), "module-a should NOT have testsSkipped (it's DIRECT)");
+    }
+
+    @Test
+    void afterProjectsRead_invalidMode_failSafeReturnsNormally() throws Exception {
+        // ScalpelConfiguration.fromProperties throws IllegalArgumentException for an invalid
+        // scalpel.mode. Since fromProperties is now inside a try block, the build should
+        // proceed normally (no exception) when the config fails to parse.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        MavenSession session = mock(MavenSession.class);
+        Properties sysProps = new Properties();
+        sysProps.setProperty("scalpel.mode", "bogus-invalid-mode");
+        sysProps.setProperty("scalpel.baseBranch", "base");
+        when(session.getSystemProperties()).thenReturn(sysProps);
+        when(session.getUserProperties()).thenReturn(new Properties());
+        when(session.getProjects()).thenReturn(allProjects);
+        MavenExecutionRequest execRequest = mock(MavenExecutionRequest.class);
+        when(execRequest.getMultiModuleProjectDirectory()).thenReturn(root.toFile());
+        when(session.getRequest()).thenReturn(execRequest);
+
+        // Should NOT throw — config parsing error is caught and logged
+        participant.afterProjectsRead(session);
+    }
+
+    @Test
+    void afterProjectsRead_invalidGlobPattern_failSafeReturnsNormally() throws Exception {
+        // An invalid glob pattern (e.g. "[unclosed") in excludePaths causes
+        // PatternSyntaxException. With failSafe=true (default), this should be caught
+        // and the build should proceed normally.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        // Invalid glob pattern — "[unclosed" is not a valid glob
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "[unclosed");
+
+        // Should NOT throw — PatternSyntaxException is caught by the failSafe handler
+        participant.afterProjectsRead(session);
+    }
+
+    @Test
+    void afterProjectsRead_invalidGlobPattern_failSafeDisabled_throws() throws Exception {
+        // With failSafe=false, an invalid glob pattern should propagate as MavenExecutionException.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        // Invalid glob pattern + failSafe disabled
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "[unclosed");
+        session.getSystemProperties().setProperty("scalpel.failSafe", "false");
+
+        // Should throw MavenExecutionException when failSafe is disabled
+        assertThrows(
+                MavenExecutionException.class,
+                () -> participant.afterProjectsRead(session),
+                "Should throw MavenExecutionException when failSafe is disabled and glob is invalid");
     }
 }


### PR DESCRIPTION
## Summary

- **ScalpelCore.detectChanges**: Widen `catch (IOException | JGitInternalException)` to `catch (Exception)` so that `RevisionSyntaxException` (from `Repository.resolve` with bad revspecs like `"  "` or `"@{-99}"`) and other unchecked exceptions are handled by the failSafe mechanism instead of hard-failing the build.
- **ScalpelLifecycleParticipant.afterProjectsRead**: Move `ScalpelConfiguration.fromProperties` inside a try-catch so that `IllegalArgumentException` from an invalid `scalpel.mode` or `scalpel.maxResourceFileSize` no longer escapes before any failSafe handling exists. Add `catch (Exception)` with failSafe handling for `PatternSyntaxException` from `getPathMatcher` with invalid glob patterns like `[unclosed`.

Addresses item 2 from #50.

## Test plan

- [x] New test: `ScalpelCoreTest.detectChanges_failSafe_catchesUncheckedExceptions` — verifies failSafe returns null on `IllegalArgumentException`
- [x] New test: `ScalpelCoreTest.detectChanges_failSafeDisabled_throwsOnUncheckedExceptions` — verifies exception propagates when failSafe=false
- [x] New test: `ScalpelLifecycleParticipantTest.afterProjectsRead_invalidMode_failSafeReturnsNormally` — verifies invalid `scalpel.mode` is caught (config parsing error)
- [x] New test: `ScalpelLifecycleParticipantTest.afterProjectsRead_invalidGlobPattern_failSafeReturnsNormally` — verifies `PatternSyntaxException` from bad exclude glob is caught
- [x] New test: `ScalpelLifecycleParticipantTest.afterProjectsRead_invalidGlobPattern_failSafeDisabled_throws` — verifies `MavenExecutionException` propagates when failSafe=false
- [x] All existing tests pass (`mvn verify`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)