### PR TITLE
Fix #50 item 5: add Maven 4 CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
     uses: maveniverse/parent/.github/workflows/ci.yml@release-55
     with:
       maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'
-      maven-matrix: '[ "3.9.16" ]'
+      maven-matrix: '[ "3.9.16", "4.0.0-rc-6" ]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Verify
-    uses: maveniverse/parent/.github/workflows/ci.yml@release-55
+    uses: maveniverse/parent/.github/workflows/ci.yml@release-59
     with:
       maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'
       maven-matrix: '[ "3.9.16", "4.0.0-rc-6" ]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
     uses: maveniverse/parent/.github/workflows/ci.yml@release-59
     with:
       maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'
-      maven-matrix: '[ "3.9.16", "4.0.0-rc-6" ]'
+      maven-matrix: '[ "3.9.16" ]'

--- a/it/extension4-its/pom.xml
+++ b/it/extension4-its/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>eu.maveniverse.maven.scalpel.it</groupId>
+    <artifactId>it</artifactId>
+    <version>${nisse.jgit.dynamicVersion}</version>
+  </parent>
+
+  <artifactId>extension4-its</artifactId>
+  <packaging>pom</packaging>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>eu.maveniverse.maven.scalpel</groupId>
+      <artifactId>extension3</artifactId>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>run-its</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-maven-distro</id>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <phase>generate-test-resources</phase>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.apache.maven</groupId>
+                      <artifactId>apache-maven</artifactId>
+                      <version>${maven4Version}</version>
+                      <classifier>bin</classifier>
+                      <type>zip</type>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <configuration>
+              <mavenHome>${project.build.directory}/dependency/apache-maven-${maven4Version}</mavenHome>
+              <projectsDirectory>${project.basedir}/../extension3-its/src/it</projectsDirectory>
+              <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+              <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+              <cloneClean>true</cloneClean>
+              <pomIncludes>
+                <pomInclude>*/pom.xml</pomInclude>
+              </pomIncludes>
+              <preBuildHookScript>setup</preBuildHookScript>
+              <postBuildHookScript>verify</postBuildHookScript>
+              <addTestClassPath>false</addTestClassPath>
+              <extraArtifacts>
+                <extraArtifact>eu.maveniverse.maven.scalpel:scalpel:${project.version}:pom</extraArtifact>
+              </extraArtifacts>
+            </configuration>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>run-its</id>
+                <goals>
+                  <goal>install</goal>
+                  <goal>run</goal>
+                </goals>
+                <phase>integration-test</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/it/extension4-its/pom.xml
+++ b/it/extension4-its/pom.xml
@@ -30,6 +30,17 @@
   </dependencies>
 
   <profiles>
+    <!-- Maven 4 requires JDK 17+; skip these ITs on older JDKs -->
+    <profile>
+      <id>jdk-lt-17</id>
+      <activation>
+        <jdk>(,17)</jdk>
+      </activation>
+      <properties>
+        <invoker.skip>true</invoker.skip>
+        <mdep.skip>true</mdep.skip>
+      </properties>
+    </profile>
     <profile>
       <id>run-its</id>
       <build>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -25,6 +25,7 @@
 
   <modules>
     <module>extension3-its</module>
+    <module>extension4-its</module>
   </modules>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,9 @@
     <maven3Version>3.9.16</maven3Version>
     <maven3ResolverVersion>1.9.27</maven3ResolverVersion>
 
+    <!-- Maven 4 versions -->
+    <maven4Version>4.0.0-rc-6</maven4Version>
+
     <version.slf4j>1.7.36</version.slf4j>
     <version.jacoco>0.8.13</version.jacoco>
   </properties>


### PR DESCRIPTION
## Summary

Addresses [#50 item 5](https://github.com/maveniverse/scalpel/issues/50) — Maven 4 is never exercised in CI.

- **`extension4-its` module**: new IT module that runs all 24 existing invoker ITs against a Maven 4 distribution (`4.0.0-rc-6`). Shares test projects from `extension3-its` via `projectsDirectory` — no duplication. Auto-skips on JDK < 17 (Maven 4 requires JDK 17+).
- **`maven4Version` property**: added to root POM for the Maven 4 distribution version.
- **Workflow bump**: `release-55` → `release-59` for correct matrix excludes.

### Why Maven 4 is NOT in the CI matrix

Maven 4 cannot be used as the **outer** build tool for this project because Maven 4's stricter POM model validation rejects `${nisse.jgit.dynamicVersion}` in the `<version>` element (reports `'version' must not contain any of these characters \/:"<>|?*`). This is a Nisse compatibility limitation, not a Scalpel issue.

Maven 4 coverage is achieved through the `extension4-its` invoker module instead, which runs Scalpel **inside** a Maven 4 distribution as a sub-build — this is what actually matters for users.

### What was intentionally skipped

The optional `MavenXpp3Reader` → `MavenStaxReader` migration (`PomChangeAnalyzer.java` line 212) was left out: `MavenStaxReader` doesn't exist in Maven 3.9.x, and the current deprecated-but-functional code works on both versions. A cross-version strategy would add unnecessary complexity.

## Test plan

- [x] `./mvnw clean verify -P run-its` — all 48 ITs pass (24 Maven 3 + 24 Maven 4)
- [x] `./mvnw spotless:check` — formatting clean
- [x] CI passes on all JDK/OS matrix legs

🤖 Generated with [Claude Code](https://claude.com/claude-code)