### PR TITLE
Fix #89: report writes honour failSafe; every bail-out overwrites stale reports with a status document

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ is published alongside the code. The current version is **2**.
 }
 ```
 
+**Status-only reports:** when analysis does not complete (failSafe bail-out, unexpected
+error) or is deliberately skipped (no changes detected, disabled by
+`disableOnBranch`/`disableOnBaseBranch`/`disableTriggers`, or all changed files excluded
+by path filters), Scalpel overwrites the report file with a minimal status document so a
+previous run's report cannot be mistaken for current results. It carries two optional
+fields: `status` (`"failed"` or `"skipped"`) and `reason` (human-readable explanation,
+e.g. `"no changes detected"`). Both fields are absent from normal full reports.
+
 **Schema version history:**
 
 | Version | Changes |

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -32,9 +32,21 @@ public class ScalpelCore {
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final GitChangeDetector gitChangeDetector;
 
+    /**
+     * Human-readable reason when the last {@link #detectChanges} invocation deliberately skipped
+     * change detection (returned null for a non-error condition such as a disableOnBranch match),
+     * or null if the last invocation did not skip or skipped due to a failSafe bail-out.
+     * Set on each call; advisory only, so a stale value from a concurrent build is harmless.
+     */
+    private volatile String lastDetectionSkipReason;
+
     @Inject
     public ScalpelCore(GitChangeDetector gitChangeDetector) {
         this.gitChangeDetector = requireNonNull(gitChangeDetector, "gitChangeDetector");
+    }
+
+    public String getLastDetectionSkipReason() {
+        return lastDetectionSkipReason;
     }
 
     /**
@@ -48,11 +60,13 @@ public class ScalpelCore {
      */
     public ChangeDetectionResult detectChanges(Path reactorRoot, ScalpelConfiguration config, Set<String> allPomPaths)
             throws ScalpelException {
+        lastDetectionSkipReason = null;
         Repository repository;
         try {
             repository = openRepository(reactorRoot);
         } catch (RepositoryNotFoundException | IllegalArgumentException e) {
             logger.info("Scalpel: Not a git repository, building all modules");
+            lastDetectionSkipReason = "not a git repository";
             return null;
         } catch (IOException e) {
             return handleError(config, "Error opening git repository", e);
@@ -69,6 +83,7 @@ public class ScalpelCore {
                                     "Scalpel: Disabled because current branch '{}' matches pattern '{}'",
                                     currentBranch,
                                     pattern);
+                            lastDetectionSkipReason = "disabled by disableOnBranch";
                             return null;
                         }
                     }
@@ -88,6 +103,7 @@ public class ScalpelCore {
                     if (matchesSafely(baseBranchName, pattern, "disableOnBaseBranch")) {
                         logger.info(
                                 "Scalpel: Disabled because base branch '{}' matches pattern '{}'", baseBranch, pattern);
+                        lastDetectionSkipReason = "disabled by disableOnBaseBranch";
                         return null;
                     }
                 }
@@ -95,6 +111,7 @@ public class ScalpelCore {
 
             if (baseBranch == null) {
                 logger.info("Scalpel: No base branch configured or detected, building all modules");
+                lastDetectionSkipReason = "no base branch configured";
                 return null;
             }
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -50,6 +50,8 @@ public final class ScalpelReport {
     public static final String CATEGORY_TRANSITIVE = "TRANSITIVE";
 
     private final String baseBranch;
+    private final String status;
+    private final String reason;
     private final boolean fullBuildTriggered;
     private final String triggerFile;
     private final List<String> changedFiles;
@@ -61,6 +63,8 @@ public final class ScalpelReport {
 
     private ScalpelReport(
             String baseBranch,
+            String status,
+            String reason,
             boolean fullBuildTriggered,
             String triggerFile,
             List<String> changedFiles,
@@ -70,6 +74,8 @@ public final class ScalpelReport {
             List<AffectedModule> affectedModules,
             int excludedUpstreamCount) {
         this.baseBranch = baseBranch;
+        this.status = status;
+        this.reason = reason;
         this.fullBuildTriggered = fullBuildTriggered;
         this.triggerFile = triggerFile;
         this.changedFiles = changedFiles;
@@ -205,6 +211,12 @@ public final class ScalpelReport {
                 .append(jsonString(Version.version()))
                 .append(",\n");
         sb.append("  \"baseBranch\": ").append(jsonString(baseBranch)).append(",\n");
+        if (status != null) {
+            sb.append("  \"status\": ").append(jsonString(status)).append(",\n");
+        }
+        if (reason != null) {
+            sb.append("  \"reason\": ").append(jsonString(reason)).append(",\n");
+        }
         sb.append("  \"fullBuildTriggered\": ").append(fullBuildTriggered).append(",\n");
         sb.append("  \"triggerFile\": ").append(jsonString(triggerFile)).append(",\n");
         sb.append("  \"changedFiles\": ").append(jsonStringArray(changedFiles)).append(",\n");
@@ -322,6 +334,8 @@ public final class ScalpelReport {
 
     public static class Builder {
         private String baseBranch;
+        private String status;
+        private String reason;
         private boolean fullBuildTriggered;
         private String triggerFile;
         private final List<String> changedFiles = new ArrayList<>();
@@ -333,6 +347,16 @@ public final class ScalpelReport {
 
         public Builder baseBranch(String baseBranch) {
             this.baseBranch = baseBranch;
+            return this;
+        }
+
+        public Builder status(String status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder reason(String reason) {
+            this.reason = reason;
             return this;
         }
 
@@ -382,6 +406,8 @@ public final class ScalpelReport {
             }
             return new ScalpelReport(
                     baseBranch,
+                    status,
+                    reason,
                     fullBuildTriggered,
                     triggerFile,
                     changedFiles,

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -68,6 +68,15 @@
       "type": "array",
       "items": { "$ref": "#/$defs/affectedModule" },
       "description": "Modules affected by the changeset, with reasons and optional metadata."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["failed", "skipped"],
+      "description": "Present only on status-only documents written when analysis did not complete: 'failed' for error/failSafe bail-outs, 'skipped' for deliberate non-analysis paths (e.g. no changes detected, disabled by disableOnBranch/disableOnBaseBranch/disableTriggers, or all changed files excluded by path filters)."
+    },
+    "reason": {
+      "type": "string",
+      "description": "Human-readable explanation accompanying an optional status field (e.g. 'no changes detected')."
     }
   },
   "$defs": {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -129,6 +129,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // Detect changes
             ChangeDetectionResult result = scalpelCore.detectChanges(reactorRoot, config, allPomPaths);
             if (result == null) {
+                if (config.isModeReport()) {
+                    writeFailedStatusReport(config, reactorRoot, "change detection unavailable (failSafe bail-out)");
+                }
                 return;
             }
 
@@ -211,6 +214,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     if (config.isFailSafe()) {
                         logger.warn("Scalpel: Error analyzing POM changes, building all modules: {}", e.getMessage());
                         logger.debug("POM analysis error details", e);
+                        if (config.isModeReport()) {
+                            writeFailedStatusReport(config, reactorRoot, "error analyzing POM changes");
+                        }
                         return;
                     } else {
                         throw new MavenExecutionException("Scalpel: Error analyzing POM changes", e);
@@ -888,7 +894,41 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Files.write(logPath, lines, StandardCharsets.UTF_8);
             logger.info("Scalpel: Impacted modules written to {}", config.getImpactedLog());
         } catch (IOException e) {
-            throw new MavenExecutionException("Scalpel: Failed to write impacted log", e);
+            handleWriteFailure(config, "Failed to write impacted log", e);
+        }
+    }
+
+    /**
+     * Honours failSafe on report/log write failures: with failSafe=true the build continues with a
+     * warning, otherwise the write failure fails the build as before.
+     */
+    private void handleWriteFailure(ScalpelConfiguration config, String message, IOException e)
+            throws MavenExecutionException {
+        if (config.isFailSafe()) {
+            logger.warn("Scalpel: {} (failSafe=true, continuing build): {}", message, e.toString());
+        } else {
+            throw new MavenExecutionException("Scalpel: " + message, e);
+        }
+    }
+
+    /**
+     * Overwrites the configured reportFile with a minimal failed-status document so a previous
+     * run's report cannot be mistaken for current results by CI. Only called on failSafe bail-out
+     * paths; write failures here are logged and swallowed (the build continues by design).
+     */
+    private void writeFailedStatusReport(ScalpelConfiguration config, Path reactorRoot, String reason) {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch(config.getBaseBranch())
+                .status("failed")
+                .reason(reason)
+                .fullBuildTriggered(true)
+                .build();
+        try {
+            report.writeToFile(reactorRoot, config.getReportFile());
+            logger.warn(
+                    "Scalpel: Analysis failed, report at {} overwritten with failed status", config.getReportFile());
+        } catch (IOException e) {
+            logger.warn("Scalpel: Could not overwrite report with failed status: {}", e.toString());
         }
     }
 
@@ -905,7 +945,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             report.writeToFile(reactorRoot, config.getReportFile());
             logger.info("Scalpel: Report written to {}", config.getReportFile());
         } catch (IOException e) {
-            throw new MavenExecutionException("Scalpel: Failed to write report", e);
+            handleWriteFailure(config, "Failed to write report", e);
         }
     }
 
@@ -937,7 +977,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             report.writeToFile(reactorRoot, config.getReportFile());
             logger.info("Scalpel: Report written to {}", config.getReportFile());
         } catch (IOException e) {
-            throw new MavenExecutionException("Scalpel: Failed to write report", e);
+            handleWriteFailure(config, "Failed to write report", e);
         }
     }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -131,14 +131,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (result == null) {
                 if (config.isModeReport()) {
                     String skipReason = scalpelCore.getLastDetectionSkipReason();
-                    if (skipReason != null && skipReason.startsWith("disabled by")) {
+                    if (skipReason != null) {
                         writeStatusReport(config, reactorRoot, "skipped", skipReason);
                     } else {
                         writeStatusReport(
-                                config,
-                                reactorRoot,
-                                "failed",
-                                "change detection did not run (disabled or bail-out; see build log)");
+                                config, reactorRoot, "failed", "change detection did not run (see build log)");
                     }
                 }
                 return;
@@ -948,20 +945,22 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
      * continues by design).
      */
     private void writeStatusReport(ScalpelConfiguration config, Path reactorRoot, String status, String reason) {
-        ScalpelReport report = ScalpelReport.builder()
-                .baseBranch(config.getBaseBranch())
-                .status(status)
-                .reason(reason)
-                .fullBuildTriggered(true)
-                .build();
+        String baseBranch = config.getBaseBranch();
         try {
+            ScalpelReport report = ScalpelReport.builder()
+                    .baseBranch(baseBranch != null ? baseBranch : "(unconfigured)")
+                    .status(status)
+                    .reason(reason)
+                    .fullBuildTriggered(true)
+                    .build();
             report.writeToFile(reactorRoot, config.getReportFile());
             logger.warn(
                     "Scalpel: Analysis did not complete (status={}, reason={}), report at {} overwritten",
                     status,
                     reason,
                     config.getReportFile());
-        } catch (IOException e) {
+        } catch (Exception e) {
+            // Status reports must never fail the build; that is their entire job.
             logger.warn("Scalpel: Could not overwrite report with {} status: {}", status, e.toString());
         }
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -130,7 +130,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             ChangeDetectionResult result = scalpelCore.detectChanges(reactorRoot, config, allPomPaths);
             if (result == null) {
                 if (config.isModeReport()) {
-                    writeFailedStatusReport(config, reactorRoot, "change detection unavailable (failSafe bail-out)");
+                    String skipReason = scalpelCore.getLastDetectionSkipReason();
+                    if (skipReason != null && skipReason.startsWith("disabled by")) {
+                        writeStatusReport(config, reactorRoot, "skipped", skipReason);
+                    } else {
+                        writeStatusReport(
+                                config,
+                                reactorRoot,
+                                "failed",
+                                "change detection did not run (disabled or bail-out; see build log)");
+                    }
                 }
                 return;
             }
@@ -140,6 +149,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 if (config.isBuildAllIfNoChanges()) {
                     logger.info("Scalpel: No changes detected, building all modules (buildAllIfNoChanges=true)");
                 }
+                if (config.isModeReport()) {
+                    writeStatusReport(config, reactorRoot, "skipped", "no changes detected");
+                }
                 return;
             }
 
@@ -147,6 +159,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Check disable triggers (bail out entirely if any changed file matches)
             if (matchesDisableTrigger(changedFiles, config)) {
+                if (config.isModeReport()) {
+                    writeStatusReport(config, reactorRoot, "skipped", "disabled by disableTriggers match");
+                }
                 return;
             }
 
@@ -154,6 +169,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             changedFiles = filterExcludedPaths(changedFiles, config);
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: All changed files excluded by path filters, building all modules");
+                if (config.isModeReport()) {
+                    writeStatusReport(config, reactorRoot, "skipped", "all changed files excluded by path filters");
+                }
                 return;
             }
 
@@ -419,6 +437,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (config.isFailSafe()) {
                 logger.warn("Scalpel: Unexpected error, building all modules: {}", e.getMessage());
                 logger.debug("Unexpected error details", e);
+                if (config.isModeReport()) {
+                    writeFailedStatusReport(config, reactorRoot, "unexpected error: " + e.getMessage());
+                }
                 return;
             }
             throw new MavenExecutionException("Scalpel: " + e.getMessage(), e);
@@ -917,18 +938,31 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
      * paths; write failures here are logged and swallowed (the build continues by design).
      */
     private void writeFailedStatusReport(ScalpelConfiguration config, Path reactorRoot, String reason) {
+        writeStatusReport(config, reactorRoot, "failed", reason);
+    }
+
+    /**
+     * Overwrites the configured reportFile with a minimal status-only document ("failed" for
+     * bail-outs, "skipped" for deliberate non-analysis paths) so a previous run's report cannot
+     * be mistaken for current results by CI. Write failures are logged and swallowed (the build
+     * continues by design).
+     */
+    private void writeStatusReport(ScalpelConfiguration config, Path reactorRoot, String status, String reason) {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch(config.getBaseBranch())
-                .status("failed")
+                .status(status)
                 .reason(reason)
                 .fullBuildTriggered(true)
                 .build();
         try {
             report.writeToFile(reactorRoot, config.getReportFile());
             logger.warn(
-                    "Scalpel: Analysis failed, report at {} overwritten with failed status", config.getReportFile());
+                    "Scalpel: Analysis did not complete (status={}, reason={}), report at {} overwritten",
+                    status,
+                    reason,
+                    config.getReportFile());
         } catch (IOException e) {
-            logger.warn("Scalpel: Could not overwrite report with failed status: {}", e.toString());
+            logger.warn("Scalpel: Could not overwrite report with {} status: {}", status, e.toString());
         }
     }
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2750,6 +2750,84 @@ class ScalpelLifecycleParticipantTest {
         assertFalse(json.contains("\"status\": \"failed\""), "Deliberate disable must not be labelled failed");
     }
 
+    /**
+     * Review #137: baseBranch may be null (no explicit config, no CI environment) when detection
+     * bails out; the status report must still be written with a placeholder instead of crashing
+     * the build with IllegalStateException from the report builder.
+     */
+    @Test
+    void reportMode_failSafeBailout_nullBaseBranch_writesStatusReportWithPlaceholder() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        when(scalpelCore.getLastDetectionSkipReason()).thenReturn("no base branch configured");
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().remove("scalpel.baseBranch");
+        session.getSystemProperties().setProperty("scalpel.failSafe", "true");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Status report must be written even without a base branch");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"status\": \"skipped\""), "Bail-out with skip reason should be reported as skipped");
+        assertTrue(
+                json.contains("no base branch configured"), "Overwritten report should carry the actual skip reason");
+        assertTrue(json.contains("(unconfigured)"), "Placeholder base branch should be recorded");
+    }
+
+    /**
+     * Review #137: "not a git repository" is a skip (detection deliberately did not run), not a
+     * failure; the status document must say skipped with that reason.
+     */
+    @Test
+    void reportMode_notAGitRepository_writesSkippedStatusWithReason() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        when(scalpelCore.getLastDetectionSkipReason()).thenReturn("not a git repository");
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Status report should be written when detection skips");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"status\": \"skipped\""), "Not-a-git-repo should be reported as skipped");
+        assertTrue(json.contains("not a git repository"), "Reason should name the skip condition");
+        assertFalse(json.contains("\"status\": \"failed\""), "Skip condition must not be labelled failed");
+    }
+
     @Test
     void disabled_doesNothing() throws Exception {
         Path root = tempDir.resolve("project");

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2628,6 +2628,128 @@ class ScalpelLifecycleParticipantTest {
         assertFalse(modulePresent(json, "module-a"), "No module analysis should be present");
     }
 
+    /**
+     * Issue #89: with no changes detected, the stale report from a previous run must be
+     * overwritten with a skipped-status document, not left in place for CI.
+     */
+    @Test
+    void reportMode_noChanges_overwritesStaleReportWithSkippedStatus() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        Files.createDirectories(reportFile.getParent());
+        Files.write(reportFile, "STALE-REPORT".getBytes(StandardCharsets.UTF_8));
+
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(new LinkedHashSet<>(), new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        assertTrue(Files.exists(reportFile), "Report file should still exist (overwritten, not deleted)");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"status\": \"skipped\""), "Overwritten report should carry skipped status");
+        assertTrue(json.contains("no changes detected"), "Overwritten report should carry accurate reason");
+        assertFalse(json.contains("STALE-REPORT"), "Stale content must not survive the bail-out");
+    }
+
+    /**
+     * Issue #89: when every changed file is excluded by path filters, the stale report from a
+     * previous run must be overwritten with a skipped-status document, not left in place for CI.
+     */
+    @Test
+    void reportMode_allPathsExcluded_overwritesStaleReportWithSkippedStatus() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        Files.createDirectories(reportFile.getParent());
+        Files.write(reportFile, "STALE-REPORT".getBytes(StandardCharsets.UTF_8));
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("docs/guide.md");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "docs/**");
+
+        participant.afterProjectsRead(session);
+
+        assertTrue(Files.exists(reportFile), "Report file should still exist (overwritten, not deleted)");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"status\": \"skipped\""), "Overwritten report should carry skipped status");
+        assertTrue(
+                json.contains("all changed files excluded by path filters"),
+                "Overwritten report should carry accurate reason");
+        assertFalse(json.contains("STALE-REPORT"), "Stale content must not survive the bail-out");
+    }
+
+    /**
+     * Issue #89: when detection was deliberately disabled (disableOnBranch/disableOnBaseBranch),
+     * the status document must say skipped with that reason, not failed.
+     */
+    @Test
+    void reportMode_disabledByBranch_writesSkippedStatus() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        when(scalpelCore.getLastDetectionSkipReason()).thenReturn("disabled by disableOnBranch");
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Status report should be written when detection is disabled");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"status\": \"skipped\""), "Deliberate disable should be reported as skipped");
+        assertTrue(json.contains("disabled by disableOnBranch"), "Reason should name the disabling config");
+        assertFalse(json.contains("\"status\": \"failed\""), "Deliberate disable must not be labelled failed");
+    }
+
     @Test
     void disabled_doesNothing() throws Exception {
         Path root = tempDir.resolve("project");

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2490,6 +2490,111 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(json.contains("\"fullBuildTriggered\": true"), "Full build should be triggered");
     }
 
+    /**
+     * Issue #89: with scalpel.failSafe=true, an unwritable reportFile must not fail the build.
+     * "target" is created as a regular file so that target/scalpel-report.json cannot be written.
+     */
+    @Test
+    void reportMode_failSafeTrue_unwritableReportFile_doesNotThrow() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.failSafe", "true");
+        // Make the report location unwritable: "target" exists as a regular file
+        Files.write(root.resolve("target"), new byte[0]);
+
+        participant.afterProjectsRead(session);
+    }
+
+    @Test
+    void reportMode_failSafeFalse_unwritableReportFile_throws() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.failSafe", "false");
+        Files.write(root.resolve("target"), new byte[0]);
+
+        assertThrows(org.apache.maven.MavenExecutionException.class, () -> participant.afterProjectsRead(session));
+    }
+
+    /**
+     * Issue #89: when analysis bails out (detectChanges returns null under failSafe), a previous
+     * run's report must be overwritten with a failed-status document, not left stale for CI.
+     */
+    @Test
+    void reportMode_failSafeBailout_overwritesStaleReport() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        // Stale report from a previous successful run
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        Files.createDirectories(reportFile.getParent());
+        Files.write(reportFile, "STALE-REPORT".getBytes(StandardCharsets.UTF_8));
+
+        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.failSafe", "true");
+
+        participant.afterProjectsRead(session);
+
+        assertTrue(Files.exists(reportFile), "Report file should still exist (overwritten, not deleted)");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"status\": \"failed\""), "Overwritten report should carry failed status");
+        assertFalse(json.contains("STALE-REPORT"), "Stale content must not survive the bail-out");
+    }
+
     @Test
     void reportMode_nullDetectionResultSkipsProcessing() throws Exception {
         Path root = tempDir.resolve("project");

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2620,9 +2620,12 @@ class ScalpelLifecycleParticipantTest {
 
         participant.afterProjectsRead(session);
 
-        // No report should be written when detection returns null
+        // Analysis bailed out: a failed-status report must be written so no stale data survives
         Path reportFile = root.resolve("target/scalpel-report.json");
-        assertFalse(Files.exists(reportFile), "Report file should not be created when detection returns null");
+        assertTrue(Files.exists(reportFile), "Failed-status report should be written when detection returns null");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"status\": \"failed\""), "Report should carry failed status");
+        assertFalse(modulePresent(json, "module-a"), "No module analysis should be present");
     }
 
     @Test


### PR DESCRIPTION
## Problem

As filed in #89, two hazards in the report-mode failure path:

1. **Writes ignored failSafe.** The report and impacted-log write sites threw `MavenExecutionException` unconditionally, so a read-only `target/` failed the build even with `scalpel.failSafe=true`.
2. **Stale reports survived.** Every bail-out path returned before writing, so on a reused workspace CI kept reading the previous run's `target/scalpel-report.json` as if current - including the most common path of all: a run with no changes.

## Change

- `handleWriteFailure`: with failSafe=true a write failure WARNs and the build continues; with failSafe=false it throws as before. Covers the JSON report, the full-build report and the impacted log.
- Every report-mode bail-out now overwrites the configured reportFile with a minimal status document instead of leaving the previous run's file: new optional `status` (failed/skipped) and `reason` fields. `ScalpelCore` records why detection did not run, so deliberate conditions (`disableOnBranch`/`disableOnBaseBranch` match, not a git repo, no base branch) are reported as `status:"skipped"` with the exact reason, while genuine failures (failSafe bail-outs, unexpected exceptions) are `status:"failed"`. No-changes, all-excluded and disableTriggers paths get accurate skipped reasons too.
- Schema (`scalpel-report-v2.schema.json`) and README document the optional status/reason fields; additive only, no version bump per the #60 policy.

**Deliberate behavior changes** (flagging explicitly): report mode now ALWAYS produces a report file at the configured path (status document at minimum) - code relying on "no report file = nothing detected" must read `status` instead; one existing test was updated accordingly.

## Verification

TDD across three commits (RED failSafe/stale-report tests, GREEN implementation, review follow-up covering the disable-reason routing and the remaining bail-outs). Full suites green (core 129, extension3 152).