### PR TITLE
Fix #126: unordered list comparison must not collapse duplicate entries

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -18,7 +18,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -809,7 +808,11 @@ class PomChangeAnalyzer {
         if (a.size() != b.size()) {
             return false;
         }
-        return new HashSet<>(a).equals(new HashSet<>(b));
+        List<String> sortedA = new ArrayList<>(a);
+        List<String> sortedB = new ArrayList<>(b);
+        sortedA.sort(String::compareTo);
+        sortedB.sort(String::compareTo);
+        return sortedA.equals(sortedB);
     }
 
     private boolean equalRepositoryLists(List<Repository> a, List<Repository> b) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -826,6 +826,26 @@ class PomChangeAnalyzerTest {
                                 + "<includes><include>**/*.xml</include></includes>"
                                 + "</resource></resources></build>")),
                 Arguments.of(
+                        "resource includes changed only by duplicated entry",
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<includes><include>**/*.xml</include><include>**/*.xml</include>"
+                                + "<include>**/*.properties</include></includes>"
+                                + "</resource></resources></build>"),
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<includes><include>**/*.xml</include>"
+                                + "<include>**/*.properties</include><include>**/*.properties</include>"
+                                + "</includes></resource></resources></build>")),
+                Arguments.of(
+                        "resource excludes changed only by duplicated entry",
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<excludes><exclude>**/*.keystore</exclude><exclude>**/*.keystore</exclude>"
+                                + "<exclude>**/*.jks</exclude></excludes>"
+                                + "</resource></resources></build>"),
+                        parentPomWith("<build><resources><resource><directory>src/main/resources</directory>"
+                                + "<excludes><exclude>**/*.keystore</exclude>"
+                                + "<exclude>**/*.jks</exclude><exclude>**/*.jks</exclude></excludes>"
+                                + "</resource></resources></build>")),
+                Arguments.of(
                         "test resource directory changed",
                         parentPomWith("<build><testResources><testResource>"
                                 + "<directory>src/test/resources2</directory>"


### PR DESCRIPTION
## Problem

As filed in #126 (bug subset): `PomChangeAnalyzer.equalStringListsUnordered` compared two `HashSet`s after a size check, so `[xml, xml, properties]` vs `[xml, properties, properties]` compared equal. A change to a filtered resource's `includes`/`excludes` that only alters DUPLICATED entries was therefore invisible: the resource looked unchanged and the module was not marked affected (under-build).

## Change

Compare sorted copies instead of set views: unordered semantics preserved, duplicates respected. The method's contract and callers (resource includes/excludes comparison) are unchanged.

## Verification

TDD: RED first (two new parameterized cases, duplicated-include and duplicated-exclude, failing exactly as predicted), then the fix. Full `core` + `extension3` suites green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison of unordered resource include and exclude entries.
  * Reordered entries with duplicates are now correctly treated as equivalent, preventing unnecessary parent POM changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->