### PR TITLE
Fix #85: validate fetch remote against configured remotes, handle slash-containing branch names

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -167,14 +167,36 @@ public class GitChangeDetector {
     }
 
     public void fetchBranch(Repository repository, String baseBranch) throws IOException {
-        // Parse "origin/main" → remote="origin", branch="main"
-        int slashIndex = baseBranch.indexOf('/');
-        if (slashIndex < 0) {
-            logger.debug("Cannot parse remote from baseBranch '{}', skipping fetch", baseBranch);
+        if (baseBranch == null || baseBranch.isEmpty()) {
+            logger.debug("Empty baseBranch, skipping fetch");
             return;
         }
-        String remote = baseBranch.substring(0, slashIndex);
-        String branch = baseBranch.substring(slashIndex + 1);
+        // Reject URL-shaped values early: JGit treats unknown remote names as URLs,
+        // so a typo like "git@host:evil.git/main" would otherwise attempt a network fetch
+        if (baseBranch.contains("://") || baseBranch.startsWith("git@") || baseBranch.contains(":")) {
+            throw new IOException("Invalid scalpel.baseBranch '" + baseBranch
+                    + "': URL-shaped value, expected <remote>/<branch> or <branch>");
+        }
+        // Only treat the prefix before the first slash as a remote if it is a configured remote;
+        // otherwise the whole string is a (possibly slash-containing) local branch name
+        String remote = null;
+        String branch = baseBranch;
+        int slashIndex = baseBranch.indexOf('/');
+        if (slashIndex > 0) {
+            String candidate = baseBranch.substring(0, slashIndex);
+            if (repository.getRemoteNames().contains(candidate)) {
+                remote = candidate;
+                branch = baseBranch.substring(slashIndex + 1);
+            }
+        }
+        if (!Repository.isValidRefName("refs/heads/" + branch)) {
+            throw new IOException("Invalid scalpel.baseBranch '" + baseBranch + "': not a valid branch name"
+                    + (branch.contains("*") ? " (wildcards are not allowed)" : ""));
+        }
+        if (remote == null) {
+            logger.debug("No configured remote prefix in baseBranch '{}', skipping fetch", baseBranch);
+            return;
+        }
         String refspec = "+refs/heads/" + branch + ":refs/remotes/" + remote + "/" + branch;
 
         logger.info("Scalpel: Fetching {} from {}", branch, remote);

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -173,7 +173,7 @@ public class GitChangeDetector {
         }
         // Reject URL-shaped values early: JGit treats unknown remote names as URLs,
         // so a typo like "git@host:evil.git/main" would otherwise attempt a network fetch
-        if (baseBranch.contains("://") || baseBranch.startsWith("git@") || baseBranch.contains(":")) {
+        if (baseBranch.contains(":")) {
             throw new IOException("Invalid scalpel.baseBranch '" + baseBranch
                     + "': URL-shaped value, expected <remote>/<branch> or <branch>");
         }
@@ -187,6 +187,12 @@ public class GitChangeDetector {
             if (repository.getRemoteNames().contains(candidate)) {
                 remote = candidate;
                 branch = baseBranch.substring(slashIndex + 1);
+            } else {
+                logger.warn(
+                        "Scalpel: baseBranch '{}' has a slash but '{}' is not a configured remote; "
+                                + "treating it as a local branch name and skipping the fetch",
+                        baseBranch,
+                        candidate);
             }
         }
         if (!Repository.isValidRefName("refs/heads/" + branch)) {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
@@ -15,7 +15,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -455,6 +457,43 @@ class GitChangeDetectorTest {
         try (Repository repo = repoWithOriginRemote()) {
             // "release" is not a configured remote: the whole string is a local branch name
             assertDoesNotThrow(() -> detector.fetchBranch(repo, "release/1.0"));
+        }
+    }
+
+    /**
+     * Runs the callable with System.err captured (slf4j-simple writes to stderr)
+     * and returns everything that was written during its execution.
+     */
+    private String captureStderr(Runnable action) {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void fetchBranch_unconfiguredPrefixWithSlash_warns() throws Exception {
+        try (Repository repo = repoWithOriginRemote()) {
+            String err = captureStderr(() -> assertDoesNotThrow(() -> detector.fetchBranch(repo, "bogus/main")));
+            assertTrue(
+                    err.contains("WARN "),
+                    "expected a WARN about the unconfigured remote prefix but stderr was: " + err);
+            assertTrue(
+                    err.contains("'bogus' is not a configured remote"),
+                    "WARN should name the unconfigured prefix 'bogus' but stderr was: " + err);
+        }
+    }
+
+    @Test
+    void fetchBranch_plainBranchNoSlash_noWarn() throws Exception {
+        try (Repository repo = repoWithOriginRemote()) {
+            String err = captureStderr(() -> assertDoesNotThrow(() -> detector.fetchBranch(repo, "main")));
+            assertFalse(err.contains("WARN "), "no WARN expected for a plain branch name but stderr was: " + err);
         }
     }
 

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
@@ -410,8 +410,9 @@ class GitChangeDetectorTest {
     // ---- fetchBranch validation (#85) ----
 
     /**
-     * Creates a work repo with a commit on branch main, plus a bare remote named "origin"
-     * that has main pushed to it, and configures the remote on the work repo.
+     * Creates a work repo with a commit on its initial branch (whatever the environment
+     * defaults to), plus a bare remote named "origin" that has that branch pushed to it,
+     * and configures the remote on the work repo.
      */
     private Repository repoWithOriginRemote() throws Exception {
         Path remoteDir = tempDir.resolve("remote.git");
@@ -427,8 +428,11 @@ class GitChangeDetectorTest {
                 Files.write(workDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
                 git.add().addFilepattern("file.txt").call();
                 git.commit().setMessage("initial").call();
-                git.branchCreate().setName("main").call();
-                git.push().setRemote(remoteDir.toUri().toString()).add("main").call();
+                // The initial branch name comes from the environment (init.defaultBranch),
+                // so derive it from the repository instead of creating "main", which
+                // already exists where that is the default
+                String branch = git.getRepository().getBranch();
+                git.push().setRemote(remoteDir.toUri().toString()).add(branch).call();
                 git.remoteAdd()
                         .setName("origin")
                         .setUri(new org.eclipse.jgit.transport.URIish(

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
@@ -7,6 +7,7 @@
  */
 package eu.maveniverse.maven.scalpel.core;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -401,6 +402,82 @@ class GitChangeDetectorTest {
             assertFalse(result.containsKey("missing/pom.xml"), "Missing pom should not be in the map");
             assertEquals("<project/>", new String(result.get("pom.xml"), StandardCharsets.UTF_8));
             assertEquals("<module/>", new String(result.get("sub/pom.xml"), StandardCharsets.UTF_8));
+        }
+    }
+
+    // ---- fetchBranch validation (#85) ----
+
+    /**
+     * Creates a work repo with a commit on branch main, plus a bare remote named "origin"
+     * that has main pushed to it, and configures the remote on the work repo.
+     */
+    private Repository repoWithOriginRemote() throws Exception {
+        Path remoteDir = tempDir.resolve("remote.git");
+        Path workDir = tempDir.resolve("work");
+        Files.createDirectories(workDir);
+
+        try (Git remoteGit = Git.init().setDirectory(remoteDir.toFile()).setBare(true).call()) {
+            try (Git git = Git.init().setDirectory(workDir.toFile()).call()) {
+                git.getRepository().getConfig().setString("user", null, "name", "Scalpel Test");
+                git.getRepository().getConfig().setString("user", null, "email", "scalpel@test.invalid");
+
+                Files.write(workDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+                git.add().addFilepattern("file.txt").call();
+                git.commit().setMessage("initial").call();
+                git.branchCreate().setName("main").call();
+                git.push().setRemote(remoteDir.toUri().toString()).add("main").call();
+                git.remoteAdd()
+                        .setName("origin")
+                        .setUri(new org.eclipse.jgit.transport.URIish(remoteDir.toUri().toString()))
+                        .call();
+                return git.getRepository();
+            }
+        }
+    }
+
+    @Test
+    void fetchBranch_urlShapedBaseBranch_rejectedNotFetched() throws Exception {
+        try (Repository repo = repoWithOriginRemote()) {
+            IOException e = assertThrows(IOException.class, () -> detector.fetchBranch(repo, "git@host:evil.git/main"));
+            assertTrue(
+                    e.getMessage().contains("URL"), "expected URL-shaped rejection message but was: " + e.getMessage());
+            IOException e2 = assertThrows(IOException.class, () -> detector.fetchBranch(repo, "https://evil.git/main"));
+            assertTrue(
+                    e2.getMessage().contains("URL"),
+                    "expected URL-shaped rejection message but was: " + e2.getMessage());
+        }
+    }
+
+    @Test
+    void fetchBranch_slashContainingLocalBranch_skipsFetchInsteadOfBogusRemote() throws Exception {
+        try (Repository repo = repoWithOriginRemote()) {
+            // "release" is not a configured remote: the whole string is a local branch name
+            assertDoesNotThrow(() -> detector.fetchBranch(repo, "release/1.0"));
+        }
+    }
+
+    @Test
+    void fetchBranch_wildcardBranch_rejected() throws Exception {
+        try (Repository repo = repoWithOriginRemote()) {
+            IOException e = assertThrows(IOException.class, () -> detector.fetchBranch(repo, "feat*"));
+            assertTrue(
+                    e.getMessage().contains("Invalid"),
+                    "expected invalid-branch rejection message but was: " + e.getMessage());
+            IOException e2 = assertThrows(IOException.class, () -> detector.fetchBranch(repo, "origin/ma*n"));
+            assertTrue(
+                    e2.getMessage().contains("Invalid"),
+                    "expected invalid-branch rejection message but was: " + e2.getMessage());
+        }
+    }
+
+    @Test
+    void fetchBranch_typoBranchOnValidRemote_failsLoudly() throws Exception {
+        try (Repository repo = repoWithOriginRemote()) {
+            // Valid remote, typo'd branch: the fetch must surface the failure, not swallow it
+            IOException e = assertThrows(IOException.class, () -> detector.fetchBranch(repo, "origin/typo"));
+            assertTrue(
+                    e.getMessage().contains("origin/typo"),
+                    "expected failure naming the branch but was: " + e.getMessage());
         }
     }
 }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
@@ -349,34 +349,34 @@ class GitChangeDetectorTest {
     }
 
     @Test
-    void fetchBranch_nonexistentRemote_throwsIOException() throws Exception {
+    void fetchBranch_unconfiguredRemotePrefix_treatedAsLocalBranchAndSkipped() throws Exception {
         try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
             Files.write(tempDir.resolve("file.txt"), "x".getBytes(StandardCharsets.UTF_8));
             git.add().addFilepattern("file.txt").call();
             git.commit().setMessage("initial").call();
 
-            // "bogus/main" parses but there is no remote called "bogus"
-            assertThrows(
-                    IOException.class,
-                    () -> detector.fetchBranch(git.getRepository(), "bogus/main"),
-                    "Fetching from a nonexistent remote should throw IOException");
+            // "bogus" is not a configured remote: per #85 the whole string is a
+            // local branch name and the fetch is skipped, not attempted against
+            // a URL parsed from the prefix
+            assertDoesNotThrow(() -> detector.fetchBranch(git.getRepository(), "bogus/main"));
         }
     }
 
     @Test
-    void fetchBranch_malformedRefspec_throwsIllegalArgumentException() throws Exception {
+    void fetchBranch_urlShapedRefspec_rejectedAsUrl() throws Exception {
         try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
             Files.write(tempDir.resolve("file.txt"), "x".getBytes(StandardCharsets.UTF_8));
             git.add().addFilepattern("file.txt").call();
             git.commit().setMessage("initial").call();
 
-            // ":/nope" parses as remote=":", branch="nope" which produces an
-            // invalid RefSpec.  The current code does not catch
-            // IllegalArgumentException, so the raw exception escapes.
-            assertThrows(
-                    IllegalArgumentException.class,
+            // ":/nope" contains a colon and is URL-shaped: rejected up front with
+            // an IOException naming the configuration problem (#85), instead of
+            // escaping as a raw IllegalArgumentException from RefSpec parsing
+            IOException e = assertThrows(
+                    IOException.class,
                     () -> detector.fetchBranch(git.getRepository(), ":/nope"),
-                    "A malformed refspec should throw IllegalArgumentException");
+                    "A URL-shaped baseBranch should be rejected with IOException");
+            assertTrue(e.getMessage().contains("URL"), "message should name the URL shape: " + e.getMessage());
         }
     }
 
@@ -416,7 +416,8 @@ class GitChangeDetectorTest {
         Path workDir = tempDir.resolve("work");
         Files.createDirectories(workDir);
 
-        try (Git remoteGit = Git.init().setDirectory(remoteDir.toFile()).setBare(true).call()) {
+        try (Git remoteGit =
+                Git.init().setDirectory(remoteDir.toFile()).setBare(true).call()) {
             try (Git git = Git.init().setDirectory(workDir.toFile()).call()) {
                 git.getRepository().getConfig().setString("user", null, "name", "Scalpel Test");
                 git.getRepository().getConfig().setString("user", null, "email", "scalpel@test.invalid");
@@ -428,7 +429,8 @@ class GitChangeDetectorTest {
                 git.push().setRemote(remoteDir.toUri().toString()).add("main").call();
                 git.remoteAdd()
                         .setName("origin")
-                        .setUri(new org.eclipse.jgit.transport.URIish(remoteDir.toUri().toString()))
+                        .setUri(new org.eclipse.jgit.transport.URIish(
+                                remoteDir.toUri().toString()))
                         .call();
                 return git.getRepository();
             }


### PR DESCRIPTION
## Problem

As filed in #85: `fetchBranch` split `baseBranch` at the first slash and passed the left half to `git.fetch().setRemote(...)`. JGit still treats an unknown remote name as a URL (verified on JGit 7.7.1: the RED test shows `git@host:evil.git/main` entering the fetch path as a URI), so a crafted `scalpel.baseBranch` could fetch from an attacker-chosen host using the runner's credentials, and a wildcard branch silently widened the refspec. Separately, a legitimate local branch named `release/1.0` was mis-split into remote `release` / branch `1.0` and the fetch failed.

## Change

- URL-shaped values (anything containing `:`) are rejected up front with an IOException naming the configuration problem, before any transport opens. Git refnames cannot contain `:` (git-check-ref-format), so no legitimate value is rejected.
- The pre-slash prefix is treated as a remote ONLY if `repository.getRemoteNames()` contains it; otherwise the whole value is a local branch name and the fetch is skipped with a WARN (visibility matters here: CI auto-detection hardcodes `origin/`, and this path is only reached when the ref already fails to resolve — previously an unconfigured origin failed loudly, so the WARN keeps the situation visible instead of a silent debug-level skip).
- The branch is validated with `Repository.isValidRefName("refs/heads/" + branch)`, which also rejects wildcards.

Deliberate behavior changes (two #63-era tests updated accordingly): `bogus/main` with no remote named `bogus` is now treated as a local branch (skip + WARN) instead of throwing from a bogus fetch; `:/nope` is rejected as URL-shaped instead of escaping as a raw IllegalArgumentException.

## Verification

TDD: RED first (URL-shaped, mis-split and wildcard tests failing on main), then the fix, then the review follow-up (WARN test + guard simplification). Full `core` (135) + `extension3` (146) suites green, offline (`-o`) verified: no test touches the network.