### PR TITLE
chore: broaden fetchBranch catch to align with failSafe pattern

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -23,7 +23,6 @@ import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
@@ -112,7 +111,7 @@ public class ScalpelCore {
                 if (baseId == null) {
                     try {
                         gitChangeDetector.fetchBranch(repository, baseBranch);
-                    } catch (IOException | JGitInternalException e) {
+                    } catch (Exception e) {
                         if (config.isFailSafe()) {
                             logger.warn(
                                     "Scalpel: Failed to fetch {}, building all modules: {}",

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -389,4 +389,60 @@ class ScalpelCoreTest {
                     "Should throw ScalpelException when failSafe is disabled");
         }
     }
+
+    /**
+     * Detector whose fetchBranch throws a RuntimeException, used to exercise
+     * the inner fetch-branch catch block in detectChanges (the catch around
+     * gitChangeDetector.fetchBranch()).
+     */
+    private static final GitChangeDetector FETCH_THROWING_DETECTOR = new GitChangeDetector() {
+        @Override
+        public void fetchBranch(Repository repository, String baseBranch) {
+            throw new RuntimeException("Simulated transport failure");
+        }
+    };
+
+    @Test
+    void detectChanges_fetchBranchFailure_failSafe_returnsNull() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+
+            // Use "origin/main" as baseBranch so repository.resolve() returns null,
+            // triggering the fetchBranch path. fetchBaseBranch=true enables fetching.
+            ScalpelCore core = new ScalpelCore(FETCH_THROWING_DETECTOR);
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "origin/main");
+            sys.setProperty("scalpel.fetchBaseBranch", "true");
+            sys.setProperty("scalpel.failSafe", "true");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
+
+            assertNull(result, "failSafe should return null when fetchBranch throws");
+        }
+    }
+
+    @Test
+    void detectChanges_fetchBranchFailure_failSafeDisabled_throwsScalpelException() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+
+            ScalpelCore core = new ScalpelCore(FETCH_THROWING_DETECTOR);
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "origin/main");
+            sys.setProperty("scalpel.fetchBaseBranch", "true");
+            sys.setProperty("scalpel.failSafe", "false");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ScalpelException ex = assertThrows(
+                    ScalpelException.class,
+                    () -> core.detectChanges(tempDir, config, Set.of()),
+                    "Should throw ScalpelException when fetchBranch fails and failSafe is disabled");
+            assertTrue(ex.getMessage().contains("origin/main"), "Exception message should reference the base branch");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Broadens the inner `fetchBranch` catch block in `ScalpelCore.detectChanges()` from `IOException | JGitInternalException` to `Exception`, aligning it with the outer catch block that was already broadened in PR #54
- Removes the now-unused `JGitInternalException` import

This ensures that unexpected runtime exceptions (e.g., NPE from corrupted git state) during fetch are handled by the inner handler's specific "Failed to fetch" log message, rather than falling through to the outer generic handler.

Found during review of PR #54 (failSafe exception handling).

## Test plan

- [x] Full build passes (`./mvnw clean install -B`)
- [x] No other usages of `JGitInternalException` in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected errors while fetching the base branch.
  * Fail-safe mode now continues gracefully when fetching fails, while standard mode reports a clear error referencing the base branch.

* **Tests**
  * Added coverage for base-branch fetch failures in both fail-safe and standard modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->