### PR TITLE
Fix #102, fix #103: pin actions to SHAs, permissions blocks, quoted version expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Verify

--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: Checkout ${{ github.ref_name }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
@@ -41,14 +41,14 @@ jobs:
           echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 21
           cache: maven
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
     tags:
       - '[0-9]*.[0-9]*.[0-9]*'
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   release:
     name: Release to Maven Central
@@ -67,10 +71,11 @@ jobs:
       - name: Post release
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
           gh extension install valeriobelli/gh-milestone
-          version=${{ steps.version.outputs.version }}
+          version="$VERSION"
           echo "Trying to find milestone $version"
           milestone=$(gh milestone list --json id,title,state  --jq "map_values(select(.title == \"${version}\" and .state == \"OPEN\")).[].number")
           if [ ! -z "$milestone" ]; then

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         fetch-depth: 0
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'temurin'
         java-version: '21'


### PR DESCRIPTION
## #102 Pin GitHub Actions to commit SHAs

Every `uses:` now references a full 40-char commit SHA with a version comment (all verified against the tags via the GitHub API):

| Action | Pinned | Tag |
|---|---|---|
| actions/checkout | `3d3c42e5` | v7 |
| actions/setup-java | `b6effb05` | v5.7.0 |
| crazy-max/ghaction-import-gpg | `2dc316de` | v7.0.0 |

The GPG import action runs in the release job holding the Maven Central signing and publishing secrets; a mutable tag there is the highest-impact unpinned reference in the repo. The reusable `maveniverse/parent` workflow ref is left on its branch-pin convention (noted, not changed).

## #103 Permissions and quoting

- `ci.yml`: explicit `permissions: contents: read` (had none; it inherits the parent workflow's usage).
- `release.yml`: explicit minimal `permissions: contents: write, issues: write` — `gh release create` needs contents:write, the milestone commands need the issues scope; nothing else in the job uses GITHUB_TOKEN.
- `release.yml` Post-release step: the tag version is now passed via `env:` (`VERSION`) and assigned as a quoted shell variable, matching the pattern already used in sonarcloud.yml, instead of an unquoted `${{ }}` expansion into the shell.

All four workflow files parse as valid YAML; no floating `uses:` remains except the intentional parent-workflow branch ref.