### PR TITLE
fix: stop mapping repo-root files to the root aggregator module

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -60,7 +60,7 @@ class ModuleMapper {
         for (String changedFile : changedFiles) {
             for (MavenProject project : sortedProjects) {
                 String projectPath = getRelativePath(project, reactorRoot);
-                if (projectPath.isEmpty() ? changedFile.contains("/") : changedFile.startsWith(projectPath + "/")) {
+                if (isFileInProjectSubtree(changedFile, projectPath)) {
                     boolean isTest = isTestPath(changedFile, projectPath);
                     Boolean existing = hasMainChange.get(project);
                     if (existing == null) {
@@ -98,6 +98,15 @@ class ModuleMapper {
             relativeToProject = changedFile.substring(projectPath.length() + 1);
         }
         return relativeToProject.startsWith("src/test/");
+    }
+
+    private static boolean isFileInProjectSubtree(String changedFile, String projectPath) {
+        if (projectPath.isEmpty()) {
+            // Root project: only match files in subdirectories (src/main/...),
+            // not bare repo-root files (README.md, .gitignore)
+            return changedFile.contains("/");
+        }
+        return changedFile.startsWith(projectPath + "/");
     }
 
     private String getRelativePath(MavenProject project, Path reactorRoot) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -60,7 +60,7 @@ class ModuleMapper {
         for (String changedFile : changedFiles) {
             for (MavenProject project : sortedProjects) {
                 String projectPath = getRelativePath(project, reactorRoot);
-                if (projectPath.isEmpty() || changedFile.startsWith(projectPath + "/")) {
+                if (projectPath.isEmpty() ? changedFile.contains("/") : changedFile.startsWith(projectPath + "/")) {
                     boolean isTest = isTestPath(changedFile, projectPath);
                     Boolean existing = hasMainChange.get(project);
                     if (existing == null) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperTest.java
@@ -135,6 +135,38 @@ class ModuleMapperTest {
         assertTrue(result.getTestOnlyAffected().isEmpty());
     }
 
+    @Test
+    void mapToProjectsClassified_repoRootFileDoesNotMapToRootAggregator() {
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        // Files at the repository root (README.md, .gitignore) are not part of
+        // any module's source tree and should not trigger a rebuild of the root
+        // aggregator.  The old catch-all (projectPath.isEmpty()) matched them.
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("README.md", ".gitignore"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertTrue(result.getAllAffected().isEmpty(), "repo-root files should not map to any module");
+    }
+
+    @Test
+    void mapToProjectsClassified_rootProjectSourceStillMaps() {
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        // Files within the root project's own source tree (src/main/java/...)
+        // should still map to the root project.
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("src/main/java/com/example/App.java"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(
+                result.getMainAffected().contains(projects.get(0)),
+                "src/ files at root should map to the root project");
+    }
+
     private List<MavenProject> createProjects(Path root) {
         MavenProject parent =
                 createProject("com.example", "parent", root.resolve("pom.xml").toFile());


### PR DESCRIPTION
Repo-root files (README.md, .gitignore, LICENSE) currently map to the root aggregator module, so touching them marks the root POM affected and pulls the whole reactor into the build. A repo-root file is not a change to any module.

Extracts an `isFileInProjectSubtree` helper and uses it so only files inside a module's subtree map to that module. Repo-root files now match no module and fall through to the existing unmatched handling.

TDD: the first commit adds the failing test against current behavior, the second the fix. Rebased on current main (incl. the path-separator normalization, which touches the same class); `ModuleMapperTest` is 11/11 green on the rebased code.

Pure extension3-internal change (ModuleMapper + its test), no interaction with the currently open PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project change detection so repository-root files, such as `README.md` and `.gitignore`, no longer incorrectly affect the root project.
  * Files within the root project’s source tree continue to be recognized correctly.
  * Nested project matching remains accurate.

* **Tests**
  * Added coverage for repository-root files and root project source changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->