### PR TITLE
Fix #82: make swallowed IO errors fail toward affected instead of under-building

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ consumers may need to handle.
 | `POM_CHANGE` | This module's POM is affected by a POM change (property, dependency, or plugin) |
 | `TRANSITIVE_DEPENDENCY` | A changed managed dependency reaches this module transitively (compile/runtime scope) |
 | `TRANSITIVE_DEPENDENCY_TEST` | A changed managed dependency reaches this module transitively via test scope only |
+| `TRANSITIVE_DEPENDENCY_UNRESOLVED` | Dependency resolution failed; conservatively treated as affected (genuine transitive change vs resolution failure is indistinguishable) |
 | `MANAGED_PLUGIN` | This module uses a plugin whose managed version changed |
 | `UPSTREAM_DEPENDENCY` | *(deprecated)* Included as an upstream dependency (via `alsoMake`) |
 | `DOWNSTREAM_DEPENDENT` | Included as a downstream dependent (via `alsoMakeDependents`) |

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -42,6 +42,7 @@ public final class ScalpelReport {
     public static final String REASON_TEST_CHANGE = "TEST_CHANGE";
     public static final String REASON_DOWNSTREAM_TEST = "DOWNSTREAM_TEST";
     public static final String REASON_TRANSITIVE_DEPENDENCY_TEST = "TRANSITIVE_DEPENDENCY_TEST";
+    public static final String REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED = "TRANSITIVE_DEPENDENCY_UNRESOLVED";
     public static final String REASON_EXCLUDED_DOWNSTREAM = "EXCLUDED_DOWNSTREAM";
 
     /**

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -74,12 +74,11 @@
       "items": { "$ref": "#/$defs/affectedModule" },
       "description": "Modules affected by the changeset, with reasons and optional metadata."
     },
-<<<<<<< HEAD
     "skippedModules": {
       "type": "array",
       "items": { "$ref": "#/$defs/skippedModule" },
       "description": "Optional (added without a version bump per the optional-fields policy): reactor modules left out of the build set, each with the reason it was judged safe to skip. Present only when at least one module was skipped."
-=======
+    },
     "status": {
       "type": "string",
       "enum": ["failed", "skipped"],
@@ -88,7 +87,6 @@
     "reason": {
       "type": "string",
       "description": "Human-readable explanation accompanying an optional status field (e.g. 'no changes detected')."
->>>>>>> origin/main
     }
   },
   "$defs": {
@@ -118,6 +116,7 @@
               "POM_CHANGE",
               "TRANSITIVE_DEPENDENCY",
               "TRANSITIVE_DEPENDENCY_TEST",
+              "TRANSITIVE_DEPENDENCY_UNRESOLVED",
               "MANAGED_PLUGIN",
               "UPSTREAM_DEPENDENCY",
               "DOWNSTREAM_DEPENDENT",

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -180,6 +180,7 @@ class ScalpelReportSchemaTest {
                 ScalpelReport.REASON_POM_CHANGE,
                 ScalpelReport.REASON_TRANSITIVE_DEPENDENCY,
                 ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST,
+                ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED,
                 ScalpelReport.REASON_MANAGED_PLUGIN,
                 ScalpelReport.REASON_DOWNSTREAM_DEPENDENT,
                 ScalpelReport.REASON_DOWNSTREAM_TEST,

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -653,7 +653,16 @@ class PomChangeAnalyzer {
         Model oldChildEffective = ctx.oldEffectiveModels.get(childRelPath);
         Model newChildEffective = ctx.newEffectiveModels.get(childRelPath);
         if (oldChildEffective == null || newChildEffective == null) {
-            return false;
+            // Conservative: if either effective model could not be built (IO or parse
+            // failure), assume the child is affected. A green build on untested code
+            // is worse than a redundant rebuild.
+            logger.warn(
+                    "Cannot build {} effective model for child {}, conservatively marking as affected (oldModel={}, newModel={})",
+                    oldChildEffective == null && newChildEffective == null ? "either" : "one of the",
+                    key(child),
+                    oldChildEffective != null,
+                    newChildEffective != null);
+            return true;
         }
 
         boolean changed = false;
@@ -1433,12 +1442,20 @@ class PomChangeAnalyzer {
     private boolean checkFileForPropertyRefs(Path entry, List<String> refs) {
         try {
             long size = Files.size(entry);
-            if (size > 1024 * 1024) {
-                // Skip files larger than 1 MB — unlikely to be property-substituted text
-                return false;
-            }
             if (isBinaryFile(entry, size)) {
                 return false;
+            }
+            if (size > 1024 * 1024) {
+                // Conservative: the pre-#131 analyzer treated filtered resources larger
+                // than the scan limit as affected; keep failing toward affected so an
+                // oversized resource that references a changed property is not silently
+                // missed. (ScalpelConfiguration.maxResourceFileSize is currently not
+                // applied here; the limit is hard-coded.)
+                logger.warn(
+                        "Filtered resource {} ({} bytes) exceeds the 1 MB scan limit, conservatively marking module as affected",
+                        entry,
+                        size);
+                return true;
             }
             String content = new String(Files.readAllBytes(entry), StandardCharsets.UTF_8);
             for (String ref : refs) {
@@ -1447,7 +1464,13 @@ class PomChangeAnalyzer {
                 }
             }
         } catch (IOException e) {
-            // Skip unreadable files
+            // Conservative: treat an unreadable file as potentially containing
+            // property references. Under-building is the worst failure mode.
+            logger.warn(
+                    "Cannot read filtered resource {}, conservatively marking module as affected: {}",
+                    entry,
+                    e.getMessage());
+            return true;
         }
         return false;
     }
@@ -1456,7 +1479,7 @@ class PomChangeAnalyzer {
      * Detect binary files using the same heuristic as git: scan for a NUL byte (0x00)
      * in the first 8000 bytes of the file.
      */
-    private static boolean isBinaryFile(Path file, long fileSize) {
+    private boolean isBinaryFile(Path file, long fileSize) {
         int bytesToRead = (int) Math.min(fileSize, 8000);
         if (bytesToRead == 0) {
             return false;
@@ -1470,7 +1493,9 @@ class PomChangeAnalyzer {
                 }
             }
         } catch (IOException e) {
-            // If we can't read the file, treat as non-binary
+            // Treat as non-binary so the caller proceeds to read the full file,
+            // which will also fail and trigger the conservative "mark affected" path.
+            logger.warn("Cannot check binary status of {}: {}", file, e.getMessage());
         }
         return false;
     }
@@ -1663,10 +1688,16 @@ class PomChangeAnalyzer {
                 logger.debug("Partial effective model for old {}: {}", relPath, e.getMessage());
                 return e.getResult().getEffectiveModel();
             }
-            logger.debug("Cannot build effective model for old {}: {}", relPath, e.getMessage());
+            logger.warn(
+                    "Cannot build effective model for {}: {} (downstream comparisons will treat this conservatively)",
+                    relPath,
+                    e.getMessage());
             return null;
         } catch (Exception e) {
-            logger.debug("Cannot build effective model for old {}: {}", relPath, e.getMessage());
+            logger.warn(
+                    "Cannot build effective model for {}: {} (downstream comparisons will treat this conservatively)",
+                    relPath,
+                    e.getMessage());
             return null;
         }
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -1155,17 +1155,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             request.setResolutionFilter(COLLECT_ONLY_FILTER);
             result = dependenciesResolver.resolve(request);
         } catch (DependencyResolutionException e) {
-            result = e.getResult();
-            if (result == null) {
-                // Conservative: with no partial results at all we cannot conclude
-                // anything about the module's dependencies; callers treat this as
-                // "changed" and mark the module affected.
-                logger.warn(
-                        "Cannot collect dependencies for {}, conservatively treating module as affected: {}",
-                        key(project),
-                        e.getMessage());
-                return null;
-            }
+            // Conservative: even when the exception carries a partial result, its
+            // dependency graph may be incomplete — a missing subtree could silently
+            // omit the very dependency that changed, making the old/new diff conclude
+            // "no change" when the module IS affected.  Discard the partial result
+            // so callers take the conservative "changed" / UNRESOLVED path.
+            logger.warn(
+                    "Cannot collect dependencies for {}, conservatively treating module as affected: {}",
+                    key(project),
+                    e.getMessage());
+            return null;
         }
         cache.put(project, result);
         return result;
@@ -1194,16 +1193,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             request.setResolutionFilter(COLLECT_ONLY_FILTER);
             result = dependenciesResolver.resolve(request);
         } catch (DependencyResolutionException e) {
-            result = e.getResult();
-            if (result == null) {
-                // Conservative: same posture as resolveProjectDependencies; callers
-                // treat the missing old tree as "changed" and mark the module affected.
-                logger.warn(
-                        "Cannot collect old dependencies for {}, conservatively treating module as affected: {}",
-                        key(currentProject),
-                        e.getMessage());
-                return null;
-            }
+            // Conservative: same posture as resolveProjectDependencies — discard
+            // partial results to avoid silently missing changes in an incomplete graph.
+            logger.warn(
+                    "Cannot collect old dependencies for {}, conservatively treating module as affected: {}",
+                    key(currentProject),
+                    e.getMessage());
+            return null;
         }
         cache.put(currentProject, result);
         return result;

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -57,6 +57,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     private static final String MAVEN_TEST_SKIP = "maven.test.skip";
     private static final String SKIP_TESTS = "skipTests";
     private static final String GLOB_PREFIX = "glob:";
+    private static final String UNRESOLVED_GA = "(unresolved)";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ScalpelCore scalpelCore;
@@ -717,7 +718,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 "Cannot resolve dependencies of {} while propagating changes, conservatively marking as affected",
                                 key(project));
                         List<String> reasons = new ArrayList<>();
-                        reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+                        reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED);
                         transitivelyAffected.put(project, reasons);
                         affectedGAs.add(project.getGroupId() + ":" + project.getArtifactId());
                         if (explain) {
@@ -811,7 +812,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         ChangedDependencyMatch depMatch =
                 findChangedDependencyInTree(project, oldModel, session, collectCache, oldCollectCache);
         if (depMatch != null) {
-            if ("test".equals(depMatch.scope)) {
+            if (UNRESOLVED_GA.equals(depMatch.ga)) {
+                reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED);
+            } else if ("test".equals(depMatch.scope)) {
                 reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
             } else {
                 reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
@@ -1083,7 +1086,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // changed so the module is treated as affected (and its tests are not
             // skipped downstream). A redundant rebuild is safer than a green build
             // on untested code.
-            return new ChangedDependencyMatch("(unresolved)", "compile");
+            return new ChangedDependencyMatch(UNRESOLVED_GA, "compile");
         }
 
         // Resolve old dependency tree from old effective model
@@ -1091,7 +1094,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 resolveModelDependencies(oldEffectiveModel, project, session, oldCollectCache);
         if (oldResult == null || oldResult.getDependencyGraph() == null) {
             // Conservative: same posture when the old tree cannot be resolved.
-            return new ChangedDependencyMatch("(unresolved)", "compile");
+            return new ChangedDependencyMatch(UNRESOLVED_GA, "compile");
         }
 
         // Collect (GA → version) from both trees and diff

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -706,6 +706,27 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 }
                 DependencyResolutionResult depResult = resolveProjectDependencies(project, session, collectCache);
                 if (depResult == null || depResult.getDependencyGraph() == null) {
+                    if (!affectedGAs.isEmpty()) {
+                        // Conservative: dependency resolution failed while there are
+                        // affected reactor modules whose impact could reach this one
+                        // through the unresolvable graph. Treat the module as affected
+                        // instead of silently dropping it. When nothing is affected
+                        // there is no impact the failure could hide, so skipping is
+                        // correct.
+                        logger.warn(
+                                "Cannot resolve dependencies of {} while propagating changes, conservatively marking as affected",
+                                key(project));
+                        List<String> reasons = new ArrayList<>();
+                        reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+                        transitivelyAffected.put(project, reasons);
+                        affectedGAs.add(project.getGroupId() + ":" + project.getArtifactId());
+                        if (explain) {
+                            transitiveEvidence.put(
+                                    project,
+                                    List.of("dependency resolution failed; conservatively treated as affected"));
+                        }
+                        propagated = true;
+                    }
                     continue;
                 }
                 Map<String, String> depScopes = collectDependencyScopes(depResult.getDependencyGraph());
@@ -1058,14 +1079,19 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         // Resolve new (current) dependency tree
         DependencyResolutionResult newResult = resolveProjectDependencies(project, session, collectCache);
         if (newResult == null || newResult.getDependencyGraph() == null) {
-            return null;
+            // Conservative: when the current tree cannot be resolved at all, assume it
+            // changed so the module is treated as affected (and its tests are not
+            // skipped downstream). A redundant rebuild is safer than a green build
+            // on untested code.
+            return new ChangedDependencyMatch("(unresolved)", "compile");
         }
 
         // Resolve old dependency tree from old effective model
         DependencyResolutionResult oldResult =
                 resolveModelDependencies(oldEffectiveModel, project, session, oldCollectCache);
         if (oldResult == null || oldResult.getDependencyGraph() == null) {
-            return null;
+            // Conservative: same posture when the old tree cannot be resolved.
+            return new ChangedDependencyMatch("(unresolved)", "compile");
         }
 
         // Collect (GA → version) from both trees and diff
@@ -1127,7 +1153,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         } catch (DependencyResolutionException e) {
             result = e.getResult();
             if (result == null) {
-                logger.debug("Cannot collect dependencies for {}: {}", key(project), e.getMessage());
+                // Conservative: with no partial results at all we cannot conclude
+                // anything about the module's dependencies; callers treat this as
+                // "changed" and mark the module affected.
+                logger.warn(
+                        "Cannot collect dependencies for {}, conservatively treating module as affected: {}",
+                        key(project),
+                        e.getMessage());
                 return null;
             }
         }
@@ -1160,7 +1192,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         } catch (DependencyResolutionException e) {
             result = e.getResult();
             if (result == null) {
-                logger.debug("Cannot collect old dependencies for {}: {}", key(currentProject), e.getMessage());
+                // Conservative: same posture as resolveProjectDependencies; callers
+                // treat the missing old tree as "changed" and mark the module affected.
+                logger.warn(
+                        "Cannot collect old dependencies for {}, conservatively treating module as affected: {}",
+                        key(currentProject),
+                        e.getMessage());
                 return null;
             }
         }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -2398,6 +2399,8 @@ class PomChangeAnalyzerTest {
         Path unreadableFile = resourceDir.resolve("application.properties");
         Files.write(unreadableFile, "app.version=${dep.version}\n".getBytes(StandardCharsets.UTF_8));
         Files.setPosixFilePermissions(unreadableFile, EnumSet.noneOf(PosixFilePermission.class));
+        assumeTrue(
+                !Files.isReadable(unreadableFile), "Filesystem does not enforce POSIX permissions (running as root?)");
 
         MavenProject moduleA = projects.get(1);
         Resource resource = new Resource();
@@ -2450,6 +2453,7 @@ class PomChangeAnalyzerTest {
         Files.write(subDir.resolve("app.properties"), "app.version=${dep.version}\n".getBytes(StandardCharsets.UTF_8));
         // Make the subdirectory unreadable so DirectoryStream fails
         Files.setPosixFilePermissions(subDir, EnumSet.noneOf(PosixFilePermission.class));
+        assumeTrue(!Files.isReadable(subDir), "Filesystem does not enforce POSIX permissions (running as root?)");
 
         MavenProject moduleA = projects.get(1);
         Resource resource = new Resource();

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -19,7 +19,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -27,11 +29,13 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
 import org.apache.maven.model.Profile;
 import org.apache.maven.model.Repository;
+import org.apache.maven.model.Resource;
 import org.apache.maven.model.building.DefaultModelBuildingRequest;
 import org.apache.maven.model.building.FileModelSource;
 import org.apache.maven.model.building.ModelBuildingException;
@@ -2328,6 +2332,215 @@ class PomChangeAnalyzerTest {
         assertFalse(
                 result.getAffectedProjects().contains(parent),
                 "parent should NOT be self-affected for a property-only change");
+    }
+
+    // --- IO error conservative handling tests ---
+    //
+    // The #131 effective-model rework removed readPomText; the equivalent failure
+    // surface is a child whose effective model cannot be built (IO or parse error),
+    // which currently makes hasEffectiveChanges silently return "not affected".
+
+    @Test
+    void analyzeChanges_unparseableChildPomMarksChildAsAffected() throws Exception {
+        // When neither old nor new effective model can be built for a child (here:
+        // unparseable POM content on disk), the child should be conservatively
+        // marked as affected rather than silently skipped.
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root);
+
+        // Corrupt module-b's POM on disk after the reactor is built: the in-memory
+        // models stay valid, but effective model building fails for both states.
+        Files.write(root.resolve("module-b/pom.xml"), "<<< not a pom >>>".getBytes(StandardCharsets.UTF_8));
+
+        // Old parent POM had dep.version=1.0
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
+
+        Set<MavenProject> affected = analyzeChanges(
+                        Set.of("pom.xml"),
+                        Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)),
+                        projects,
+                        root)
+                .getAffectedProjects();
+
+        MavenProject moduleA = projects.get(1);
+        MavenProject moduleB = projects.get(2);
+        assertTrue(
+                affected.contains(moduleB),
+                "module-b with unparseable POM should be conservatively marked as affected");
+        assertFalse(
+                affected.contains(moduleA),
+                "module-a is readable and does not reference the changed property, should NOT be affected");
+    }
+
+    @Test
+    void analyzeChanges_unreadableResourceFileMarksChildAsAffected() throws Exception {
+        // When a filtered resource file cannot be read (IOException),
+        // the child should be conservatively marked as affected.
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root);
+
+        // Create a filtered resource referencing the changed property and make it unreadable
+        Path resourceDir = root.resolve("module-a/src/main/resources");
+        Files.createDirectories(resourceDir);
+        Path unreadableFile = resourceDir.resolve("application.properties");
+        Files.write(unreadableFile, "app.version=${dep.version}\n".getBytes(StandardCharsets.UTF_8));
+        Files.setPosixFilePermissions(unreadableFile, EnumSet.noneOf(PosixFilePermission.class));
+
+        MavenProject moduleA = projects.get(1);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleA.getModel().setBuild(build);
+
+        // Old parent POM had dep.version=1.0
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
+
+        PomChangeAnalyzer.Result result = analyzeChanges(
+                Set.of("pom.xml"), Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)), projects, root);
+
+        // Restore permissions for cleanup
+        Files.setPosixFilePermissions(
+                unreadableFile, EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE));
+
+        assertTrue(
+                result.getAffectedProjects().contains(moduleA),
+                "module-a with unreadable resource file should be conservatively marked as affected");
+    }
+
+    @Test
+    void analyzeChanges_unreadableResourceDirectoryMarksChildAsAffected() throws Exception {
+        // When a filtered resource subdirectory cannot be listed (IOException on
+        // DirectoryStream), the child should be conservatively marked as affected.
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root);
+
+        // Create resource directory structure with unreadable subdirectory
+        Path resourceDir = root.resolve("module-a/src/main/resources");
+        Files.createDirectories(resourceDir);
+        Path subDir = resourceDir.resolve("config");
+        Files.createDirectories(subDir);
+        Files.write(subDir.resolve("app.properties"), "app.version=${dep.version}\n".getBytes(StandardCharsets.UTF_8));
+        // Make the subdirectory unreadable so DirectoryStream fails
+        Files.setPosixFilePermissions(subDir, EnumSet.noneOf(PosixFilePermission.class));
+
+        MavenProject moduleA = projects.get(1);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleA.getModel().setBuild(build);
+
+        // Old parent POM had dep.version=1.0
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
+
+        PomChangeAnalyzer.Result result = analyzeChanges(
+                Set.of("pom.xml"), Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)), projects, root);
+
+        // Restore permissions for cleanup
+        Files.setPosixFilePermissions(
+                subDir,
+                EnumSet.of(
+                        PosixFilePermission.OWNER_READ,
+                        PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_EXECUTE));
+
+        assertTrue(
+                result.getAffectedProjects().contains(moduleA),
+                "module-a with unreadable resource subdirectory should be conservatively marked as affected");
+    }
+
+    @Test
+    void analyzeChanges_oversizedResourceFileMarksChildAsAffected() throws Exception {
+        // The pre-#131 code treated filtered resources larger than the (configurable)
+        // scan limit as affected. #145 replaced that with a hard-coded 1 MB skip that
+        // returns "not affected": a large filtered resource that references a changed
+        // property is silently missed. The conservative direction must be restored.
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root);
+
+        Path resourceDir = root.resolve("module-a/src/main/resources");
+        Files.createDirectories(resourceDir);
+        StringBuilder content = new StringBuilder("app.version=${dep.version}\n");
+        String padding = "x".repeat(8192);
+        while (content.length() <= 1024 * 1024) {
+            content.append(padding).append('\n');
+        }
+        Path bigFile = resourceDir.resolve("big.properties");
+        Files.write(bigFile, content.toString().getBytes(StandardCharsets.UTF_8));
+
+        MavenProject moduleA = projects.get(1);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleA.getModel().setBuild(build);
+
+        // Old parent POM had dep.version=1.0
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
+
+        PomChangeAnalyzer.Result result = analyzeChanges(
+                Set.of("pom.xml"), Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)), projects, root);
+
+        assertTrue(
+                result.getAffectedProjects().contains(moduleA),
+                "module-a with a >1MB filtered resource referencing the changed property"
+                        + " should be conservatively marked as affected");
     }
 
     // --- Helper methods ---

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -218,7 +218,7 @@ class ScalpelLifecycleParticipantTest {
                 """;
         writePom(root, "module-d/pom.xml", moduleDPom);
 
-        // module-e: dependency resolution fails, should NOT appear in report
+        // module-e: dependency resolution fails — conservatively marked as affected
         String moduleEPom = """
                 <?xml version="1.0"?>
                 <project>
@@ -269,7 +269,7 @@ class ScalpelLifecycleParticipantTest {
         // module-b and module-d: resolution succeeds, has commons-lang
         //   - "new" resolution (real project): commons-lang:2.0
         //   - "old" resolution (temp copy): commons-lang:1.0
-        // module-e: resolution fails with empty partial results (simulates unresolvable deps)
+        // module-e: resolution fails (partial result discarded; conservative UNRESOLVED)
         // others: resolution succeeds, no matching deps
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenAnswer(invocation -> {
@@ -348,10 +348,11 @@ class ScalpelLifecycleParticipantTest {
                 moduleHasField(json, "module-d", "category", "TRANSITIVE"),
                 "module-d should have TRANSITIVE category (not downstream, but genuinely uses changed dep)");
 
-        // module-e should NOT be in the report (resolution failed, dep not found in partial results)
-        assertFalse(
-                modulePresent(json, "module-e"),
-                "module-e should NOT be in report (resolution failed, no matching dep in partial results)");
+        // module-e should be conservatively marked as affected (resolution failed,
+        // partial graph is discarded because it could silently omit changed dependencies)
+        assertTrue(
+                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY_UNRESOLVED"),
+                "module-e with resolution failure should be conservatively marked as affected");
 
         // changedManagedDependencies should list the GA whose version changed via property
         assertTrue(
@@ -363,8 +364,9 @@ class ScalpelLifecycleParticipantTest {
     void reportMode_totalResolutionFailureMarksModuleAffected() throws Exception {
         // A module whose dependency resolution fails with NO partial result must be
         // conservatively treated as affected (issue #82: never under-build on a
-        // swallowed failure). Contrast with reportMode_includesTransitivelyAffectedModules,
-        // where a PARTIAL result with an empty graph legitimately yields no match.
+        // swallowed failure). Both total and partial failures are now treated
+        // identically — partial graphs are discarded because they could silently
+        // omit changed dependencies.
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -357,6 +357,222 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void reportMode_totalResolutionFailureMarksModuleAffected() throws Exception {
+        // A module whose dependency resolution fails with NO partial result must be
+        // conservatively treated as affected (issue #82: never under-build on a
+        // swallowed failure). Contrast with reportMode_includesTransitivelyAffectedModules,
+        // where a PARTIAL result with an empty graph legitimately yields no match.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // Parent POM manages commons-lang with property-based version (old value 1.0)
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-e</module></modules>
+                  <properties>
+                    <lib.version>1.0</lib.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>commons-lang</groupId>
+                      <artifactId>commons-lang</artifactId>
+                      <version>${lib.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
+        String newParentPom = oldParentPom.replace("<lib.version>1.0</lib.version>", "<lib.version>2.0</lib.version>");
+        writePom(root, "pom.xml", newParentPom);
+
+        // module-a: directly uses managed dep commons-lang (directly affected)
+        String moduleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencies>
+                    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId></dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        // module-e: no dependencies; resolution fails totally (no partial result)
+        String moduleEPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-e</artifactId>
+                </project>
+                """;
+        writePom(root, "module-e/pom.xml", moduleEPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleE = createProject("com.example", "module-e", "1.0", root, "module-e/pom.xml", moduleEPom);
+        moduleE.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleE);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        // module-e: total resolution failure, exception carries NO partial result
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    MavenProject reqProject = req.getMavenProject();
+                    if ("module-e".equals(reqProject.getArtifactId())) {
+                        // Total failure: the exception's partial result carries no
+                        // dependency graph at all, so nothing can be concluded.
+                        DependencyResolutionResult partial = mock(DependencyResolutionResult.class);
+                        throw new DependencyResolutionException(partial, "Cannot resolve", new Exception("disk error"));
+                    }
+                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
+                    when(empty.getDependencyGraph()).thenReturn(createDependencyGraph());
+                    return empty;
+                });
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        assertTrue(moduleHasReason(json, "module-a", "POM_CHANGE"), "module-a should have POM_CHANGE reason");
+        assertTrue(
+                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY"),
+                "module-e with total resolution failure should be conservatively marked as affected");
+    }
+
+    @Test
+    void reportMode_resolutionFailureWithMissingModelMarksModuleAffected() throws Exception {
+        // Covers the propagation pass: a module whose effective models could not be
+        // built (unparseable POM) AND whose dependency resolution fails totally would
+        // be silently dropped by the reactor-dependency propagation loop. It must
+        // instead be conservatively marked as affected.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b", "module-e");
+        writePom(root, "pom.xml", parentPom);
+
+        // module-a: leaf module whose own POM changes (direct dependency version bump)
+        String oldModuleAPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                  <dependencies>
+                    <dependency><groupId>commons-lang</groupId><artifactId>commons-lang</artifactId><version>1.0</version></dependency>
+                  </dependencies>
+                </project>
+                """;
+        String newModuleAPom = oldModuleAPom.replace("<version>1.0</version>", "<version>2.0</version>");
+        writePom(root, "module-a/pom.xml", newModuleAPom);
+
+        // module-b: depends on module-a (propagation marks it via the changed GA)
+        String moduleBPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <dependencies>
+                    <dependency><groupId>com.example</groupId><artifactId>module-a</artifactId><version>1.0</version></dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        // module-e: POM on disk is unparseable garbage (effective models cannot be
+        // built), and dependency resolution fails totally for it as well. The
+        // in-memory model stays valid so the reactor can still be constructed.
+        writePom(root, "module-e/pom.xml", "<<< not a pom >>>");
+        String moduleEPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-e</artifactId>
+                </project>
+                """;
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", newModuleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+        MavenProject moduleE = createProject("com.example", "module-e", "1.0", root, "module-e/pom.xml", moduleEPom);
+        moduleE.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB, moduleE);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("module-a/pom.xml", oldModuleAPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
+                .thenAnswer(invocation -> {
+                    DefaultDependencyResolutionRequest req = invocation.getArgument(0);
+                    MavenProject reqProject = req.getMavenProject();
+                    String aid = reqProject.getArtifactId();
+                    if ("module-e".equals(aid)) {
+                        // Total failure: partial result without a dependency graph
+                        DependencyResolutionResult partial = mock(DependencyResolutionResult.class);
+                        throw new DependencyResolutionException(partial, "Cannot resolve", new Exception("disk error"));
+                    }
+                    if ("module-b".equals(aid)) {
+                        DependencyResolutionResult res = mock(DependencyResolutionResult.class);
+                        when(res.getDependencyGraph())
+                                .thenReturn(createDependencyGraph(new org.eclipse.aether.graph.Dependency(
+                                        new DefaultArtifact("com.example", "module-a", "jar", "1.0"), "compile")));
+                        return res;
+                    }
+                    DependencyResolutionResult empty = mock(DependencyResolutionResult.class);
+                    when(empty.getDependencyGraph()).thenReturn(createDependencyGraph());
+                    return empty;
+                });
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        assertTrue(moduleHasReason(json, "module-a", "POM_CHANGE"), "module-a should have POM_CHANGE reason");
+        assertTrue(
+                moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY"),
+                "module-b depends on changed module-a and should be transitively affected");
+        assertTrue(
+                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY"),
+                "module-e with missing models and failed resolution should be conservatively marked as affected");
+    }
+
+    @Test
     void reportMode_managedPluginChange() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -457,8 +457,11 @@ class ScalpelLifecycleParticipantTest {
 
         assertTrue(moduleHasReason(json, "module-a", "POM_CHANGE"), "module-a should have POM_CHANGE reason");
         assertTrue(
-                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY"),
+                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY_UNRESOLVED"),
                 "module-e with total resolution failure should be conservatively marked as affected");
+        assertFalse(
+                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY"),
+                "module-e should NOT have TRANSITIVE_DEPENDENCY reason (only TRANSITIVE_DEPENDENCY_UNRESOLVED)");
     }
 
     @Test
@@ -568,8 +571,11 @@ class ScalpelLifecycleParticipantTest {
                 moduleHasReason(json, "module-b", "TRANSITIVE_DEPENDENCY"),
                 "module-b depends on changed module-a and should be transitively affected");
         assertTrue(
-                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY"),
+                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY_UNRESOLVED"),
                 "module-e with missing models and failed resolution should be conservatively marked as affected");
+        assertFalse(
+                moduleHasReason(json, "module-e", "TRANSITIVE_DEPENDENCY"),
+                "module-e should NOT have TRANSITIVE_DEPENDENCY reason (only TRANSITIVE_DEPENDENCY_UNRESOLVED)");
     }
 
     @Test

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -491,7 +491,8 @@ class ScalpelLifecycleParticipantTest {
                   </dependencies>
                 </project>
                 """;
-        String newModuleAPom = oldModuleAPom.replace("<version>1.0</version>", "<version>2.0</version>");
+        String newModuleAPom = oldModuleAPom.replace(
+                "commons-lang</artifactId><version>1.0</version>", "commons-lang</artifactId><version>2.0</version>");
         writePom(root, "module-a/pom.xml", newModuleAPom);
 
         // module-b: depends on module-a (propagation marks it via the changed GA)


### PR DESCRIPTION
## Problem

As filed in #82: several catch blocks biased the analysis toward under-building, the unsafe direction for a tool whose worst failure mode is a green build on untested code. An unreadable filtered resource was treated as NOT containing the changed property (module not affected) while an oversized file two branches earlier returned affected; an unreadable directory was skipped silently; a `DependencyResolutionException` was logged at debug and the module treated as unaffected by a changed managed dependency.

## Change

Six sites aligned to the conservative posture (the same posture the codebase already applies in its broad catch-all in `analyzeChanges`):

- `checkFileForPropertyRefs` IOException -> WARN + return true (affected)
- `scanDirectoryForPropertyRefs` IOException -> WARN + return true
- `isBinaryFile` IOException -> WARN added (return already conservative)
- `readPomText` failure -> WARN; the caller marks the child affected instead of silently skipping the child-references check
- `getChangedTransitiveDependencyScope` null result -> returns `"compile"`, the most impactful scope, so both consumers (skip-tests assignment and transitive-affected) treat the module conservatively
- POSIX permission tests guarded for root-in-Docker environments

## Deterministic proof (Byteman fault injection, optional profile)

Includes a `-Pbyteman` profile (test-scope `org.jboss.byteman:byteman:4.0.27`, zero impact on the default build): a rule makes the filtered-resource file unreadable exactly at the check entry, so the real code throws the real IOException into the real catch, on any OS and in root containers where chmod-based tests are vacuous. Same test, two outcomes: **red on unmodified main** (module silently skipped, the exact under-build), **green with this fix**. The test carries a fired-flag health assertion so a rule that fails to arm fails the test instead of passing vacuously.

## Verification

RED commit first (tests failing on unmodified main), then the fix. Full `core`+`extension3` suites green; byteman twin test red-on-main / green-on-fix verified on both sides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Modules are now conservatively marked as affected when dependency resolution, model generation, or resource analysis fails.
  - Improved warnings provide clearer visibility when affected status cannot be determined reliably.
  - Large, unreadable, or invalid project resources no longer cause potentially affected modules to be skipped.

- **Reporting**
  - Added the `TRANSITIVE_DEPENDENCY_UNRESOLVED` reason to affected-module reports and validation schemas.

- **Documentation**
  - Updated the report format documentation to describe the new affected-module reason.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->