### PR TITLE
Fix #90: warn and report changed POMs that match no reactor project

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -56,6 +56,7 @@ public final class ScalpelReport {
     private final List<String> changedProperties;
     private final List<String> changedManagedDependencies;
     private final List<String> changedManagedPlugins;
+    private final List<String> unmatchedPomPaths;
     private final List<AffectedModule> affectedModules;
     private final int excludedUpstreamCount;
 
@@ -67,6 +68,7 @@ public final class ScalpelReport {
             List<String> changedProperties,
             List<String> changedManagedDependencies,
             List<String> changedManagedPlugins,
+            List<String> unmatchedPomPaths,
             List<AffectedModule> affectedModules,
             int excludedUpstreamCount) {
         this.baseBranch = baseBranch;
@@ -76,6 +78,7 @@ public final class ScalpelReport {
         this.changedProperties = changedProperties;
         this.changedManagedDependencies = changedManagedDependencies;
         this.changedManagedPlugins = changedManagedPlugins;
+        this.unmatchedPomPaths = unmatchedPomPaths;
         this.affectedModules = affectedModules;
         this.excludedUpstreamCount = excludedUpstreamCount;
     }
@@ -217,6 +220,11 @@ public final class ScalpelReport {
         sb.append("  \"changedManagedPlugins\": ")
                 .append(jsonStringArray(changedManagedPlugins))
                 .append(",\n");
+        if (unmatchedPomPaths != null && !unmatchedPomPaths.isEmpty()) {
+            sb.append("  \"unmatchedPomPaths\": ")
+                    .append(jsonStringArray(unmatchedPomPaths))
+                    .append(",\n");
+        }
         sb.append("  \"excludedUpstreamCount\": ").append(excludedUpstreamCount).append(",\n");
         sb.append("  \"affectedModules\": ");
         if (affectedModules.isEmpty()) {
@@ -328,6 +336,7 @@ public final class ScalpelReport {
         private final List<String> changedProperties = new ArrayList<>();
         private final List<String> changedManagedDependencies = new ArrayList<>();
         private final List<String> changedManagedPlugins = new ArrayList<>();
+        private final List<String> unmatchedPomPaths = new ArrayList<>();
         private final List<AffectedModule> affectedModules = new ArrayList<>();
         private int excludedUpstreamCount;
 
@@ -366,6 +375,11 @@ public final class ScalpelReport {
             return this;
         }
 
+        public Builder unmatchedPomPaths(Collection<String> paths) {
+            this.unmatchedPomPaths.addAll(paths);
+            return this;
+        }
+
         public Builder addAffectedModule(AffectedModule module) {
             this.affectedModules.add(module);
             return this;
@@ -388,6 +402,7 @@ public final class ScalpelReport {
                     changedProperties,
                     changedManagedDependencies,
                     changedManagedPlugins,
+                    unmatchedPomPaths,
                     affectedModules,
                     excludedUpstreamCount);
         }

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -59,6 +59,11 @@
       "items": { "type": "string" },
       "description": "Coordinates (groupId:artifactId) of managed plugins whose version or configuration changed in the root POM."
     },
+    "unmatchedPomPaths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional. Git-relative paths of changed POMs that match no reactor project (profile-gated modules or modules excluded via -pl). Their changes are ignored by Scalpel. Present only when non-empty."
+    },
     "excludedUpstreamCount": {
       "type": "integer",
       "minimum": 0,

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -459,6 +459,31 @@ class ScalpelReportTest {
     }
 
     @Test
+    void toJson_unmatchedPomPathsIncludedWhenSet() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("gated-module/pom.xml"))
+                .unmatchedPomPaths(List.of("gated-module/pom.xml"))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"unmatchedPomPaths\": [\"gated-module/pom.xml\"]"));
+    }
+
+    @Test
+    void toJson_unmatchedPomPathsOmittedWhenEmpty() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("module-a/pom.xml"))
+                .build();
+
+        String json = report.toJson();
+        assertFalse(json.contains("unmatchedPomPaths"));
+    }
+
+    @Test
     void jsonSchema_isOnClasspath() throws IOException {
         try (InputStream is =
                 getClass().getResourceAsStream("/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json")) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
@@ -21,6 +21,7 @@ final class AnalysisContext {
     final Set<String> changedProperties;
     final Set<String> changedManagedDepGAs;
     final Set<String> changedManagedPluginGAs;
+    final Set<String> unmatchedPomPaths;
     final Set<MavenProject> directlyAffected;
     final Set<MavenProject> affectedBySource;
     final Set<MavenProject> testOnlyBySource;
@@ -34,6 +35,7 @@ final class AnalysisContext {
         this.changedProperties = builder.changedProperties;
         this.changedManagedDepGAs = builder.changedManagedDepGAs;
         this.changedManagedPluginGAs = builder.changedManagedPluginGAs;
+        this.unmatchedPomPaths = builder.unmatchedPomPaths;
         this.directlyAffected = builder.directlyAffected;
         this.affectedBySource = builder.affectedBySource;
         this.testOnlyBySource = builder.testOnlyBySource;
@@ -70,6 +72,7 @@ final class AnalysisContext {
         private Set<String> changedProperties;
         private Set<String> changedManagedDepGAs;
         private Set<String> changedManagedPluginGAs;
+        private Set<String> unmatchedPomPaths = Set.of();
         private Set<MavenProject> directlyAffected = Set.of();
         private Set<MavenProject> affectedBySource = Set.of();
         private Set<MavenProject> testOnlyBySource = Set.of();
@@ -79,6 +82,11 @@ final class AnalysisContext {
         private TrimResult trimResult;
 
         private Builder() {}
+
+        Builder unmatchedPomPaths(Set<String> unmatchedPomPaths) {
+            this.unmatchedPomPaths = unmatchedPomPaths;
+            return this;
+        }
 
         Builder directlyAffected(Set<MavenProject> directlyAffected) {
             this.directlyAffected = directlyAffected;

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -57,16 +57,19 @@ class PomChangeAnalyzer {
         private final Set<String> changedManagedDependencyGAs;
         private final Set<String> changedManagedPluginGAs;
         private final Set<String> changedProperties;
+        private final List<String> unmatchedPomPaths;
 
         Result(
                 Set<MavenProject> affectedProjects,
                 Set<String> changedManagedDependencyGAs,
                 Set<String> changedManagedPluginGAs,
-                Set<String> changedProperties) {
+                Set<String> changedProperties,
+                List<String> unmatchedPomPaths) {
             this.affectedProjects = affectedProjects;
             this.changedManagedDependencyGAs = changedManagedDependencyGAs;
             this.changedManagedPluginGAs = changedManagedPluginGAs;
             this.changedProperties = changedProperties;
+            this.unmatchedPomPaths = unmatchedPomPaths;
         }
 
         Set<MavenProject> getAffectedProjects() {
@@ -83,6 +86,10 @@ class PomChangeAnalyzer {
 
         Set<String> getChangedProperties() {
             return changedProperties;
+        }
+
+        List<String> getUnmatchedPomPaths() {
+            return unmatchedPomPaths;
         }
     }
 
@@ -120,6 +127,7 @@ class PomChangeAnalyzer {
         Set<String> allChangedManagedDepGAs = new LinkedHashSet<>();
         Set<String> allChangedManagedPluginGAs = new LinkedHashSet<>();
         Set<String> allChangedProperties = new LinkedHashSet<>();
+        List<String> unmatchedPomPaths = new ArrayList<>();
 
         // Build a map of relative POM path -> MavenProject
         Map<String, MavenProject> projectByPomPath = new LinkedHashMap<>();
@@ -138,6 +146,7 @@ class PomChangeAnalyzer {
         for (String changedPomPath : changedPomPaths) {
             MavenProject project = projectByPomPath.get(changedPomPath);
             if (project == null) {
+                unmatchedPomPaths.add(changedPomPath);
                 logger.debug("Changed POM {} does not match any reactor project, skipping", changedPomPath);
                 continue;
             }
@@ -186,13 +195,21 @@ class PomChangeAnalyzer {
             }
         }
 
+        if (!unmatchedPomPaths.isEmpty()) {
+            logger.warn(
+                    "Scalpel: {} changed POM(s) match no reactor project (profile-gated or excluded by -pl); "
+                            + "their changes are ignored: {}",
+                    unmatchedPomPaths.size(),
+                    unmatchedPomPaths);
+        }
         logger.debug(
                 "POM change analysis complete: {} affected modules, changedProperties={}, changedManagedDeps={}, changedManagedPlugins={}",
                 affected.size(),
                 allChangedProperties,
                 allChangedManagedDepGAs,
                 allChangedManagedPluginGAs);
-        return new Result(affected, allChangedManagedDepGAs, allChangedManagedPluginGAs, allChangedProperties);
+        return new Result(
+                affected, allChangedManagedDepGAs, allChangedManagedPluginGAs, allChangedProperties, unmatchedPomPaths);
     }
 
     private void analyzeParentPomChange(

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -197,8 +197,8 @@ class PomChangeAnalyzer {
 
         if (!unmatchedPomPaths.isEmpty()) {
             logger.warn(
-                    "Scalpel: {} changed POM(s) match no reactor project (profile-gated or excluded by -pl); "
-                            + "their changes are ignored: {}",
+                    "Scalpel: {} changed POM(s) match no reactor project (profile-gated, excluded by -pl, "
+                            + "or module removed); their changes are ignored: {}",
                     unmatchedPomPaths.size(),
                     unmatchedPomPaths);
         }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -194,6 +194,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedDepGAs = new LinkedHashSet<>();
             Set<String> changedManagedPluginGAs = new LinkedHashSet<>();
             Set<String> changedProperties = new LinkedHashSet<>();
+            Set<String> unmatchedPomPaths = new LinkedHashSet<>();
             if (!pomChanges.isEmpty()) {
                 logger.debug("POM changes detected: {}", pomChanges);
                 try {
@@ -207,6 +208,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     changedManagedDepGAs = pomResult.getChangedManagedDependencyGAs();
                     changedManagedPluginGAs = pomResult.getChangedManagedPluginGAs();
                     changedProperties = pomResult.getChangedProperties();
+                    unmatchedPomPaths.addAll(pomResult.getUnmatchedPomPaths());
                 } catch (Exception e) {
                     if (config.isFailSafe()) {
                         logger.warn("Scalpel: Error analyzing POM changes, building all modules: {}", e.getMessage());
@@ -362,6 +364,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         reactorRoot,
                         AnalysisContext.builder(
                                         changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
+                                .unmatchedPomPaths(unmatchedPomPaths)
                                 .directlyAffected(directlyAffected)
                                 .affectedBySource(affectedBySource)
                                 .testOnlyBySource(sourceResult.getTestOnlyAffected())
@@ -917,7 +920,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .changedFiles(ctx.changedFiles)
                 .changedProperties(ctx.changedProperties)
                 .changedManagedDependencies(ctx.changedManagedDepGAs)
-                .changedManagedPlugins(ctx.changedManagedPluginGAs);
+                .changedManagedPlugins(ctx.changedManagedPluginGAs)
+                .unmatchedPomPaths(ctx.unmatchedPomPaths);
 
         logger.debug(
                 "Building report: {} directly affected, {} transitively affected, trim result has {} upstream / {} downstream / {} downstream-test",

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -1736,6 +1737,38 @@ class PomChangeAnalyzerTest {
                 analyzer.analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
 
         assertTrue(affected.isEmpty(), "Unmatched POM path should not affect any module");
+    }
+
+    @Test
+    void analyzeChanges_unmatchedPomCollectedInResult() throws Exception {
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createSimpleReactor(root);
+
+        Set<String> changedPoms = new LinkedHashSet<>();
+        changedPoms.add("nonexistent/pom.xml");
+        changedPoms.add("also-missing/pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertEquals(
+                List.of("nonexistent/pom.xml", "also-missing/pom.xml"),
+                result.getUnmatchedPomPaths(),
+                "Unmatched changed POM paths should be exposed on the Result");
+        assertTrue(result.getAffectedProjects().isEmpty(), "Unmatched POM paths should not affect any module");
+    }
+
+    @Test
+    void analyzeChanges_matchedPomsLeaveUnmatchedListEmpty() throws Exception {
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createSimpleReactor(root);
+
+        Set<String> changedPoms = Set.of("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+
+        PomChangeAnalyzer.Result result = analyzer.analyzeChanges(changedPoms, oldPoms, projects, root);
+
+        assertTrue(result.getUnmatchedPomPaths().isEmpty(), "All changed POMs matched a reactor project");
     }
 
     // --- Import-scope BOM detection tests ---


### PR DESCRIPTION
## Problem

As filed in #90: a changed `pom.xml` whose path matches no reactor project is dropped with only a debug log. That is correct for a deleted module, but a module present in `<modules>` yet absent from `session.getProjects()` (profile-gated, or `-pl` with `disableOnSelectedProjects=false` default) has its POM change silently ignored - the adopter sees Scalpel working, sees the POM changed, and the change simply does not participate in the analysis.

## Change

- `PomChangeAnalyzer` collects unmatched changed POM paths into `Result.unmatchedPomPaths` and emits a single WARN with the count and paths (naming the three causes: profile-gated, `-pl`-excluded, or removed module).
- `ScalpelReport` gains an optional `unmatchedPomPaths` array (additive, emitted only when non-empty, no version bump per the #60 policy); the participant wires it through; the checked-in `scalpel-report-v2.schema.json` documents it as optional.

## Verification

TDD: RED first (tests failing to compile against the missing API), then the implementation, then a review pass on the WARN wording. Full `core` (131) + `extension3` (148) suites green, including the golden-report comparison (field omitted when empty).