### PR TITLE
Fix #50 item 6: add JaCoCo coverage gate

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,8 +37,7 @@ jobs:
         SONAR_PR_BASE: ${{ github.base_ref }}
       run: >-
         ./mvnw --no-transfer-progress
-        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report
-        org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         -Dsonar.projectKey=maveniverse_scalpel
         -Dsonar.organization=maveniverse
         -Dsonar.host.url=https://sonarcloud.io
@@ -53,8 +52,7 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: >-
         ./mvnw --no-transfer-progress
-        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report
-        org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         -Dsonar.projectKey=maveniverse_scalpel
         -Dsonar.organization=maveniverse
         -Dsonar.host.url=https://sonarcloud.io

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -22,6 +22,10 @@
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Scalpel Maven extension for smart reactor trimming.</description>
 
+  <properties>
+    <jacoco.skip>true</jacoco.skip>
+  </properties>
+
   <dependencies>
     <!-- Scalpel -->
     <dependency>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -29,6 +29,7 @@
 
   <properties>
     <enforcer.skip>true</enforcer.skip>
+    <jacoco.skip>true</jacoco.skip>
     <maven.install.skip>true</maven.install.skip>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <maven3ResolverVersion>1.9.27</maven3ResolverVersion>
 
     <version.slf4j>1.7.36</version.slf4j>
+    <version.jacoco>0.8.13</version.jacoco>
   </properties>
 
   <dependencyManagement>
@@ -161,6 +162,11 @@
             </additionalOptions>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${version.jacoco}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -175,6 +181,44 @@
               <goal>main-index</goal>
               <goal>test-index</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>jacoco-prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>jacoco-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.50</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Summary

Addresses item 6 from #50: *"There is no coverage gate."*

- **Added JaCoCo Maven plugin (0.8.13)** to `pom.xml` with `prepare-agent`, `report`, and `check` goals, pinning the version instead of relying on unpinned CLI invocations
- **Coverage threshold:** 50% line coverage per bundle — both `core` (83%) and `extension3` (91%) already exceed this comfortably; the floor catches catastrophic regressions while giving room to tighten later
- **Skipped modules:** `extension` (no test sources) and `it` (integration-test harness) set `jacoco.skip=true`
- **Simplified `sonarcloud.yml`:** removed the inline `org.jacoco:jacoco-maven-plugin:prepare-agent` and `org.jacoco:jacoco-maven-plugin:report` CLI invocations — coverage now runs as part of the normal `verify` lifecycle, so `./mvnw verify` produces coverage locally too

## Test plan

- [x] `./mvnw clean verify` passes with JaCoCo check enforced
- [x] JaCoCo reports generated for `core` and `extension3`
- [x] JaCoCo correctly skipped for `extension` and `it` modules
- [x] `spotless:check` passes (no formatting issues)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)