### PR TITLE
chore: align report schema with forward-compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ consumers may need to handle.
 | `DOWNSTREAM_DEPENDENT` | Included as a downstream dependent (via `alsoMakeDependents`) |
 | `DOWNSTREAM_TEST` | Included as a downstream dependent via test-scoped dependency only |
 | `FORCE_BUILD` | This module was force-included via `forceBuildModules` |
-| `EXCLUDED_DOWNSTREAM` | Downstream module whose tests were skipped (see `testsSkippedReason`) |
 
 **Affected module source sets** (present on directly affected modules with source changes):
 

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -17,7 +17,6 @@
     "excludedUpstreamCount",
     "affectedModules"
   ],
-  "additionalProperties": false,
   "properties": {
     "version": {
       "type": "string",
@@ -75,7 +74,6 @@
     "affectedModule": {
       "type": "object",
       "required": ["groupId", "artifactId", "path", "reasons"],
-      "additionalProperties": false,
       "properties": {
         "groupId": {
           "type": "string",
@@ -103,8 +101,7 @@
               "UPSTREAM_DEPENDENCY",
               "DOWNSTREAM_DEPENDENT",
               "DOWNSTREAM_TEST",
-              "FORCE_BUILD",
-              "EXCLUDED_DOWNSTREAM"
+              "FORCE_BUILD"
             ]
           },
           "minItems": 1,


### PR DESCRIPTION
## Summary

Fixes two issues found during review of PR #53 (report schema v2):

- **Remove `additionalProperties: false`** from both the root object and the `affectedModule` definition. The README (lines 167-169) states that new optional fields may be added within a major version and consumers should ignore unknown fields. Setting `additionalProperties: false` contradicts this — any future optional field would break validators without a schema version bump.

- **Remove `EXCLUDED_DOWNSTREAM` from the `reasons` enum.** This value is never used as a module-inclusion reason in the codebase. It is only assigned to `testsSkippedReason` (see `ScalpelLifecycleParticipant.java`). Including it in the `reasons` enum is misleading. The `testsSkippedReason` field description still references `EXCLUDED_DOWNSTREAM`, which is correct.

## Test plan

- [x] Full `./mvnw clean install -B` passes with no test failures

---

Review finding from PR #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)