### PR TITLE
Fix #50: auto-prefix bare glob patterns so they match nested files

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -405,7 +405,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private boolean matchesDisableTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
         for (String pattern : config.getDisableTriggers()) {
-            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern);
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
             for (String changedFile : changedFiles) {
                 if (matcher.matches(Paths.get(changedFile))) {
                     logger.info(
@@ -423,9 +423,26 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
         List<PathMatcher> matchers = new ArrayList<>(patterns.size());
         for (String pattern : patterns) {
-            matchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern));
+            matchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern)));
         }
         return matchers;
+    }
+
+    /**
+     * Normalizes a user-supplied glob pattern so that bare patterns (those containing no path
+     * separator) match files at any depth in the repository tree. For example, {@code *.md} is
+     * rewritten to {@code {*.md,**&#47;*.md}} so that it matches both {@code README.md} (root)
+     * and {@code docs/guide.md} (nested). A plain {@code **&#47;} prefix alone would not match
+     * root-level files on the default {@link java.nio.file.FileSystem} because the path separator
+     * in the pattern is required to be present in the matched path. Patterns that already contain
+     * a {@code /} are returned unchanged because the user explicitly specified the directory
+     * structure.
+     */
+    static String normalizeGlobPattern(String pattern) {
+        if (pattern.contains("/")) {
+            return pattern;
+        }
+        return "{" + pattern + ",**/" + pattern + "}";
     }
 
     private Set<String> filterExcludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
@@ -468,7 +485,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private String findFullBuildTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
         for (String pattern : config.getFullBuildTriggers()) {
-            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern);
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
             for (String changedFile : changedFiles) {
                 if (matcher.matches(Paths.get(changedFile))) {
                     logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -4223,4 +4223,64 @@ class ScalpelLifecycleParticipantTest {
                 () -> participant.afterProjectsRead(session),
                 "Should throw MavenExecutionException when failSafe is disabled and glob is invalid");
     }
+
+    @Test
+    void normalizeGlobPattern_barePatternIsPrefixed() {
+        assertEquals("{*.md,**/*.md}", ScalpelLifecycleParticipant.normalizeGlobPattern("*.md"));
+        assertEquals("{LICENSE,**/LICENSE}", ScalpelLifecycleParticipant.normalizeGlobPattern("LICENSE"));
+        assertEquals(
+                "{.editorconfig,**/.editorconfig}", ScalpelLifecycleParticipant.normalizeGlobPattern(".editorconfig"));
+    }
+
+    @Test
+    void normalizeGlobPattern_patternWithSlashIsUnchanged() {
+        assertEquals("docs/*.md", ScalpelLifecycleParticipant.normalizeGlobPattern("docs/*.md"));
+        assertEquals("**/*.md", ScalpelLifecycleParticipant.normalizeGlobPattern("**/*.md"));
+        assertEquals(".github/**", ScalpelLifecycleParticipant.normalizeGlobPattern(".github/**"));
+    }
+
+    @Test
+    void reportMode_bareExcludePathMatchesNestedFile() throws Exception {
+        // Verifies that a bare glob like *.md (no /) excludes nested files (e.g. docs/guide.md)
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        // module-a has a nested .md file changed, module-b has a source file changed
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/docs/guide.md");
+        changedFiles.add("module-b/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        // Use bare *.md pattern (no slash) — should match nested files after normalization
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "*.md");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(modulePresent(json, "module-b"), "module-b should be in report (source changed)");
+        assertFalse(
+                modulePresent(json, "module-a"),
+                "module-a should NOT be in report (nested .md excluded by bare *.md pattern)");
+    }
 }

--- a/it/extension3-its/src/it/exclude-paths-nested/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/exclude-paths-nested/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/exclude-paths-nested/invoker.properties
+++ b/it/extension3-its/src/it/exclude-paths-nested/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.excludePaths=*.md

--- a/it/extension3-its/src/it/exclude-paths-nested/module-a/pom.xml
+++ b/it/extension3-its/src/it/exclude-paths-nested/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.excludepathsnested</groupId>
+        <artifactId>exclude-paths-nested</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/exclude-paths-nested/module-b/pom.xml
+++ b/it/extension3-its/src/it/exclude-paths-nested/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.excludepathsnested</groupId>
+        <artifactId>exclude-paths-nested</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.excludepathsnested</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/exclude-paths-nested/module-c/pom.xml
+++ b/it/extension3-its/src/it/exclude-paths-nested/module-c/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.excludepathsnested</groupId>
+        <artifactId>exclude-paths-nested</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/exclude-paths-nested/pom.xml
+++ b/it/extension3-its/src/it/exclude-paths-nested/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.excludepathsnested</groupId>
+    <artifactId>exclude-paths-nested</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/exclude-paths-nested/setup.groovy
+++ b/it/extension3-its/src/it/exclude-paths-nested/setup.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, then add a nested .md file (excluded) and a source file in module-b
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Add a nested .md file inside module-a/docs (should be excluded by bare *.md pattern)
+new File(dir, 'module-a/docs').mkdirs()
+new File(dir, 'module-a/docs/guide.md').text = '# Guide'
+// Add a source file in module-b (should NOT be excluded)
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add nested doc and source to module-b')

--- a/it/extension3-its/src/it/exclude-paths-nested/verify.groovy
+++ b/it/extension3-its/src/it/exclude-paths-nested/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated
+assert log.contains('Scalpel')
+
+// The nested .md file (module-a/docs/guide.md) should have been excluded by the bare *.md pattern
+assert log.contains('excluded by path filters') : "Expected files to be excluded by path filters"
+
+// module-b was changed (source) -> it should be the only directly affected module
+assert log.contains('1 modules directly affected') : "Expected exactly 1 module directly affected"
+
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine != null : "Expected 'directly affected' log line"
+assert directlyAffectedLine.contains('module-b') : "module-b should be directly affected (source changed)"
+
+// module-c has no relationship to module-b -> should NOT be in the build set
+def buildingLine = log.readLines().find { it.contains('Building') && it.contains('of 4 modules') }
+assert buildingLine != null : "Expected 'Building X of 4 modules' log line"
+assert buildingLine.contains('module-b') : "module-b should be in the build set"
+assert !buildingLine.contains('module-c') : "module-c should NOT be in the build set"


### PR DESCRIPTION
## Summary

- Auto-prefix bare glob patterns (those containing no `/`) with `{pattern,**/pattern}` so they match files at any depth in the tree, not just at the repository root.
- Applied normalization to all three glob compilation sites: `compileGlobMatchers` (excludePaths, includePaths), `matchesDisableTrigger`, and `findFullBuildTrigger`.
- Added unit tests for `normalizeGlobPattern` and a new `exclude-paths-nested` integration test verifying that `*.md` excludes `module-a/docs/guide.md`.

Fixes item 1 of #50.

## Details

Java's `PathMatcher` treats bare globs like `*.md` as single-segment matchers — they match `README.md` at root but not `docs/guide.md`. Users writing `excludePaths=*.md` expect all `.md` files to be excluded regardless of depth.

A simple `**/` prefix would break root-level matching (Java's `glob:**/*.md` requires at least one path separator), so the fix uses the alternation syntax `{*.md,**/*.md}` to match both root and nested files. Patterns already containing a `/` (e.g., `docs/*.md`, `.github/**`) are left unchanged.

## Test plan

- [x] Unit tests for `normalizeGlobPattern` (bare vs. slash-containing patterns)
- [x] Unit test `reportMode_bareExcludePathMatchesNestedFile` verifying nested `.md` exclusion
- [x] Integration test `exclude-paths-nested` — bare `*.md` excludes `module-a/docs/guide.md`
- [x] All 138 existing unit tests continue to pass (including the existing `exclude-paths` tests)
- [x] Full Maven build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)