### PR TITLE
ci: fix SonarCloud plugin resolution failure

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,7 +37,8 @@ jobs:
         SONAR_PR_BASE: ${{ github.base_ref }}
       run: >-
         ./mvnw --no-transfer-progress
-        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
+        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report
+        org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         -Dsonar.projectKey=maveniverse_scalpel
         -Dsonar.organization=maveniverse
         -Dsonar.host.url=https://sonarcloud.io
@@ -52,7 +53,8 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: >-
         ./mvnw --no-transfer-progress
-        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
+        org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report
+        org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         -Dsonar.projectKey=maveniverse_scalpel
         -Dsonar.organization=maveniverse
         -Dsonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
## CI Fix

**Failed run:** https://github.com/maveniverse/scalpel/actions/runs/31224196362

### Root Cause

The SonarCloud workflow uses the shorthand `sonar:sonar` Maven goal, but the `sonar-maven-plugin` is not declared in the project POM or any parent POM plugin group. Maven cannot resolve the `sonar` prefix, causing every SonarCloud run to fail with:

```
[ERROR] No plugin found for prefix 'sonar' in the current project and in the plugin groups
[com.diffplug.spotless, org.gaul, org.eclipse.sisu, com.mycila, eu.maveniverse.maven.plugins,
org.apache.maven.plugins, org.codehaus.mojo] available from the repositories [...]
```

This has been broken since the workflow was first introduced (commit da7b1a0).

### Fix Applied

Replace `sonar:sonar` with the fully-qualified plugin coordinates `org.sonarsource.scanner.maven:sonar-maven-plugin:sonar` in both the PR and push analysis steps. This allows Maven to resolve the plugin directly without needing a POM declaration or pluginGroup entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated code-quality analysis for pull requests and code updates.
  * Standardized analysis execution across validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->