### PR TITLE
fix: validate scalpel config strictly and warn on unknown keys

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -300,7 +300,7 @@ public final class ScalpelConfiguration {
         Set<String> seen = new HashSet<>();
         collectUnknownScalpelKeys(system, seen, warnings);
         collectUnknownScalpelKeys(user, seen, warnings);
-        return warnings.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(warnings);
+        return warnings.isEmpty() ? List.of() : Collections.unmodifiableList(warnings);
     }
 
     private static void collectUnknownScalpelKeys(Properties props, Set<String> seen, List<String> warnings) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -8,9 +8,12 @@
 package eu.maveniverse.maven.scalpel.core;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 public final class ScalpelConfiguration {
 
@@ -57,6 +60,34 @@ public final class ScalpelConfiguration {
     private static final String DEFAULT_REPORT_FILE = "target/scalpel-report.json";
     public static final long DEFAULT_MAX_RESOURCE_FILE_SIZE = 10L * 1024 * 1024; // 10 MB
 
+    private static final Set<String> KNOWN_KEYS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            ENABLED,
+            BASE_BRANCH,
+            HEAD,
+            ALSO_MAKE,
+            ALSO_MAKE_DEPENDENTS,
+            FULL_BUILD_TRIGGERS,
+            FAIL_SAFE,
+            MODE,
+            DISABLE_ON_BRANCH,
+            DISABLE_ON_BASE_BRANCH,
+            EXCLUDE_PATHS,
+            INCLUDE_PATHS,
+            DISABLE_TRIGGERS,
+            DISABLE_ON_SELECTED_PROJECTS,
+            SKIP_TESTS_FOR_UPSTREAM,
+            SKIP_TESTS_FOR_DOWNSTREAM_MODULES,
+            UPSTREAM_ARGS,
+            DOWNSTREAM_ARGS,
+            FETCH_BASE_BRANCH,
+            UNCOMMITTED,
+            UNTRACKED,
+            FORCE_BUILD_MODULES,
+            BUILD_ALL_IF_NO_CHANGES,
+            IMPACTED_LOG,
+            REPORT_FILE,
+            MAX_RESOURCE_FILE_SIZE)));
+
     private final boolean enabled;
     private final String baseBranch;
     private final String head;
@@ -83,6 +114,7 @@ public final class ScalpelConfiguration {
     private final String mode;
     private final String reportFile;
     private final long maxResourceFileSize;
+    private final List<String> warnings;
 
     private ScalpelConfiguration(
             boolean enabled,
@@ -110,7 +142,8 @@ public final class ScalpelConfiguration {
             boolean failSafe,
             String mode,
             String reportFile,
-            long maxResourceFileSize) {
+            long maxResourceFileSize,
+            List<String> warnings) {
         this.enabled = enabled;
         this.baseBranch = baseBranch;
         this.head = head;
@@ -137,17 +170,19 @@ public final class ScalpelConfiguration {
         this.mode = mode;
         this.reportFile = reportFile;
         this.maxResourceFileSize = maxResourceFileSize;
+        this.warnings = warnings;
     }
 
     public static ScalpelConfiguration fromProperties(Properties system, Properties user) {
-        boolean enabled = Boolean.parseBoolean(resolve(system, user, ENABLED, "true"));
+        boolean enabled = parseStrictBoolean(ENABLED, resolve(system, user, ENABLED, "true"));
         String baseBranch = resolve(system, user, BASE_BRANCH, null);
         if (baseBranch == null) {
             baseBranch = detectBaseBranch(system);
         }
         String head = resolve(system, user, HEAD, "HEAD");
-        boolean alsoMake = Boolean.parseBoolean(resolve(system, user, ALSO_MAKE, "true"));
-        boolean alsoMakeDependents = Boolean.parseBoolean(resolve(system, user, ALSO_MAKE_DEPENDENTS, "true"));
+        boolean alsoMake = parseStrictBoolean(ALSO_MAKE, resolve(system, user, ALSO_MAKE, "true"));
+        boolean alsoMakeDependents =
+                parseStrictBoolean(ALSO_MAKE_DEPENDENTS, resolve(system, user, ALSO_MAKE_DEPENDENTS, "true"));
         String triggers = resolve(system, user, FULL_BUILD_TRIGGERS, DEFAULT_FULL_BUILD_TRIGGERS);
         List<String> fullBuildTriggers = parseList(triggers);
         List<String> disableOnBranch = parseList(resolve(system, user, DISABLE_ON_BRANCH, null));
@@ -155,20 +190,23 @@ public final class ScalpelConfiguration {
         List<String> excludePaths = parseList(resolve(system, user, EXCLUDE_PATHS, null));
         List<String> includePaths = parseList(resolve(system, user, INCLUDE_PATHS, null));
         List<String> disableTriggers = parseList(resolve(system, user, DISABLE_TRIGGERS, null));
-        boolean disableOnSelectedProjects =
-                Boolean.parseBoolean(resolve(system, user, DISABLE_ON_SELECTED_PROJECTS, "false"));
-        boolean fetchBaseBranch = Boolean.parseBoolean(resolve(system, user, FETCH_BASE_BRANCH, "false"));
-        boolean skipTestsForUpstream = Boolean.parseBoolean(resolve(system, user, SKIP_TESTS_FOR_UPSTREAM, "false"));
+        boolean disableOnSelectedProjects = parseStrictBoolean(
+                DISABLE_ON_SELECTED_PROJECTS, resolve(system, user, DISABLE_ON_SELECTED_PROJECTS, "false"));
+        boolean fetchBaseBranch =
+                parseStrictBoolean(FETCH_BASE_BRANCH, resolve(system, user, FETCH_BASE_BRANCH, "false"));
+        boolean skipTestsForUpstream =
+                parseStrictBoolean(SKIP_TESTS_FOR_UPSTREAM, resolve(system, user, SKIP_TESTS_FOR_UPSTREAM, "false"));
         List<String> skipTestsForDownstreamModules =
                 parseList(resolve(system, user, SKIP_TESTS_FOR_DOWNSTREAM_MODULES, null));
         List<String> upstreamArgs = parseList(resolve(system, user, UPSTREAM_ARGS, null));
         List<String> downstreamArgs = parseList(resolve(system, user, DOWNSTREAM_ARGS, null));
-        boolean uncommitted = Boolean.parseBoolean(resolve(system, user, UNCOMMITTED, "false"));
-        boolean untracked = Boolean.parseBoolean(resolve(system, user, UNTRACKED, "false"));
+        boolean uncommitted = parseStrictBoolean(UNCOMMITTED, resolve(system, user, UNCOMMITTED, "false"));
+        boolean untracked = parseStrictBoolean(UNTRACKED, resolve(system, user, UNTRACKED, "false"));
         List<String> forceBuildModules = parseList(resolve(system, user, FORCE_BUILD_MODULES, null));
-        boolean buildAllIfNoChanges = Boolean.parseBoolean(resolve(system, user, BUILD_ALL_IF_NO_CHANGES, "false"));
+        boolean buildAllIfNoChanges =
+                parseStrictBoolean(BUILD_ALL_IF_NO_CHANGES, resolve(system, user, BUILD_ALL_IF_NO_CHANGES, "false"));
         String impactedLog = resolve(system, user, IMPACTED_LOG, null);
-        boolean failSafe = Boolean.parseBoolean(resolve(system, user, FAIL_SAFE, "true"));
+        boolean failSafe = parseStrictBoolean(FAIL_SAFE, resolve(system, user, FAIL_SAFE, "true"));
         String mode = resolve(system, user, MODE, MODE_TRIM);
         if (!MODE_TRIM.equals(mode) && !MODE_SKIP_TESTS.equals(mode) && !MODE_REPORT.equals(mode)) {
             throw new IllegalArgumentException("Invalid scalpel.mode '" + mode + "', expected one of: " + MODE_TRIM
@@ -189,6 +227,8 @@ public final class ScalpelConfiguration {
                         + "', must be a positive integer (bytes)");
             }
         }
+
+        List<String> warnings = detectUnknownKeys(system, user);
 
         return new ScalpelConfiguration(
                 enabled,
@@ -216,17 +256,18 @@ public final class ScalpelConfiguration {
                 failSafe,
                 mode,
                 reportFile,
-                maxResourceFileSize);
+                maxResourceFileSize,
+                warnings);
     }
 
     private static String resolve(Properties system, Properties user, String key, String defaultValue) {
         String value = system.getProperty(key);
         if (value != null) {
-            return value;
+            return value.trim();
         }
         value = user.getProperty(key);
         if (value != null) {
-            return value;
+            return value.trim();
         }
         return defaultValue;
     }
@@ -241,6 +282,77 @@ public final class ScalpelConfiguration {
             result.add(part.trim());
         }
         return Collections.unmodifiableList(result);
+    }
+
+    private static boolean parseStrictBoolean(String key, String value) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        throw new IllegalArgumentException(
+                "Invalid boolean value '" + value + "' for " + key + ". Expected 'true' or 'false'.");
+    }
+
+    private static List<String> detectUnknownKeys(Properties system, Properties user) {
+        List<String> warnings = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        collectUnknownScalpelKeys(system, seen, warnings);
+        collectUnknownScalpelKeys(user, seen, warnings);
+        return warnings.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(warnings);
+    }
+
+    private static void collectUnknownScalpelKeys(Properties props, Set<String> seen, List<String> warnings) {
+        for (String key : props.stringPropertyNames()) {
+            if (key.startsWith(PREFIX) && !KNOWN_KEYS.contains(key) && seen.add(key)) {
+                String closest = findClosestKey(key);
+                if (closest != null) {
+                    warnings.add("Unknown configuration key '" + key + "'. Did you mean '" + closest + "'?");
+                } else {
+                    warnings.add("Unknown configuration key '" + key + "'.");
+                }
+            }
+        }
+    }
+
+    private static String findClosestKey(String unknown) {
+        String best = null;
+        int bestDist = Integer.MAX_VALUE;
+        for (String known : KNOWN_KEYS) {
+            int dist = editDistance(unknown, known);
+            if (dist < bestDist) {
+                bestDist = dist;
+                best = known;
+            }
+        }
+        // Only suggest if the edit distance is at most half the key length.
+        // This filters out completely unrelated keys.
+        if (best != null && bestDist <= Math.max(unknown.length(), best.length()) / 2) {
+            return best;
+        }
+        return null;
+    }
+
+    static int editDistance(String a, String b) {
+        int lenA = a.length();
+        int lenB = b.length();
+        int[] prev = new int[lenB + 1];
+        int[] curr = new int[lenB + 1];
+        for (int j = 0; j <= lenB; j++) {
+            prev[j] = j;
+        }
+        for (int i = 1; i <= lenA; i++) {
+            curr[0] = i;
+            for (int j = 1; j <= lenB; j++) {
+                int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+                curr[j] = Math.min(Math.min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+            }
+            int[] tmp = prev;
+            prev = curr;
+            curr = tmp;
+        }
+        return prev[lenB];
     }
 
     private static String detectBaseBranch(Properties system) {
@@ -376,6 +488,10 @@ public final class ScalpelConfiguration {
 
     public long getMaxResourceFileSize() {
         return maxResourceFileSize;
+    }
+
+    public List<String> getWarnings() {
+        return warnings;
     }
 
     @Override

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -326,9 +326,12 @@ public final class ScalpelConfiguration {
                 best = known;
             }
         }
-        // Only suggest if the edit distance is at most half the key length.
-        // This filters out completely unrelated keys.
-        if (best != null && bestDist <= Math.max(unknown.length(), best.length()) / 2) {
+        // Only suggest if the edit distance is at most half the suffix length
+        // (after stripping the shared "scalpel." prefix). Without this adjustment,
+        // the 8-char shared prefix inflates the threshold and causes unrelated keys
+        // like "scalpel.foobar" to incorrectly suggest "scalpel.head".
+        int suffixLen = Math.max(unknown.length(), best.length()) - PREFIX.length();
+        if (best != null && bestDist <= suffixLen / 2) {
             return best;
         }
         return null;
@@ -523,6 +526,7 @@ public final class ScalpelConfiguration {
                 + ", failSafe=" + failSafe
                 + ", reportFile='" + reportFile + '\''
                 + ", maxResourceFileSize=" + maxResourceFileSize
+                + ", warnings=" + warnings
                 + '}';
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -330,8 +330,11 @@ public final class ScalpelConfiguration {
         // (after stripping the shared "scalpel." prefix). Without this adjustment,
         // the 8-char shared prefix inflates the threshold and causes unrelated keys
         // like "scalpel.foobar" to incorrectly suggest "scalpel.head".
+        if (best == null) {
+            return null;
+        }
         int suffixLen = Math.max(unknown.length(), best.length()) - PREFIX.length();
-        if (best != null && bestDist <= suffixLen / 2) {
+        if (bestDist <= suffixLen / 2) {
             return best;
         }
         return null;

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ScalpelConfigurationTest {
 
@@ -451,5 +452,136 @@ class ScalpelConfigurationTest {
         assertEquals("main", list.get(0));
         assertEquals("release/.*", list.get(1));
         assertEquals("hotfix", list.get(2));
+    }
+
+    // ---------------------------------------------------------------
+    // AC#1: Strict boolean validation
+    // ---------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"yes", "1", "on", "Yes", "TRUE!", "tru", "fals"})
+    void invalidBooleanValue_throwsException(String badValue) {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.enabled", badValue);
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, new Properties()));
+        assertTrue(ex.getMessage().contains("scalpel.enabled"), "message should mention the key");
+        assertTrue(ex.getMessage().contains(badValue), "message should mention the bad value");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"true, true", "false, false", "TRUE, true", "FALSE, false", "True, true", "False, false"})
+    void validBooleanValues_accepted(String input, boolean expected) {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.enabled", input);
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertEquals(expected, config.isEnabled());
+    }
+
+    @Test
+    void invalidBooleanOnFailSafe_throwsWithKeyName() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.failSafe", "1");
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> ScalpelConfiguration.fromProperties(sys, new Properties()));
+        assertTrue(ex.getMessage().contains("scalpel.failSafe"));
+    }
+
+    // ---------------------------------------------------------------
+    // AC#2: Value trimming at the source
+    // ---------------------------------------------------------------
+
+    @Test
+    void stringValue_trailingWhitespace_isTrimmed() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.baseBranch", "origin/main ");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertEquals("origin/main", config.getBaseBranch());
+    }
+
+    @Test
+    void stringValue_leadingWhitespace_isTrimmed() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.head", " HEAD");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertEquals("HEAD", config.getHead());
+    }
+
+    @Test
+    void booleanValue_surroundingWhitespace_isTrimmed() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.enabled", " true ");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertTrue(config.isEnabled());
+    }
+
+    // ---------------------------------------------------------------
+    // AC#3: Unknown scalpel key detection
+    // ---------------------------------------------------------------
+
+    @Test
+    void unknownKey_wrongCase_producesWarning() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.basebranch", "origin/main");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        List<String> warnings = config.getWarnings();
+        assertFalse(warnings.isEmpty(), "should have at least one warning");
+        assertTrue(
+                warnings.stream().anyMatch(w -> w.contains("scalpel.basebranch")),
+                "warning should mention the unknown key");
+        assertTrue(
+                warnings.stream().anyMatch(w -> w.contains("scalpel.baseBranch")),
+                "warning should suggest the correct key");
+    }
+
+    @Test
+    void unknownKey_missingSuffix_producesWarning() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.excludePath", "*.md");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        List<String> warnings = config.getWarnings();
+        assertFalse(warnings.isEmpty());
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("scalpel.excludePath")));
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("scalpel.excludePaths")));
+    }
+
+    @Test
+    void unknownKey_completelyWrong_producesWarning() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.foobar", "x");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        List<String> warnings = config.getWarnings();
+        assertFalse(warnings.isEmpty());
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("scalpel.foobar")));
+    }
+
+    @Test
+    void unknownKey_inUserProperties_producesWarning() {
+        Properties user = new Properties();
+        user.setProperty("scalpel.enbaled", "true");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(new Properties(), user);
+        List<String> warnings = config.getWarnings();
+        assertFalse(warnings.isEmpty());
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("scalpel.enbaled")));
+        assertTrue(warnings.stream().anyMatch(w -> w.contains("scalpel.enabled")));
+    }
+
+    @Test
+    void knownKeys_noWarnings() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.enabled", "true");
+        sys.setProperty("scalpel.baseBranch", "origin/main");
+        sys.setProperty("scalpel.mode", "trim");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertTrue(config.getWarnings().isEmpty(), "known keys should not produce warnings");
+    }
+
+    @Test
+    void nonScalpelKeys_noWarnings() {
+        Properties sys = new Properties();
+        sys.setProperty("maven.compiler.source", "17");
+        sys.setProperty("project.build.sourceEncoding", "UTF-8");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertTrue(config.getWarnings().isEmpty(), "non-scalpel keys should be ignored");
     }
 }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -553,6 +553,9 @@ class ScalpelConfigurationTest {
         List<String> warnings = config.getWarnings();
         assertFalse(warnings.isEmpty());
         assertTrue(warnings.stream().anyMatch(w -> w.contains("scalpel.foobar")));
+        assertTrue(
+                warnings.stream().noneMatch(w -> w.contains("Did you mean")),
+                "completely wrong key should not produce a suggestion");
     }
 
     @Test

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -91,6 +91,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             return;
         }
 
+        for (String warning : config.getWarnings()) {
+            logger.warn("Scalpel: {}", warning);
+        }
+
         String version = Version.version();
 
         if (!config.isEnabled()) {


### PR DESCRIPTION
`fromProperties` currently accepts anything: typos in property names (`scalpel.incluedPaths=...`) are silent no-ops, values are never trimmed, and `Boolean.parseBoolean` means `scalpel.enabled=yes` or `=1` silently *disables* the extension.

This adds eager validation in `ScalpelConfiguration`:
- strict boolean parsing (only `true`/`false`, after trimming) with a clear error naming the property;
- value trimming;
- unknown `scalpel.*` key detection with a closest-match suggestion (e.g. `incluedPaths` -> `includePaths`);
- a warnings list surfaced by `ScalpelLifecycleParticipant` right after parsing.

On invalid values `fromProperties` throws `IllegalArgumentException`, which lands in the existing catch in `afterProjectsRead` (warn + build all), so the fail-safe posture you merged for config parsing is unchanged. This was noted as adjacent to #50 item 2 in my follow-up comment there.

Rebase note: one conflict against the config catch block was resolved by keeping the merged catch semantics verbatim and grafting only the warnings loop; the stricter per-value failSafe handling from the original branch was dropped in favour of the current upstream behaviour. Verified: `ScalpelConfigurationTest` 74/74 and `ScalpelLifecycleParticipantTest` 59/59 green on the rebased code.

TDD: first commit is the failing test against current behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration values now ignore surrounding whitespace and validate boolean settings consistently.
  * Unknown `scalpel.*` properties are reported with deduplicated warnings and helpful suggestions where applicable.
  * Configuration warnings are displayed during project startup.

* **Bug Fixes**
  * Invalid boolean and safety settings now produce clear, key-specific error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->