### PR TITLE
Fix #50: optimize POM blob reads and merge resolve caches

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -9,9 +9,11 @@ package eu.maveniverse.maven.scalpel.core;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Named;
@@ -22,14 +24,17 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.lib.FileMode;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
+import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.filter.PathFilterGroup;
 import org.eclipse.jgit.util.io.NullOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,13 +187,36 @@ public class GitChangeDetector {
         }
     }
 
+    /**
+     * Reads multiple files at the given commit in a single TreeWalk pass.
+     * Uses a PathFilterGroup so the TreeWalk only visits matching entries,
+     * and shares a single ObjectReader/RevWalk across all reads.
+     */
     public Map<String, byte[]> readPomFilesAtCommit(Repository repository, ObjectId commitId, Set<String> paths)
             throws IOException {
+        if (paths.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        // PathFilterGroup requires a non-empty collection of path strings
+        List<String> pathList = new ArrayList<>(paths);
         Map<String, byte[]> result = new HashMap<>();
-        for (String path : paths) {
-            byte[] content = readFileAtCommit(repository, commitId, path);
-            if (content != null) {
-                result.put(path, content);
+        try (ObjectReader reader = repository.newObjectReader();
+                RevWalk revWalk = new RevWalk(reader)) {
+            RevCommit commit = revWalk.parseCommit(commitId);
+            try (TreeWalk treeWalk = new TreeWalk(reader)) {
+                treeWalk.addTree(commit.getTree());
+                treeWalk.setRecursive(true);
+                treeWalk.setFilter(PathFilterGroup.createFromStrings(pathList));
+                while (treeWalk.next()) {
+                    if (treeWalk.getFileMode(0) == FileMode.REGULAR_FILE
+                            || treeWalk.getFileMode(0) == FileMode.EXECUTABLE_FILE) {
+                        String path = treeWalk.getPathString();
+                        ObjectLoader loader = reader.open(treeWalk.getObjectId(0));
+                        ByteArrayOutputStream out = new ByteArrayOutputStream();
+                        loader.copyTo(out);
+                        result.put(path, out.toByteArray());
+                    }
+                }
             }
         }
         return result;

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -173,9 +173,16 @@ public class ScalpelCore {
                 return new ChangeDetectionResult(changedFiles, Collections.<String, byte[]>emptyMap());
             }
 
-            // Read old POM files for comparison
+            // Read old POM files for comparison — only read the ones that actually changed,
+            // not every reactor POM. The PomChangeAnalyzer only needs old content for changed POMs.
+            Set<String> changedPomPaths = new LinkedHashSet<>();
+            for (String path : changedFiles) {
+                if (allPomPaths.contains(path)) {
+                    changedPomPaths.add(path);
+                }
+            }
             Map<String, byte[]> oldPomContents =
-                    gitChangeDetector.readPomFilesAtCommit(repository, mergeBase, allPomPaths);
+                    gitChangeDetector.readPomFilesAtCommit(repository, mergeBase, changedPomPaths);
 
             return new ChangeDetectionResult(changedFiles, oldPomContents);
         } catch (ScalpelException e) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -26,6 +26,7 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -45,6 +46,8 @@ import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -260,9 +263,19 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         "Scalpel: {} modules directly affected: {}", directlyAffected.size(), keys(directlyAffected));
             }
 
+            // Single shared cache for dependency collection results — used by both
+            // computeTransitivelyAffected and applySkipTests to avoid resolving the same
+            // module twice.
+            Map<MavenProject, DependencyResolutionResult> collectCache = new LinkedHashMap<>();
+
             // Compute transitively affected modules (via changed managed deps/plugins)
             Map<MavenProject, List<String>> transitivelyAffected = computeTransitivelyAffected(
-                    allProjects, directlyAffected, changedManagedDepGAs, changedManagedPluginGAs, session);
+                    allProjects,
+                    directlyAffected,
+                    changedManagedDepGAs,
+                    changedManagedPluginGAs,
+                    session,
+                    collectCache);
 
             if (directlyAffected.isEmpty() && transitivelyAffected.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
@@ -363,7 +376,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         changedManagedDepGAs,
                         changedManagedPluginGAs,
                         includeMatchers,
-                        reactorRoot);
+                        reactorRoot,
+                        collectCache);
             } else {
                 // trim mode: remove unaffected projects from reactor
                 List<MavenProject> buildSet = trimResult.getBuildSet();
@@ -469,7 +483,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<MavenProject> directlyAffected,
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs,
-            MavenSession session) {
+            MavenSession session,
+            Map<MavenProject, DependencyResolutionResult> collectCache) {
         Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
         if (changedManagedDepGAs.isEmpty() && changedManagedPluginGAs.isEmpty()) {
             logger.debug("Skipping transitive analysis: no changed managed dependencies or plugins to check against");
@@ -480,13 +495,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 allProjects.size() - directlyAffected.size(),
                 changedManagedDepGAs.size(),
                 changedManagedPluginGAs.size());
-        Map<MavenProject, DependencyResolutionResult> resolveCache = new LinkedHashMap<>();
         for (MavenProject project : allProjects) {
             if (directlyAffected.contains(project)) {
                 continue;
             }
             List<String> reasons = computeTransitiveReasons(
-                    project, changedManagedDepGAs, changedManagedPluginGAs, session, resolveCache);
+                    project, changedManagedDepGAs, changedManagedPluginGAs, session, collectCache);
             if (!reasons.isEmpty()) {
                 transitivelyAffected.put(project, reasons);
             }
@@ -505,13 +519,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs,
             MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> resolveCache) {
+            Map<MavenProject, DependencyResolutionResult> collectCache) {
         List<String> reasons = new ArrayList<>();
         if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
             reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
         }
         if (!changedManagedDepGAs.isEmpty()) {
-            String depScope = getChangedTransitiveDependencyScope(project, session, changedManagedDepGAs, resolveCache);
+            String depScope = getChangedTransitiveDependencyScope(project, session, changedManagedDepGAs, collectCache);
             if (depScope != null) {
                 if ("test".equals(depScope)) {
                     reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
@@ -531,12 +545,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs,
             List<PathMatcher> includeMatchers,
-            Path reactorRoot) {
+            Path reactorRoot,
+            Map<MavenProject, DependencyResolutionResult> collectCache) {
 
         Set<MavenProject> buildSetLookup = new LinkedHashSet<>(trimResult.getBuildSet());
         List<MavenProject> testProjects = new ArrayList<>();
         List<MavenProject> skippedProjects = new ArrayList<>();
-        Map<MavenProject, DependencyResolutionResult> resolveCache = new LinkedHashMap<>();
 
         // Directly affected modules always run tests
         for (MavenProject project : trimResult.getBuildSet()) {
@@ -554,7 +568,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     session,
                     changedManagedPluginGAs,
                     changedManagedDepGAs,
-                    resolveCache)) {
+                    collectCache)) {
                 // Skip tests on excluded downstream modules (unless they also have plugin/dep changes)
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
@@ -588,7 +602,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Check transitive dependencies if managed deps changed
             if (!changedManagedDepGAs.isEmpty()
-                    && hasChangedTransitiveDependency(project, session, changedManagedDepGAs, resolveCache)) {
+                    && hasChangedTransitiveDependency(project, session, changedManagedDepGAs, collectCache)) {
                 testProjects.add(project);
                 continue;
             }
@@ -702,7 +716,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             MavenSession session,
             Set<String> changedManagedPluginGAs,
             Set<String> changedManagedDepGAs,
-            Map<MavenProject, DependencyResolutionResult> resolveCache) {
+            Map<MavenProject, DependencyResolutionResult> collectCache) {
         if (config.getSkipTestsForDownstreamModules().isEmpty()) {
             return false;
         }
@@ -718,53 +732,95 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             return false;
         }
         return changedManagedDepGAs.isEmpty()
-                || !hasChangedTransitiveDependency(project, session, changedManagedDepGAs, resolveCache);
+                || !hasChangedTransitiveDependency(project, session, changedManagedDepGAs, collectCache);
     }
 
     private boolean hasChangedTransitiveDependency(
             MavenProject project,
             MavenSession session,
             Set<String> changedGAs,
-            Map<MavenProject, DependencyResolutionResult> resolveCache) {
-        return getChangedTransitiveDependencyScope(project, session, changedGAs, resolveCache) != null;
+            Map<MavenProject, DependencyResolutionResult> collectCache) {
+        return getChangedTransitiveDependencyScope(project, session, changedGAs, collectCache) != null;
     }
+
+    /**
+     * A DependencyFilter that rejects all nodes, preventing artifact downloads
+     * while still allowing the dependency graph to be collected.
+     */
+    private static final DependencyFilter COLLECT_ONLY_FILTER = new DependencyFilter() {
+        @Override
+        public boolean accept(DependencyNode node, List<DependencyNode> parents) {
+            return false;
+        }
+    };
 
     /**
      * Returns the effective scope of the changed transitive dependency, or null if no match.
      * If any matching dependency has compile/runtime/provided scope, returns that scope.
      * If all matching dependencies are test-scoped, returns "test".
+     * <p>
+     * Uses a reject-all DependencyFilter so that only the dependency graph is collected
+     * without downloading any artifact files — we only need GA coordinates and scopes.
      */
     private String getChangedTransitiveDependencyScope(
             MavenProject project,
             MavenSession session,
             Set<String> changedGAs,
-            Map<MavenProject, DependencyResolutionResult> resolveCache) {
-        DependencyResolutionResult result = resolveCache.get(project);
+            Map<MavenProject, DependencyResolutionResult> collectCache) {
+        DependencyResolutionResult result = collectCache.get(project);
         if (result == null) {
             try {
                 DefaultDependencyResolutionRequest request =
                         new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
+                // Reject-all filter: collects the dependency graph without downloading artifacts
+                request.setResolutionFilter(COLLECT_ONLY_FILTER);
                 result = dependenciesResolver.resolve(request);
             } catch (DependencyResolutionException e) {
                 result = e.getResult();
                 if (result == null) {
                     logger.debug(
-                            "Cannot resolve dependencies for {}, no partial results available: {}",
+                            "Cannot collect dependencies for {}, no partial results available: {}",
                             key(project),
                             e.getMessage());
                     return null;
                 }
                 logger.debug(
-                        "Partial dependency resolution for {}, checking available results: {}",
+                        "Partial dependency collection for {}, checking available results: {}",
                         key(project),
                         e.getMessage());
             }
-            resolveCache.put(project, result);
+            collectCache.put(project, result);
         }
 
+        // Walk the dependency graph tree to find matching GAs and their scopes.
+        // The reject-all filter means getResolvedDependencies() is empty, but
+        // getDependencyGraph() still contains the full collected tree.
+        DependencyNode root = result.getDependencyGraph();
+        if (root == null) {
+            return null;
+        }
+        return findChangedDependencyScope(root, changedGAs, project);
+    }
+
+    /**
+     * Walks the dependency graph tree to find any dependency matching the changed GAs,
+     * returning the narrowest non-test scope found (or "test" if only test-scoped matches).
+     */
+    private String findChangedDependencyScope(DependencyNode root, Set<String> changedGAs, MavenProject project) {
         String narrowestScope = null;
-        for (Dependency dep : result.getResolvedDependencies()) {
+        Set<String> visited = new HashSet<>();
+        List<DependencyNode> stack = new ArrayList<>();
+        stack.addAll(root.getChildren());
+        while (!stack.isEmpty()) {
+            DependencyNode node = stack.remove(stack.size() - 1);
+            Dependency dep = node.getDependency();
+            if (dep == null) {
+                continue;
+            }
             String ga = dep.getArtifact().getGroupId() + ":" + dep.getArtifact().getArtifactId();
+            if (!visited.add(ga)) {
+                continue; // already visited this GA
+            }
             if (changedGAs.contains(ga)) {
                 String scope = dep.getScope();
                 logger.debug(
@@ -777,6 +833,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 }
                 narrowestScope = "test";
             }
+            stack.addAll(node.getChildren());
         }
         return narrowestScope;
     }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -47,6 +47,8 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.DependencyNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -210,16 +212,16 @@ class ScalpelLifecycleParticipantTest {
                     String aid = req.getMavenProject().getArtifactId();
                     if ("module-b".equals(aid) || "module-d".equals(aid)) {
                         DependencyResolutionResult res = mock(DependencyResolutionResult.class);
-                        when(res.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
+                        when(res.getDependencyGraph()).thenReturn(createDependencyGraph(commonsLangDep));
                         return res;
                     }
                     if ("module-e".equals(aid)) {
                         DependencyResolutionResult partial = mock(DependencyResolutionResult.class);
-                        when(partial.getResolvedDependencies()).thenReturn(List.of());
+                        when(partial.getDependencyGraph()).thenReturn(createDependencyGraph());
                         throw new DependencyResolutionException(partial, "Cannot resolve", new Exception());
                     }
                     DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
-                    when(empty.getResolvedDependencies()).thenReturn(List.of());
+                    when(empty.getDependencyGraph()).thenReturn(createDependencyGraph());
                     return empty;
                 });
 
@@ -378,7 +380,7 @@ class ScalpelLifecycleParticipantTest {
 
         // No transitive deps to resolve
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
 
@@ -514,7 +516,7 @@ class ScalpelLifecycleParticipantTest {
 
         // No transitive deps to resolve for this test
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
 
@@ -612,7 +614,7 @@ class ScalpelLifecycleParticipantTest {
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
 
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
 
@@ -738,7 +740,7 @@ class ScalpelLifecycleParticipantTest {
         DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
         org.eclipse.aether.graph.Dependency testDep = new org.eclipse.aether.graph.Dependency(
                 new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "test");
-        when(moduleBResolution.getResolvedDependencies()).thenReturn(List.of(testDep));
+        when(moduleBResolution.getDependencyGraph()).thenReturn(createDependencyGraph(testDep));
 
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenAnswer(invocation -> {
@@ -747,7 +749,7 @@ class ScalpelLifecycleParticipantTest {
                         return moduleBResolution;
                     }
                     DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
-                    when(empty.getResolvedDependencies()).thenReturn(List.of());
+                    when(empty.getDependencyGraph()).thenReturn(createDependencyGraph());
                     return empty;
                 });
 
@@ -850,7 +852,7 @@ class ScalpelLifecycleParticipantTest {
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
 
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
 
@@ -1387,11 +1389,11 @@ class ScalpelLifecycleParticipantTest {
         DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
         org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
                 new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
-        when(moduleBResolution.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
+        when(moduleBResolution.getDependencyGraph()).thenReturn(createDependencyGraph(commonsLangDep));
 
         // Other modules: no matching deps
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
 
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenAnswer(invocation -> {
@@ -1771,9 +1773,9 @@ class ScalpelLifecycleParticipantTest {
         DependencyResolutionResult moduleBResolution = mock(DependencyResolutionResult.class);
         org.eclipse.aether.graph.Dependency commonsLangDep = new org.eclipse.aether.graph.Dependency(
                 new DefaultArtifact("commons-lang", "commons-lang", "jar", "2.0"), "compile");
-        when(moduleBResolution.getResolvedDependencies()).thenReturn(List.of(commonsLangDep));
+        when(moduleBResolution.getDependencyGraph()).thenReturn(createDependencyGraph(commonsLangDep));
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenAnswer(invocation -> {
                     DefaultDependencyResolutionRequest req = invocation.getArgument(0);
@@ -2229,7 +2231,7 @@ class ScalpelLifecycleParticipantTest {
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
 
@@ -3087,9 +3089,23 @@ class ScalpelLifecycleParticipantTest {
 
     private void setupEmptyDependencyResolution() throws Exception {
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
-        when(emptyResolution.getResolvedDependencies()).thenReturn(List.of());
+        when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
+    }
+
+    /**
+     * Creates a mock dependency graph root node with the given dependencies as direct children.
+     * Each dependency becomes a leaf child node of the root.
+     */
+    private static DependencyNode createDependencyGraph(org.eclipse.aether.graph.Dependency... deps) {
+        DefaultDependencyNode root = new DefaultDependencyNode((org.eclipse.aether.graph.Dependency) null);
+        List<DependencyNode> children = new ArrayList<>();
+        for (org.eclipse.aether.graph.Dependency dep : deps) {
+            children.add(new DefaultDependencyNode(dep));
+        }
+        root.setChildren(children);
+        return root;
     }
 
     private MavenSession createSimpleSession(Path root, List<MavenProject> allProjects, String mode) {
@@ -3361,11 +3377,11 @@ class ScalpelLifecycleParticipantTest {
                     DefaultDependencyResolutionRequest req = invocation.getArgument(0);
                     if ("module-a".equals(req.getMavenProject().getArtifactId())) {
                         DependencyResolutionResult res = mock(DependencyResolutionResult.class);
-                        when(res.getResolvedDependencies()).thenReturn(List.of(graphqlDep));
+                        when(res.getDependencyGraph()).thenReturn(createDependencyGraph(graphqlDep));
                         return res;
                     }
                     DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
-                    when(empty.getResolvedDependencies()).thenReturn(List.of());
+                    when(empty.getDependencyGraph()).thenReturn(createDependencyGraph());
                     return empty;
                 });
 


### PR DESCRIPTION
## Summary
- **Item 8**: Replace per-path `RevWalk`+`TreeWalk` with a single `TreeWalk` using `PathFilterGroup` for batch POM file reads. Share one `ObjectReader` across all reads. Only read changed POM files instead of all reactor POMs.
- **Item 9**: Merge duplicate resolve caches in `computeTransitivelyAffected` and `applySkipTests` into a shared `collectCache`. Use a reject-all `DependencyFilter` so only the dependency graph is collected without downloading artifacts. Walk `getDependencyGraph()` tree instead of `getResolvedDependencies()` flat list.

## Test plan
- [x] All 135 extension3 tests pass (53 ScalpelLifecycleParticipant tests)
- [x] All 81 core tests pass (10 ScalpelCore tests including POM content read test)
- [x] Tests updated to mock `getDependencyGraph()` with `DefaultDependencyNode` trees instead of `getResolvedDependencies()` flat lists
- [ ] CI build passes

Closes #50 (items 8 and 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)