### PR TITLE
Fix #95: shallow-clone test coverage, shallow detection, actionable warnings

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -8,8 +8,8 @@
 package eu.maveniverse.maven.scalpel.core;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -58,7 +58,8 @@ public class GitChangeDetector {
      * method; only the internal DepthWalk classes track it), so the marker file is checked directly.
      */
     public boolean isShallow(Repository repository) {
-        return repository.getDirectory() != null && new File(repository.getDirectory(), "shallow").isFile();
+        return repository.getDirectory() != null
+                && Files.isRegularFile(repository.getDirectory().toPath().resolve("shallow"));
     }
 
     public ObjectId findMergeBase(Repository repository, String baseBranch, String head) throws IOException {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.scalpel.core;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,6 +51,15 @@ public class GitChangeDetector {
         return repository.getBranch();
     }
 
+    /**
+     * Tells whether the repository is shallow (created or fetched with a depth limit, e.g.
+     * actions/checkout with {@code fetch-depth: 1}), which is recorded in {@code .git/shallow}.
+     * JGit 5.x exposes no accessor for this, so the marker file is checked directly.
+     */
+    public boolean isShallow(Repository repository) {
+        return repository.getDirectory() != null && new File(repository.getDirectory(), "shallow").isFile();
+    }
+
     public ObjectId findMergeBase(Repository repository, String baseBranch, String head) throws IOException {
         ObjectId baseId = repository.resolve(baseBranch);
         if (baseId == null) {
@@ -69,6 +79,14 @@ public class GitChangeDetector {
             RevCommit mergeBase = revWalk.next();
             if (mergeBase == null) {
                 logger.warn("No merge base found between {} and {}", baseBranch, head);
+                if (isShallow(repository)) {
+                    logger.warn(
+                            "Repository is shallow (depth-limited clone/fetch, e.g. actions/checkout with fetch-depth: 1);"
+                                    + " the connecting history between {} and {} may be missing. Fix: use fetch-depth: 0"
+                                    + " in CI, or run 'git fetch --unshallow' before the build",
+                            baseBranch,
+                            head);
+                }
                 return null;
             }
             logger.debug("Merge base between {} and {}: {}", baseBranch, head, mergeBase.getName());
@@ -220,6 +238,14 @@ public class GitChangeDetector {
         String refspec = "+refs/heads/" + branch + ":refs/remotes/" + remote + "/" + branch;
 
         logger.info("Scalpel: Fetching {} from {}", branch, remote);
+        if (isShallow(repository)) {
+            // JGit 5.x (the Java-8 compatible line this build targets) has no depth controls
+            // on FetchCommand, so the fetch cannot be bounded or made deep on shallow repos.
+            logger.warn(
+                    "Scalpel: Repository is shallow; this fetch of {} is unbounded and may not restore the"
+                            + " missing history. Use fetch-depth: 0 in CI or 'git fetch --unshallow' before the build",
+                    baseBranch);
+        }
         try (Git git = new Git(repository)) {
             git.fetch().setRemote(remote).setRefSpecs(new RefSpec(refspec)).call();
         } catch (GitAPIException | JGitInternalException e) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -54,7 +54,8 @@ public class GitChangeDetector {
     /**
      * Tells whether the repository is shallow (created or fetched with a depth limit, e.g.
      * actions/checkout with {@code fetch-depth: 1}), which is recorded in {@code .git/shallow}.
-     * JGit 5.x exposes no accessor for this, so the marker file is checked directly.
+     * JGit 7.x still exposes no public accessor for this ({@link Repository} has no shallow
+     * method; only the internal DepthWalk classes track it), so the marker file is checked directly.
      */
     public boolean isShallow(Repository repository) {
         return repository.getDirectory() != null && new File(repository.getDirectory(), "shallow").isFile();
@@ -239,12 +240,12 @@ public class GitChangeDetector {
 
         logger.info("Scalpel: Fetching {} from {}", branch, remote);
         if (isShallow(repository)) {
-            // JGit 5.x (the Java-8 compatible line this build targets) has no depth controls
-            // on FetchCommand, so the fetch cannot be bounded or made deep on shallow repos.
+            // FetchCommand.setDepth is not wired here, so the fetch stays unbounded on shallow
+            // repos and may or may not restore the missing history.
             logger.warn(
-                    "Scalpel: Repository is shallow; this fetch of {} is unbounded and may not restore the"
+                    "Scalpel: Repository is shallow; fetching {} is unbounded and may not restore the"
                             + " missing history. Use fetch-depth: 0 in CI or 'git fetch --unshallow' before the build",
-                    baseBranch);
+                    branch);
         }
         try (Git git = new Git(repository)) {
             git.fetch().setRemote(remote).setRefSpecs(new RefSpec(refspec)).call();

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -89,9 +89,10 @@ public class GitChangeDetector {
             logger.debug("Merge base between {} and {}: {}", baseBranch, head, mergeBase.getName());
             return mergeBase.getId();
         } catch (MissingObjectException e) {
+            warnIfShallow(repository, baseBranch, head);
             logger.warn(
                     "Cannot compute merge base between {} and {}: commit history is incomplete"
-                            + " (shallow clone or missing objects). {}",
+                            + " (missing object). {}",
                     baseBranch,
                     head,
                     e.getMessage());
@@ -164,6 +165,9 @@ public class GitChangeDetector {
                 loader.copyTo(out);
                 return out.toByteArray();
             }
+        } catch (MissingObjectException e) {
+            warnIfShallow(repository, commitId.getName(), path);
+            throw e;
         }
     }
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -65,11 +65,13 @@ public class GitChangeDetector {
     public ObjectId findMergeBase(Repository repository, String baseBranch, String head) throws IOException {
         ObjectId baseId = repository.resolve(baseBranch);
         if (baseId == null) {
+            warnIfShallow(repository, baseBranch, head);
             logger.warn("Cannot resolve base branch: {}", baseBranch);
             return null;
         }
         ObjectId headId = repository.resolve(head);
         if (headId == null) {
+            warnIfShallow(repository, baseBranch, head);
             logger.warn("Cannot resolve head: {}", head);
             return null;
         }
@@ -81,14 +83,7 @@ public class GitChangeDetector {
             RevCommit mergeBase = revWalk.next();
             if (mergeBase == null) {
                 logger.warn("No merge base found between {} and {}", baseBranch, head);
-                if (isShallow(repository)) {
-                    logger.warn(
-                            "Repository is shallow (depth-limited clone/fetch, e.g. actions/checkout with fetch-depth: 1);"
-                                    + " the connecting history between {} and {} may be missing. Fix: use fetch-depth: 0"
-                                    + " in CI, or run 'git fetch --unshallow' before the build",
-                            baseBranch,
-                            head);
-                }
+                warnIfShallow(repository, baseBranch, head);
                 return null;
             }
             logger.debug("Merge base between {} and {}: {}", baseBranch, head, mergeBase.getName());
@@ -106,6 +101,22 @@ public class GitChangeDetector {
             logger.warn("Cannot compute merge base between {} and {}: {}", baseBranch, head, e.getMessage());
             logger.debug("Merge base computation error details", e);
             return null;
+        }
+    }
+
+    /**
+     * Emits the actionable remediation when the repository is shallow: the commits needed to relate
+     * {@code baseBranch} and {@code head} may sit beyond the depth-limited boundary, so an
+     * unresolved revision or a missing merge base is not a real topology problem but a clone artifact.
+     */
+    private void warnIfShallow(Repository repository, String baseBranch, String head) {
+        if (isShallow(repository)) {
+            logger.warn(
+                    "Repository is shallow (depth-limited clone/fetch, e.g. actions/checkout with fetch-depth: 1);"
+                            + " the connecting history between {} and {} may be missing. Fix: use fetch-depth: 0"
+                            + " in CI, or run 'git fetch --unshallow' before the build",
+                    baseBranch,
+                    head);
         }
     }
 

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
@@ -7,6 +7,7 @@
  */
 package eu.maveniverse.maven.scalpel.core;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,6 +88,23 @@ class ShallowCloneTest {
             assertNull(
                     detector.findMergeBase(repository, "main", "HEAD"),
                     "merge base should not be resolvable on a shallow repo with disconnected refs");
+        }
+    }
+
+    @Test
+    void isShallow_detectsShallowMarker() throws Exception {
+        Path repoDir = createShallowRepoWithDisconnectedBaseBranch();
+        try (Git git = Git.open(repoDir.toFile());
+                Repository repository = git.getRepository()) {
+            assertTrue(new GitChangeDetector().isShallow(repository));
+        }
+        // a plain repo with full history is not shallow
+        Path fullDir = tempDir.resolveSibling(tempDir.getFileName() + "-full");
+        try (Git git = Git.init().setDirectory(fullDir.toFile()).call()) {
+            write(fullDir, "f.txt", "x");
+            git.add().addFilepattern("f.txt").call();
+            git.commit().setMessage("c").call();
+            assertFalse(new GitChangeDetector().isShallow(git.getRepository()));
         }
     }
 

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
@@ -29,12 +29,13 @@ import org.junit.jupiter.api.io.TempDir;
  * Tests for shallow clones (e.g. actions/checkout with fetch-depth: 1), where the merge base
  * between the base branch and head cannot be resolved because the connecting history is absent.
  *
- * <p>Note: the build compiles against JGit 5.13.5 (the newest Java-8 compatible line), whose
- * CloneCommand/FetchCommand have no {@code setDepth}. A true shallow clone therefore cannot be
- * fetched with the in-use API, so the equivalent state is constructed via plumbing: two
- * disconnected roots (what a depth-limited fetch leaves behind: refs whose connecting commits
- * are missing, so the merge-base walk finds nothing) plus an explicit {@code .git/shallow}
- * marker, which is exactly what a real {@code fetch-depth: 1} checkout produces.</p>
+ * <p>The build compiles against JGit 7.7.1, whose CloneCommand supports {@code setDepth};
+ * {@code realShallowClone_isShallowAndCannotResolvePreCloneHistory} exercises a genuine
+ * depth-limited clone. The disconnected-roots fixture below is a deliberate alternative: it
+ * constructs the same observable state via plumbing (refs whose connecting commits are missing,
+ * so the merge-base walk finds nothing, plus an explicit {@code .git/shallow} marker) without
+ * depending on clone-transport depth behavior, which keeps the deterministic history shape
+ * explicit.</p>
  */
 class ShallowCloneTest {
 
@@ -74,6 +75,55 @@ class ShallowCloneTest {
     }
 
     @Test
+    void realShallowClone_isShallowAndCannotResolvePreCloneHistory() throws Exception {
+        // source repo with three commits, pushed to a local bare remote
+        Path srcDir = tempDir.resolve("src");
+        Path remoteDir = tempDir.resolve("remote.git");
+        try (Git git = Git.init()
+                .setDirectory(srcDir.toFile())
+                .setInitialBranch("main")
+                .call()) {
+            for (int i = 1; i <= 3; i++) {
+                write(srcDir, "f" + i + ".txt", "v" + i);
+                git.add().addFilepattern("f" + i + ".txt").call();
+                git.commit().setMessage("commit " + i).call();
+            }
+        }
+        try (Git remote = Git.init()
+                        .setBare(true)
+                        .setDirectory(remoteDir.toFile())
+                        .call();
+                Git src = Git.open(srcDir.toFile())) {
+            src.push()
+                    .setRemote(remoteDir.toUri().toString())
+                    .setRefSpecs(new org.eclipse.jgit.transport.RefSpec("refs/heads/main:refs/heads/main"))
+                    .call();
+        }
+
+        // real depth-limited clone over a local path URI
+        Path cloneDir = tempDir.resolve("clone");
+        try (Git clone = Git.cloneRepository()
+                        .setDepth(1)
+                        .setBranchesToClone(java.util.Collections.singletonList("refs/heads/main"))
+                        .setBranch("refs/heads/main")
+                        .setURI(remoteDir.toUri().toString())
+                        .setDirectory(cloneDir.toFile())
+                        .call();
+                Repository repository = clone.getRepository()) {
+            assertTrue(
+                    Files.exists(repository.getDirectory().toPath().resolve("shallow")),
+                    "setDepth(1) clone against a local path should produce .git/shallow");
+            assertTrue(new GitChangeDetector().isShallow(repository));
+            // the pre-clone history is genuinely absent: HEAD~1 cannot be resolved, so a
+            // merge base reaching past the shallow boundary comes back null
+            assertNull(repository.resolve("HEAD~1"), "HEAD~1 should not exist in a depth-1 clone");
+            assertNull(
+                    new GitChangeDetector().findMergeBase(repository, "HEAD~1", "HEAD"),
+                    "merge base with pre-clone history should not be resolvable on a depth-1 clone");
+        }
+    }
+
+    @Test
     void findMergeBase_returnsNullOnShallowRepoWithDisconnectedBaseBranch() throws Exception {
         Path repoDir = createShallowRepoWithDisconnectedBaseBranch();
         try (Git git = Git.open(repoDir.toFile());
@@ -99,7 +149,7 @@ class ShallowCloneTest {
             assertTrue(new GitChangeDetector().isShallow(repository));
         }
         // a plain repo with full history is not shallow
-        Path fullDir = tempDir.resolveSibling(tempDir.getFileName() + "-full");
+        Path fullDir = tempDir.resolve("full");
         try (Git git = Git.init().setDirectory(fullDir.toFile()).call()) {
             write(fullDir, "f.txt", "x");
             git.add().addFilepattern("f.txt").call();

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.Set;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for shallow clones (e.g. actions/checkout with fetch-depth: 1), where the merge base
+ * between the base branch and head cannot be resolved because the connecting history is absent.
+ *
+ * <p>Note: the build compiles against JGit 5.13.5 (the newest Java-8 compatible line), whose
+ * CloneCommand/FetchCommand have no {@code setDepth}. A true shallow clone therefore cannot be
+ * fetched with the in-use API, so the equivalent state is constructed via plumbing: two
+ * disconnected roots (what a depth-limited fetch leaves behind: refs whose connecting commits
+ * are missing, so the merge-base walk finds nothing) plus an explicit {@code .git/shallow}
+ * marker, which is exactly what a real {@code fetch-depth: 1} checkout produces.</p>
+ */
+class ShallowCloneTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * Creates a repo whose HEAD ("feature", root B) and base branch ("main", root A) share no
+     * history, and marks the repository shallow by writing {@code .git/shallow} listing both
+     * boundary commits - the observable state of a CI checkout with fetch-depth: 1.
+     */
+    private Path createShallowRepoWithDisconnectedBaseBranch() throws Exception {
+        try (Git git = Git.init()
+                .setDirectory(tempDir.toFile())
+                .setInitialBranch("main")
+                .call()) {
+            write("base.txt", "base");
+            git.add().addFilepattern("base.txt").call();
+            git.commit().setMessage("root A: on main").call();
+            ObjectId mainTip = git.getRepository().resolve("main");
+            assertNotNull(mainTip);
+
+            // orphan branch: root B, no shared history with main
+            git.checkout().setOrphan(true).setName("feature").call();
+            write("feature.txt", "feature");
+            git.add().addFilepattern("feature.txt").call();
+            git.commit().setMessage("root B: on feature").call();
+            ObjectId featureTip = git.getRepository().resolve("feature");
+
+            // mark shallow at both boundary commits, as a depth-limited fetch would
+            Path shallowFile = git.getRepository().getDirectory().toPath().resolve("shallow");
+            Files.write(
+                    shallowFile,
+                    (mainTip.getName() + "\n" + featureTip.getName() + "\n").getBytes(StandardCharsets.UTF_8));
+        }
+        return tempDir;
+    }
+
+    @Test
+    void findMergeBase_returnsNullOnShallowRepoWithDisconnectedBaseBranch() throws Exception {
+        Path repoDir = createShallowRepoWithDisconnectedBaseBranch();
+        try (Git git = Git.open(repoDir.toFile());
+                Repository repository = git.getRepository()) {
+            assertTrue(
+                    Files.exists(repository.getDirectory().toPath().resolve("shallow")),
+                    "repo should carry the shallow marker (.git/shallow exists)");
+            assertNotNull(repository.resolve("main"));
+            assertNotNull(repository.resolve("HEAD"));
+
+            GitChangeDetector detector = new GitChangeDetector();
+            assertNull(
+                    detector.findMergeBase(repository, "main", "HEAD"),
+                    "merge base should not be resolvable on a shallow repo with disconnected refs");
+        }
+    }
+
+    @Test
+    void detectChanges_onShallowRepo_buildsAllModulesWithActionableWarning() throws Exception {
+        Path repoDir = createShallowRepoWithDisconnectedBaseBranch();
+        ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.baseBranch", "main");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+        String logged = captureErr(() -> {
+            try {
+                assertNull(core.detectChanges(repoDir, config, Set.of()), "failSafe default should build all modules");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertTrue(
+                logged.contains("shallow"),
+                "expected an actionable WARN naming the shallow clone cause, got: " + logged);
+        assertTrue(
+                logged.contains("fetch-depth") || logged.contains("unshallow"),
+                "expected the WARN to name the fix (fetch-depth: 0 / --unshallow), got: " + logged);
+    }
+
+    private void write(String name, String content) throws Exception {
+        Files.write(tempDir.resolve(name), content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void write(Path dir, String name, String content) throws Exception {
+        Files.write(dir.resolve(name), content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private static String captureErr(ThrowingRunnable action) throws Exception {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(buffer, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return buffer.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
@@ -115,13 +115,22 @@ class ShallowCloneTest {
                     "setDepth(1) clone against a local path should produce .git/shallow");
             assertTrue(new GitChangeDetector().isShallow(repository));
             // the pre-clone history is genuinely absent: HEAD~1 cannot be resolved, so a
-            // merge base reaching past the shallow boundary comes back null. Note the second
-            // assertion below exercises the unresolvable-base guard in findMergeBase (the
-            // baseId == null early return), not isShallow itself.
+            // merge base reaching past the shallow boundary comes back null. The findMergeBase
+            // call below takes the unresolvable-base early return (baseId == null), and on a
+            // shallow repository that path must still surface the actionable remediation -
+            // not only the generic "Cannot resolve base branch" warning.
             assertNull(repository.resolve("HEAD~1"), "HEAD~1 should not exist in a depth-1 clone");
-            assertNull(
+            String logged = captureErr(() -> assertNull(
                     new GitChangeDetector().findMergeBase(repository, "HEAD~1", "HEAD"),
-                    "merge base with pre-clone history should not be resolvable on a depth-1 clone");
+                    "merge base with pre-clone history should not be resolvable on a depth-1 clone"));
+            assertTrue(
+                    logged.contains("Repository is shallow"),
+                    "unresolved revision on a shallow repo should name the shallow cause, got: " + logged);
+            assertTrue(
+                    logged.contains("fetch-depth: 0") || logged.contains("--unshallow"),
+                    "unresolved revision on a shallow repo should name the fix (fetch-depth: 0 /"
+                            + " --unshallow), got: "
+                            + logged);
         }
     }
 

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
@@ -10,9 +10,11 @@ package eu.maveniverse.maven.scalpel.core;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -219,5 +221,89 @@ class ShallowCloneTest {
             System.setErr(originalErr);
         }
         return buffer.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void realShallowClone_missingObjectBeyondBoundaryEmitsShallowGuidance() throws Exception {
+        // Source repo with three commits pushed to a bare remote
+        Path srcDir = tempDir.resolve("src");
+        Path remoteDir = tempDir.resolve("remote.git");
+        org.eclipse.jgit.lib.ObjectId[] commitIds = new org.eclipse.jgit.lib.ObjectId[3];
+        try (Git git = Git.init()
+                .setDirectory(srcDir.toFile())
+                .setInitialBranch("main")
+                .call()) {
+            for (int i = 1; i <= 3; i++) {
+                write(srcDir, "f" + i + ".txt", "v" + i);
+                git.add().addFilepattern("f" + i + ".txt").call();
+                git.commit().setMessage("commit " + i).call();
+                // Capture each commit's SHA for later use
+                commitIds[i - 1] = git.getRepository().resolve("HEAD");
+            }
+        }
+        try (Git remote = Git.init()
+                        .setBare(true)
+                        .setDirectory(remoteDir.toFile())
+                        .call();
+                Git src = Git.open(srcDir.toFile())) {
+            src.push()
+                    .setRemote(remoteDir.toUri().toString())
+                    .setRefSpecs(new org.eclipse.jgit.transport.RefSpec("refs/heads/main:refs/heads/main"))
+                    .call();
+        }
+
+        // Real depth-limited clone
+        Path cloneDir = tempDir.resolve("clone");
+        try (Git clone = Git.cloneRepository()
+                        .setDepth(1)
+                        .setBranchesToClone(java.util.List.of("refs/heads/main"))
+                        .setBranch("refs/heads/main")
+                        .setURI(remoteDir.toUri().toString())
+                        .setDirectory(cloneDir.toFile())
+                        .call();
+                Repository repository = clone.getRepository()) {
+
+            GitChangeDetector detector = new GitChangeDetector();
+
+            // Test readFileAtCommit with a pre-clone commit SHA (beyond the shallow boundary)
+            // This should emit shallow guidance before propagating MissingObjectException
+            org.eclipse.jgit.errors.MissingObjectException ex = assertThrows(
+                    org.eclipse.jgit.errors.MissingObjectException.class,
+                    () -> detector.readFileAtCommit(repository, commitIds[0], "f1.txt"),
+                    "readFileAtCommit on a pre-clone commit SHA should throw MissingObjectException");
+            assertTrue(
+                    ex.getMessage().contains("Missing") || ex.getMessage().contains(commitIds[0].getName()),
+                    "exception should indicate missing object");
+
+            // Now wrap in captureErr to assert the shallow guidance was logged
+            String logged = captureErr(() -> {
+                try {
+                    detector.readFileAtCommit(repository, commitIds[0], "f1.txt");
+                } catch (IOException ignored) {
+                }
+            });
+            assertTrue(
+                    logged.contains("Repository is shallow"),
+                    "MissingObjectException on a shallow repo should emit shallow cause, got: " + logged);
+            assertTrue(
+                    logged.contains("fetch-depth: 0") || logged.contains("--unshallow"),
+                    "MissingObjectException on a shallow repo should name the fix, got: " + logged);
+
+            // Test findMergeBase with a pre-clone commit passed as base branch
+            // When repository.resolve() handles a full SHA string for a missing object,
+            // parseCommit inside findMergeBase will throw MissingObjectException
+            String loggedMergeBase = captureErr(() -> {
+                try {
+                    detector.findMergeBase(repository, commitIds[0].getName(), "HEAD");
+                } catch (IOException ignored) {
+                }
+            });
+            assertTrue(
+                    loggedMergeBase.contains("Repository is shallow"),
+                    "findMergeBase MissingObjectException should emit shallow cause, got: " + loggedMergeBase);
+            assertTrue(
+                    loggedMergeBase.contains("fetch-depth: 0") || loggedMergeBase.contains("--unshallow"),
+                    "findMergeBase MissingObjectException should name the fix, got: " + loggedMergeBase);
+        }
     }
 }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ShallowCloneTest.java
@@ -104,7 +104,7 @@ class ShallowCloneTest {
         Path cloneDir = tempDir.resolve("clone");
         try (Git clone = Git.cloneRepository()
                         .setDepth(1)
-                        .setBranchesToClone(java.util.Collections.singletonList("refs/heads/main"))
+                        .setBranchesToClone(java.util.List.of("refs/heads/main"))
                         .setBranch("refs/heads/main")
                         .setURI(remoteDir.toUri().toString())
                         .setDirectory(cloneDir.toFile())
@@ -115,7 +115,9 @@ class ShallowCloneTest {
                     "setDepth(1) clone against a local path should produce .git/shallow");
             assertTrue(new GitChangeDetector().isShallow(repository));
             // the pre-clone history is genuinely absent: HEAD~1 cannot be resolved, so a
-            // merge base reaching past the shallow boundary comes back null
+            // merge base reaching past the shallow boundary comes back null. Note the second
+            // assertion below exercises the unresolvable-base guard in findMergeBase (the
+            // baseId == null early return), not isShallow itself.
             assertNull(repository.resolve("HEAD~1"), "HEAD~1 should not exist in a depth-1 clone");
             assertNull(
                     new GitChangeDetector().findMergeBase(repository, "HEAD~1", "HEAD"),
@@ -193,6 +195,11 @@ class ShallowCloneTest {
         void run() throws Exception;
     }
 
+    /**
+     * Runs {@code action} capturing everything written to {@link System#err} and returns it.
+     * This relies on the test classpath using slf4j-simple, whose default output target is
+     * System.err; the GitChangeDetector warnings are therefore observable through this stream.
+     */
     private static String captureErr(ThrowingRunnable action) throws Exception {
         PrintStream originalErr = System.err;
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();


### PR DESCRIPTION
## Problem

As filed in #95: shallow clones are the most likely production failure mode (`actions/checkout` defaults to fetch-depth 1; `findMergeBase` then returns null) and had zero coverage, even though the project's own workflows set `fetch-depth: 0` because they know about the trap. This is exactly what issue #45 was (JGitInternalException escaping failSafe on a shallow clone in a user's CI).

## Change

- New `ShallowCloneTest` with two fixtures: a real shallow clone via `Git.cloneRepository().setDepth(1)` against a local remote (JGit 7 has the depth API; verified it produces a real `.git/shallow`), plus a deterministic plumbing fixture (orphan branch + explicit shallow marker) kept for documentation. Both assert the merge base past the shallow boundary is unresolvable and detection terminates without throwing.
- `isShallow(Repository)`: JGit 7.7.1 exposes no public shallow accessor on Repository (only internal DepthWalk classes), so the `.git/shallow` marker check is the mechanism.
- Actionable WARN in `findMergeBase` when the merge base is null and the repo is shallow ("use fetch-depth: 0 in CI, or run git fetch --unshallow"), instead of silence.
- `fetchBranch` warns that the fetch is unbounded on shallow repos (FetchCommand.setDepth exists on JGit 7 but is not wired; noted in a comment).

## Verification

TDD (RED on the WARN, GREEN after), plus a review pass that corrected stale comments. Full `core` (133) + `extension3` (146) suites green; all fixtures offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of shallow Git clones when change history is incomplete.
  * Added clearer diagnostics when a merge base or historical file cannot be found.
  * Added actionable warnings explaining that additional history may be needed to restore accurate change detection.

* **Tests**
  * Added coverage for shallow clones, missing merge bases, historical file access, and full-module change detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->