### PR TITLE
chore: use nisse 0.9.5 with .mvn/nisse.properties for source-archive builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-.mvn/maven-user.properties export-subst

--- a/.mvn/maven-user.properties
+++ b/.mvn/maven-user.properties
@@ -1,3 +1,0 @@
-# Fallback values for source archives (expanded by git archive via export-subst)
-nisse.jgit.dynamicVersion=$Format:%(describe:tags=true)$
-nisse.jgit.date=$Format:%cI$


### PR DESCRIPTION
## Summary

Replaces the `maven-user.properties` approach from #51 with nisse's new
`.mvn/nisse.properties` low-priority fallback (maveniverse/nisse#182, shipped
in nisse 0.9.5).

**Changes:**
- Upgrade nisse extension from 0.9.2 → 0.9.5
- Replace `.mvn/maven-user.properties` with `.mvn/nisse.properties` + `export-subst`
- Remove the Maven 4-only `maven-user.properties` file

**Why:** `.mvn/maven-user.properties` is a Maven 4-only feature. Scalpel supports
Maven 3.9+ (`requireRuntimeMavenVersion.range=[3.9,)`), so the previous approach
silently broke source-archive builds on Maven 3. Nisse 0.9.5 reads
`.mvn/nisse.properties` directly — independent of Maven version.

## Verified locally

- ✅ Git checkout build: `./mvnw clean install -B -DskipTests` → BUILD SUCCESS (version from JGit)
- ✅ Source archive build: `git archive | tar -x && cd archive && ./mvnw clean install` → BUILD SUCCESS (version from `nisse.properties` fallback)