### PR TITLE
Bump maven.compiler.release from 8 to 17 [breaking]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,5 @@ jobs:
     uses: maveniverse/parent/.github/workflows/ci.yml@release-55
     with:
       maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'
+      jdk-matrix: '[ "17", "21", "25" ]'
       maven-matrix: '[ "3.9.16" ]'

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -193,7 +193,7 @@ public class GitChangeDetector {
     public Map<String, byte[]> readPomFilesAtCommit(Repository repository, ObjectId commitId, Set<String> paths)
             throws IOException {
         if (paths.isEmpty()) {
-            return Collections.emptyMap();
+            return Map.of();
         }
         // PathFilterGroup requires a non-empty collection of path strings
         List<String> pathList = new ArrayList<>(paths);

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -233,7 +233,7 @@ public final class ScalpelConfiguration {
 
     private static List<String> parseList(String value) {
         if (value == null || value.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
         String[] parts = value.split(",");
         List<String> result = new ArrayList<>(parts.length);

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -170,7 +168,7 @@ public class ScalpelCore {
 
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: No changes detected between {} and {}", baseBranch, head);
-                return new ChangeDetectionResult(changedFiles, Collections.<String, byte[]>emptyMap());
+                return new ChangeDetectionResult(changedFiles, Map.of());
             }
 
             // Read old POM files for comparison — only read the ones that actually changed,
@@ -278,7 +276,7 @@ public class ScalpelCore {
 
     private static Path resolvePathFromFile(Path file, Path baseDir) throws IOException {
         String value = new String(Files.readAllBytes(file), StandardCharsets.UTF_8).trim();
-        Path path = Paths.get(value);
+        Path path = Path.of(value);
         if (!path.isAbsolute()) {
             path = baseDir.resolve(value);
         }

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -291,7 +291,7 @@ public final class ScalpelReport {
                     break;
                 default:
                     if (c < 0x20) {
-                        sb.append(String.format("\\u%04x", (int) c));
+                        sb.append("\\u%04x".formatted((int) c));
                     } else {
                         sb.append(c);
                     }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
@@ -162,7 +161,7 @@ class ScalpelCoreTest {
     void detectChanges_notAGitRepo_returnsNull() throws Exception {
         // Create a temp directory outside the project tree to avoid JGit walking up
         // and discovering the project's own .git (java.io.tmpdir may be inside the repo)
-        Path nonGitDir = Files.createTempDirectory(Paths.get("/tmp"), "scalpel-test-no-git");
+        Path nonGitDir = Files.createTempDirectory(Path.of("/tmp"), "scalpel-test-no-git");
         try {
             ScalpelCore core = new ScalpelCore(new GitChangeDetector());
             Properties sys = new Properties();

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
@@ -7,7 +7,6 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,13 +70,12 @@ final class AnalysisContext {
         private Set<String> changedProperties;
         private Set<String> changedManagedDepGAs;
         private Set<String> changedManagedPluginGAs;
-        private Set<MavenProject> directlyAffected = Collections.<MavenProject>emptySet();
-        private Set<MavenProject> affectedBySource = Collections.<MavenProject>emptySet();
-        private Set<MavenProject> testOnlyBySource = Collections.<MavenProject>emptySet();
-        private Set<MavenProject> affectedByPom = Collections.<MavenProject>emptySet();
-        private Set<MavenProject> forceIncluded = Collections.<MavenProject>emptySet();
-        private Map<MavenProject, List<String>> transitivelyAffected =
-                Collections.<MavenProject, List<String>>emptyMap();
+        private Set<MavenProject> directlyAffected = Set.of();
+        private Set<MavenProject> affectedBySource = Set.of();
+        private Set<MavenProject> testOnlyBySource = Set.of();
+        private Set<MavenProject> affectedByPom = Set.of();
+        private Set<MavenProject> forceIncluded = Set.of();
+        private Map<MavenProject, List<String>> transitivelyAffected = Map.of();
         private TrimResult trimResult;
 
         private Builder() {}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -17,9 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -460,20 +458,16 @@ class PomChangeAnalyzer {
                 logger.debug("Active profile {} was {}", profileId, oldProfile == null ? "added" : "removed");
                 if (newProfile != null) {
                     changedProperties.addAll(diffProperties(null, newProfile.getProperties()));
-                    changedManagedDeps.addAll(diffDependencies(
-                            Collections.<Dependency>emptyList(), getProfileManagedDependencies(newProfile)));
-                    changedManagedPlugins.addAll(
-                            diffPlugins(Collections.<Plugin>emptyList(), getProfileManagedPlugins(newProfile)));
+                    changedManagedDeps.addAll(diffDependencies(List.of(), getProfileManagedDependencies(newProfile)));
+                    changedManagedPlugins.addAll(diffPlugins(List.of(), getProfileManagedPlugins(newProfile)));
                     if (!newProfile.getDependencies().isEmpty()
                             || !getProfilePlugins(newProfile).isEmpty()) {
                         selfAffected = true;
                     }
                 } else {
                     changedProperties.addAll(diffProperties(oldProfile.getProperties(), null));
-                    changedManagedDeps.addAll(diffDependencies(
-                            getProfileManagedDependencies(oldProfile), Collections.<Dependency>emptyList()));
-                    changedManagedPlugins.addAll(
-                            diffPlugins(getProfileManagedPlugins(oldProfile), Collections.<Plugin>emptyList()));
+                    changedManagedDeps.addAll(diffDependencies(getProfileManagedDependencies(oldProfile), List.of()));
+                    changedManagedPlugins.addAll(diffPlugins(getProfileManagedPlugins(oldProfile), List.of()));
                     if (!oldProfile.getDependencies().isEmpty()
                             || !getProfilePlugins(oldProfile).isEmpty()) {
                         selfAffected = true;
@@ -775,14 +769,14 @@ class PomChangeAnalyzer {
         if (model.getBuild() != null && model.getBuild().getResources() != null) {
             return model.getBuild().getResources();
         }
-        return Collections.<Resource>emptyList();
+        return List.of();
     }
 
     private List<Resource> getTestResourcesList(Model model) {
         if (model.getBuild() != null && model.getBuild().getTestResources() != null) {
             return model.getBuild().getTestResources();
         }
-        return Collections.<Resource>emptyList();
+        return List.of();
     }
 
     private boolean equalResourceLists(List<Resource> a, List<Resource> b) {
@@ -857,12 +851,12 @@ class PomChangeAnalyzer {
 
     private List<Repository> safeRepositories(Model model) {
         List<Repository> repos = model.getRepositories();
-        return repos != null ? repos : Collections.<Repository>emptyList();
+        return repos != null ? repos : List.of();
     }
 
     private List<Repository> safePluginRepositories(Model model) {
         List<Repository> repos = model.getPluginRepositories();
-        return repos != null ? repos : Collections.<Repository>emptyList();
+        return repos != null ? repos : List.of();
     }
 
     private List<Plugin> getPlugins(Model model) {
@@ -891,7 +885,7 @@ class PomChangeAnalyzer {
 
     private List<Profile> safeProfiles(Model model) {
         List<Profile> profiles = model.getProfiles();
-        return profiles != null ? profiles : Collections.<Profile>emptyList();
+        return profiles != null ? profiles : List.of();
     }
 
     private List<Dependency> getProfileManagedDependencies(Profile profile) {
@@ -899,7 +893,7 @@ class PomChangeAnalyzer {
                 && profile.getDependencyManagement().getDependencies() != null) {
             return profile.getDependencyManagement().getDependencies();
         }
-        return Collections.<Dependency>emptyList();
+        return List.of();
     }
 
     private List<Plugin> getProfileManagedPlugins(Profile profile) {
@@ -908,14 +902,14 @@ class PomChangeAnalyzer {
                 && profile.getBuild().getPluginManagement().getPlugins() != null) {
             return profile.getBuild().getPluginManagement().getPlugins();
         }
-        return Collections.<Plugin>emptyList();
+        return List.of();
     }
 
     private List<Plugin> getProfilePlugins(Profile profile) {
         if (profile.getBuild() != null && profile.getBuild().getPlugins() != null) {
             return profile.getBuild().getPlugins();
         }
-        return Collections.<Plugin>emptyList();
+        return List.of();
     }
 
     private void augmentWithPropertyReferences(
@@ -1124,7 +1118,7 @@ class PomChangeAnalyzer {
             if (dir == null) {
                 continue;
             }
-            Path resourceDir = Paths.get(dir);
+            Path resourceDir = Path.of(dir);
             if (!resourceDir.isAbsolute()) {
                 resourceDir = project.getBasedir().toPath().resolve(resourceDir);
             }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -11,7 +11,6 @@ import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,7 +30,7 @@ class ReactorTrimmer {
 
     public TrimResult computeBuildSet(
             Set<MavenProject> directlyAffected, ProjectDependencyGraph graph, ScalpelConfiguration config) {
-        return computeBuildSet(directlyAffected, Collections.<MavenProject>emptySet(), graph, config);
+        return computeBuildSet(directlyAffected, Set.of(), graph, config);
     }
 
     public TrimResult computeBuildSet(

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -23,9 +23,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -421,7 +419,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         for (String pattern : config.getDisableTriggers()) {
             PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
             for (String changedFile : changedFiles) {
-                if (matcher.matches(Paths.get(changedFile))) {
+                if (matcher.matches(Path.of(changedFile))) {
                     logger.info(
                             "Scalpel: Disabled due to change in {} (matches disable trigger {})", changedFile, pattern);
                     return true;
@@ -433,7 +431,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private static List<PathMatcher> compileGlobMatchers(List<String> patterns) {
         if (patterns.isEmpty()) {
-            return Collections.emptyList();
+            return List.of();
         }
         List<PathMatcher> matchers = new ArrayList<>(patterns.size());
         for (String pattern : patterns) {
@@ -468,7 +466,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         for (String file : changedFiles) {
             boolean excluded = false;
             for (PathMatcher matcher : excludeMatchers) {
-                if (matcher.matches(Paths.get(file))) {
+                if (matcher.matches(Path.of(file))) {
                     excluded = true;
                     break;
                 }
@@ -486,7 +484,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private boolean matchesIncludePaths(MavenProject project, List<PathMatcher> matchers, Path reactorRoot) {
         String relPath = relativePath(reactorRoot, project);
-        Path modulePath = Paths.get(relPath);
+        Path modulePath = Path.of(relPath);
         for (PathMatcher matcher : matchers) {
             // Match the module path directly (e.g., "module-a" matches pattern "module-a")
             // or match a file within the module (e.g., "module-a/pom.xml" matches pattern "module-a/**")
@@ -501,7 +499,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         for (String pattern : config.getFullBuildTriggers()) {
             PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
             for (String changedFile : changedFiles) {
-                if (matcher.matches(Paths.get(changedFile))) {
+                if (matcher.matches(Path.of(changedFile))) {
                     logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
                     return changedFile;
                 }
@@ -1072,7 +1070,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     logger.debug("Report: {} -> category=DOWNSTREAM, reason={}", key(project), reason);
                 }
                 builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                                project.getGroupId(), project.getArtifactId(), path, Collections.singletonList(reason))
+                                project.getGroupId(), project.getArtifactId(), path, List.of(reason))
                         .category(ScalpelReport.CATEGORY_DOWNSTREAM)
                         .testsSkippedReason(testsSkippedReason)
                         .build());

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
@@ -32,7 +32,7 @@ final class TrimResult {
             Set<MavenProject> directlyAffected,
             Set<MavenProject> upstreamOnly,
             Set<MavenProject> downstreamOnly) {
-        this(buildSet, directlyAffected, upstreamOnly, downstreamOnly, Collections.<MavenProject>emptySet());
+        this(buildSet, directlyAffected, upstreamOnly, downstreamOnly, Set.of());
     }
 
     TrimResult(

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,7 @@
   <properties>
     <project.build.outputTimestamp>2025-12-19T13:39:09Z</project.build.outputTimestamp>
 
-    <maven.compiler.release>8</maven.compiler.release>
-    <maven.compiler.testRelease>21</maven.compiler.testRelease>
+    <maven.compiler.release>17</maven.compiler.release>
     <requireRuntimeMavenVersion.range>[3.9,)</requireRuntimeMavenVersion.range>
 
     <!-- Maven 3 versions -->


### PR DESCRIPTION
## Summary
- Raises `maven.compiler.release` from `8` to `17` and removes the now-redundant `maven.compiler.testRelease` property
- Fixes modernizer violations triggered by the new target (`Paths.get()` → `Path.of()`, `Collections.emptyList/Set/Map()` → `List/Set/Map.of()`, `String.format()` → `String.formatted()`)
- Preparatory step for upgrading JGit from 5.x to 7.x (which requires JDK 17)

Since Scalpel is a build tool and the primary consumer (Apache Camel) already requires JDK 17, this trade-off is acceptable (per #26).

Refs #26

## Test plan
- [x] Full build passes: `./mvnw clean verify -e -B -P run-its`
- [x] All 24 integration tests pass
- [x] All modernizer violations resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - The project now requires Java 17 to build and run.

- **Refactor**
  - Updated internal collection and path handling to use modern Java APIs.
  - Maintained existing analysis, parsing, reporting, and project-selection behavior.
  - Improved consistency when handling empty results and default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->