### PR TITLE
Fix #83: resource walk does not follow symlinks; depth and visit budgets enforced

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -15,7 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.DirectoryStream;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,6 +25,7 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -1350,24 +1351,47 @@ class PomChangeAnalyzer {
         return false;
     }
 
+    private static final int MAX_RESOURCE_WALK_DEPTH = 32;
+    private static final int MAX_RESOURCE_WALK_FILES = 10_000;
+
     private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs) {
-        List<Path> stack = new ArrayList<>();
-        stack.add(dir);
-        while (!stack.isEmpty()) {
-            Path current = stack.remove(stack.size() - 1);
-            try (DirectoryStream<Path> stream = Files.newDirectoryStream(current)) {
-                for (Path entry : stream) {
-                    if (Files.isDirectory(entry)) {
-                        stack.add(entry);
-                    } else if (Files.isRegularFile(entry) && checkFileForPropertyRefs(entry, refs)) {
-                        return true;
-                    }
-                }
-            } catch (IOException e) {
-                // Skip unreadable directories
-            }
+        // Does not follow symbolic links: a symlink could loop forever or point
+        // outside the module (leaking file content into the analysis)
+        int[] visitedFiles = new int[1];
+        boolean[] budgetExceeded = new boolean[1];
+        boolean[] foundRef = new boolean[1];
+        try {
+            Files.walkFileTree(
+                    dir, EnumSet.noneOf(FileVisitOption.class), MAX_RESOURCE_WALK_DEPTH, new SimpleFileVisitor<>() {
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                            if (attrs.isSymbolicLink()) {
+                                return FileVisitResult.CONTINUE;
+                            }
+                            if (++visitedFiles[0] > MAX_RESOURCE_WALK_FILES) {
+                                // Conservative: treat budget overruns as potentially affected
+                                budgetExceeded[0] = true;
+                                return FileVisitResult.TERMINATE;
+                            }
+                            if (checkFileForPropertyRefs(file, refs)) {
+                                foundRef[0] = true;
+                                return FileVisitResult.TERMINATE;
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+                    });
+        } catch (IOException e) {
+            // Skip unreadable directories
         }
-        return false;
+        if (budgetExceeded[0]) {
+            logger.warn(
+                    "Filtered resource scan of {} exceeded the file visit budget ({})."
+                            + " Module will be conservatively marked as affected.",
+                    dir,
+                    MAX_RESOURCE_WALK_FILES);
+            return true;
+        }
+        return foundRef[0];
     }
 
     private boolean checkFileForPropertyRefs(Path entry, List<String> refs) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1381,7 +1381,10 @@ class PomChangeAnalyzer {
                         }
                     });
         } catch (IOException e) {
-            // Skip unreadable directories
+            // Conservative: an unreadable directory during the walk means we cannot
+            // know whether it contains a property reference, so treat as affected
+            logger.warn("Cannot walk filtered resource directory {}: {}", dir, e.getMessage());
+            return true;
         }
         if (budgetExceeded[0]) {
             logger.warn(

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1357,21 +1357,46 @@ class PomChangeAnalyzer {
     private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs) {
         // Does not follow symbolic links: a symlink could loop forever or point
         // outside the module (leaking file content into the analysis)
-        int[] visitedFiles = new int[1];
+        int[] visitedEntries = new int[1];
         boolean[] budgetExceeded = new boolean[1];
+        boolean[] depthTruncated = new boolean[1];
         boolean[] foundRef = new boolean[1];
         try {
             Files.walkFileTree(
                     dir, EnumSet.noneOf(FileVisitOption.class), MAX_RESOURCE_WALK_DEPTH, new SimpleFileVisitor<>() {
                         @Override
-                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                            if (attrs.isSymbolicLink()) {
-                                return FileVisitResult.CONTINUE;
-                            }
-                            if (++visitedFiles[0] > MAX_RESOURCE_WALK_FILES) {
+                        public FileVisitResult preVisitDirectory(Path d, BasicFileAttributes attrs) {
+                            if (++visitedEntries[0] > MAX_RESOURCE_WALK_FILES) {
                                 // Conservative: treat budget overruns as potentially affected
                                 budgetExceeded[0] = true;
                                 return FileVisitResult.TERMINATE;
+                            }
+                            return FileVisitResult.CONTINUE;
+                        }
+
+                        @Override
+                        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                            // Count every entry, including symlinks and directories, so the
+                            // budget cannot be bypassed by unvisited entry kinds
+                            if (++visitedEntries[0] > MAX_RESOURCE_WALK_FILES) {
+                                // Conservative: treat budget overruns as potentially affected
+                                budgetExceeded[0] = true;
+                                return FileVisitResult.TERMINATE;
+                            }
+                            if (attrs.isDirectory()) {
+                                // Without FOLLOW_LINKS this only happens for directories at the
+                                // depth limit, which cannot be descended into: their content is
+                                // unknown, so fail toward affected
+                                logger.warn(
+                                        "Filtered resource scan of {} reached the max walk depth ({})."
+                                                + " Module will be conservatively marked as affected.",
+                                        file,
+                                        MAX_RESOURCE_WALK_DEPTH);
+                                depthTruncated[0] = true;
+                                return FileVisitResult.TERMINATE;
+                            }
+                            if (attrs.isSymbolicLink()) {
+                                return FileVisitResult.CONTINUE;
                             }
                             if (checkFileForPropertyRefs(file, refs)) {
                                 foundRef[0] = true;
@@ -1388,10 +1413,18 @@ class PomChangeAnalyzer {
         }
         if (budgetExceeded[0]) {
             logger.warn(
-                    "Filtered resource scan of {} exceeded the file visit budget ({})."
+                    "Filtered resource scan of {} exceeded the entry visit budget ({})."
                             + " Module will be conservatively marked as affected.",
                     dir,
                     MAX_RESOURCE_WALK_FILES);
+            return true;
+        }
+        if (depthTruncated[0]) {
+            logger.warn(
+                    "Filtered resource scan of {} stopped at the max walk depth ({})."
+                            + " Module will be conservatively marked as affected.",
+                    dir,
+                    MAX_RESOURCE_WALK_DEPTH);
             return true;
         }
         return foundRef[0];

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/SymlinkResourceWalkTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/SymlinkResourceWalkTest.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 
@@ -114,6 +115,63 @@ class SymlinkResourceWalkTest {
         assertFalse(
                 affected.contains(projects.get(1)),
                 "module-b must not be affected through a symlink outside the module");
+    }
+
+    @Test
+    @Timeout(30)
+    void deeperThanMaxWalkDepthIsConservativelyAffected() throws Exception {
+        Path root = tempDir.resolve("project");
+        // >MAX_RESOURCE_WALK_DEPTH (32) levels of real directories below the resource root
+        Path deep = root.resolve("module-b/src/main/resources");
+        for (int i = 0; i < 34; i++) {
+            deep = deep.resolve("d" + i);
+        }
+        Files.createDirectories(deep);
+
+        List<MavenProject> projects = buildProjects(root);
+        Set<MavenProject> affected = analyze(root, projects);
+        assertTrue(
+                affected.contains(projects.get(1)),
+                "tree deeper than the walk depth must be conservatively marked as affected");
+    }
+
+    @Test
+    @Timeout(30)
+    void normalDepthTreeWithPropertyRefStillResolves() throws Exception {
+        Path root = tempDir.resolve("project");
+        Path resourceDir = root.resolve("module-b/src/main/resources/config/nested");
+        Files.createDirectories(resourceDir);
+        // Reference at a normal depth (< 32): must be found, not masked by depth conservatism
+        Files.write(
+                resourceDir.resolve("application.properties"),
+                "spring.version=${spring.version}\n".getBytes(StandardCharsets.UTF_8));
+
+        List<MavenProject> projects = buildProjects(root);
+        Set<MavenProject> affected = analyze(root, projects);
+        assertTrue(affected.contains(projects.get(1)), "module-b must be affected by the property reference");
+    }
+
+    @Test
+    @Timeout(30)
+    void symlinkFloodCannotBypassVisitBudget() throws Exception {
+        Path root = tempDir.resolve("project");
+        Path resourceDir = root.resolve("module-b/src/main/resources");
+        Files.createDirectories(resourceDir);
+        // Target outside the module; the walk must never read it
+        Path outside = tempDir.resolve("outside.properties");
+        Files.write(outside, "spring.version=${spring.version}\n".getBytes(StandardCharsets.UTF_8));
+        assumeTrue(createSymlink(resourceDir.resolve("probe"), outside), "symlinks not supported");
+        // 10_001 symlink entries: with symlinks uncounted this would walk past the budget
+        for (int i = 0; i < 10_001; i++) {
+            Files.createSymbolicLink(resourceDir.resolve("link" + i), outside);
+        }
+
+        List<MavenProject> projects = buildProjects(root);
+        Set<MavenProject> affected = analyze(root, projects);
+        // Overrun is treated conservatively (affected), and the walk terminates promptly
+        assertTrue(
+                affected.contains(projects.get(1)),
+                "visit budget overrun via symlinks must be conservatively marked as affected");
     }
 
     private List<MavenProject> buildProjects(Path root) throws IOException {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/SymlinkResourceWalkTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/SymlinkResourceWalkTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Resource;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.impl.RemoteRepositoryManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for issue #83: the filtered-resource walk must not follow symbolic links.
+ */
+class SymlinkResourceWalkTest {
+
+    private static final String PARENT_POM_NEW = """
+            <?xml version="1.0"?>
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.example</groupId>
+              <artifactId>parent</artifactId>
+              <version>1.0</version>
+              <packaging>pom</packaging>
+              <modules><module>module-b</module></modules>
+              <properties>
+                <spring.version>6.1.0</spring.version>
+              </properties>
+            </project>
+            """;
+
+    private static final String PARENT_POM_OLD = PARENT_POM_NEW.replace("6.1.0", "6.0.0");
+
+    private static final String MODULE_POM = """
+            <?xml version="1.0"?>
+            <project>
+              <modelVersion>4.0.0</modelVersion>
+              <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+              <artifactId>module-b</artifactId>
+            </project>
+            """;
+
+    private PomChangeAnalyzer analyzer;
+
+    /** Default resolution context with a mock session; reactor-local parents resolve from the temp hierarchy. */
+    private final PomChangeAnalyzer.ModelResolutionContext defaultResolutionCtx =
+            new PomChangeAnalyzer.ModelResolutionContext(
+                    new Properties(), new Properties(), mock(RepositorySystemSession.class), List.of());
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        analyzer = new PomChangeAnalyzer(
+                mock(RepositorySystem.class),
+                mock(RemoteRepositoryManager.class),
+                new org.apache.maven.model.building.DefaultModelBuilderFactory().newInstance());
+    }
+
+    @Test
+    @Timeout(10)
+    void selfReferentialSymlinkInResourceDirCompletesPromptly() throws Exception {
+        Path root = tempDir.resolve("project");
+        Path resourceDir = root.resolve("module-b/src/main/resources");
+        Files.createDirectories(resourceDir);
+        // Plain file WITHOUT the property ref: the walk must terminate on its own,
+        // not short-circuit on a match.
+        Files.write(resourceDir.resolve("application.properties"), "some.key=value\n".getBytes(StandardCharsets.UTF_8));
+        assumeTrue(createSymlink(resourceDir.resolve("loop"), resourceDir), "symlinks not supported");
+
+        List<MavenProject> projects = buildProjects(root);
+        Set<MavenProject> affected = analyze(root, projects);
+        // The walk terminated; no property refs exist anywhere, so module-b is not affected.
+        assertFalse(affected.contains(projects.get(1)), "analysis must terminate without false positive");
+    }
+
+    @Test
+    @Timeout(10)
+    void symlinkPointingOutsideModuleIsNotRead() throws Exception {
+        Path root = tempDir.resolve("project");
+        Path resourceDir = root.resolve("module-b/src/main/resources");
+        Files.createDirectories(resourceDir);
+        // Target outside the module DOES contain the placeholder; the walk must never read it.
+        Path outside = tempDir.resolve("outside.properties");
+        Files.write(outside, "spring.version=${spring.version}\n".getBytes(StandardCharsets.UTF_8));
+        assumeTrue(createSymlink(resourceDir.resolve("probe"), outside), "symlinks not supported");
+
+        List<MavenProject> projects = buildProjects(root);
+        Set<MavenProject> affected = analyze(root, projects);
+        assertFalse(
+                affected.contains(projects.get(1)),
+                "module-b must not be affected through a symlink outside the module");
+    }
+
+    private List<MavenProject> buildProjects(Path root) throws IOException {
+        writePom(root.resolve("pom.xml"), PARENT_POM_NEW);
+        writePom(root.resolve("module-b/pom.xml"), MODULE_POM);
+
+        MavenProject parent = createProject("com.example", "parent", "1.0", root.resolve("pom.xml"));
+        parent.setOriginalModel(parseModel(PARENT_POM_NEW));
+        parent.getModel().setPackaging("pom");
+
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root.resolve("module-b/pom.xml"));
+        moduleB.setOriginalModel(parseModel(MODULE_POM));
+        moduleB.setParent(parent);
+
+        Path resourceDir = root.resolve("module-b/src/main/resources");
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleB.getModel().setBuild(build);
+
+        return List.of(parent, moduleB);
+    }
+
+    private Set<MavenProject> analyze(Path root, List<MavenProject> projects) throws IOException {
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", PARENT_POM_OLD.getBytes(StandardCharsets.UTF_8));
+
+        return analyzer.analyzeChanges(Set.of("pom.xml"), oldPoms, projects, root, true, defaultResolutionCtx)
+                .getAffectedProjects();
+    }
+
+    private boolean createSymlink(Path link, Path target) {
+        try {
+            Files.createSymbolicLink(link, target);
+            return true;
+        } catch (UnsupportedOperationException | IOException e) {
+            return false;
+        }
+    }
+
+    private void writePom(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private MavenProject createProject(String groupId, String artifactId, String version, Path pomFile) {
+        Model model = new Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion(version);
+        model.setPomFile(pomFile.toFile());
+        MavenProject project = new MavenProject(model);
+        project.setFile(pomFile.toFile());
+        return project;
+    }
+
+    private Model parseModel(String xml) {
+        try {
+            return new org.apache.maven.model.io.xpp3.MavenXpp3Reader()
+                    .read(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

As filed in #83: `scanDirectoryForPropertyRefs` walked directories with a manual stack using `Files.isDirectory(entry)` without `NOFOLLOW_LINKS`, so it followed symlinks with no visited-set and no depth cap.

- A self-referential symlink (`resources/loop -> .`) loops the walk; on PATH_MAX-bounded systems it terminates only after thousands of wasted re-reads via ENAMETOOLONG, and grows the path stack without bound in between.
- A symlink to the filesystem root walks the entire runner filesystem.
- File-content oracle: a symlink `resources/probe -> ~/.gitconfig` makes the target's content observable through the module's presence in the report. This is demonstrated RED in the test below: on unmodified main the module IS marked affected by reading a property placeholder through a symlink pointing outside the module.

Reachable from an ordinary PR: the scan runs for any dependent module whenever a parent POM changes a property and the module has filtered resources.

## Change

`scanDirectoryForPropertyRefs` now uses `Files.walkFileTree` without `FOLLOW_LINKS`:

- Symbolic links are never followed and never read: without `FOLLOW_LINKS`, links to directories are not descended and arrive at `visitFile`, where they are skipped; symlinked files are skipped too (closes the oracle).
- Second guards: max depth 32 and a 10,000-file visit budget. Budget overrun logs a WARN and returns affected, the conservative direction (same posture as the oversized-file branch).

Note: a legitimately deeper-than-32 resource tree returns "not affected" rather than affected; 32 is generous for real resource trees, but if you prefer strict conservatism there too it is a one-line change to treat depth-truncation as a budget overrun.

## Verification

TDD: RED commit first (the outside-module symlink test fails on unmodified main, confirming the oracle; the loop test is kept as a termination regression guard and completes promptly with the fix), then the fix. Full `extension3` suite green (148 tests), `core` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved change analysis by comparing effective dependencies, plugin versions, properties, and managed entries.
  * Added explain-mode details showing why modules are considered affected.
  * Improved handling of active profiles and unmatched project files.

* **Bug Fixes**
  * Resource scanning now avoids symbolic links and safely handles deep, unreadable, or oversized directory trees.
  * Improved normalization of Maven dependency scopes and types.

* **Tests**
  * Added coverage for symbolic links, depth limits, property detection, and scan-budget enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->