### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to enable automated dependency update PRs
- Configured for **Maven** dependencies (weekly, up to 10 open PRs)
- Configured for **GitHub Actions** workflows (weekly, up to 5 open PRs)

## Test plan
- [ ] Verify Dependabot starts picking up the config after merge (check the Insights → Dependency graph → Dependabot tab)
- [ ] Confirm first batch of update PRs arrives within a week

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for Maven packages and GitHub Actions.
  * Limited automated update pull requests to help manage review volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->