### PR TITLE
Fix #91: report skipped modules with reasons

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -44,6 +44,12 @@ public final class ScalpelReport {
     public static final String REASON_TRANSITIVE_DEPENDENCY_TEST = "TRANSITIVE_DEPENDENCY_TEST";
     public static final String REASON_EXCLUDED_DOWNSTREAM = "EXCLUDED_DOWNSTREAM";
 
+    /**
+     * Skip reason for a reactor module that was left out of the build set because it is
+     * not affected by the changeset (not direct, transitive, upstream or downstream).
+     */
+    public static final String SKIP_REASON_NOT_AFFECTED = "NOT_AFFECTED";
+
     public static final String CATEGORY_DIRECT = "DIRECT";
     public static final String CATEGORY_UPSTREAM = "UPSTREAM";
     public static final String CATEGORY_DOWNSTREAM = "DOWNSTREAM";
@@ -57,6 +63,7 @@ public final class ScalpelReport {
     private final List<String> changedManagedDependencies;
     private final List<String> changedManagedPlugins;
     private final List<AffectedModule> affectedModules;
+    private final List<SkippedModule> skippedModules;
     private final int excludedUpstreamCount;
 
     private ScalpelReport(
@@ -68,6 +75,7 @@ public final class ScalpelReport {
             List<String> changedManagedDependencies,
             List<String> changedManagedPlugins,
             List<AffectedModule> affectedModules,
+            List<SkippedModule> skippedModules,
             int excludedUpstreamCount) {
         this.baseBranch = baseBranch;
         this.fullBuildTriggered = fullBuildTriggered;
@@ -77,6 +85,7 @@ public final class ScalpelReport {
         this.changedManagedDependencies = changedManagedDependencies;
         this.changedManagedPlugins = changedManagedPlugins;
         this.affectedModules = affectedModules;
+        this.skippedModules = skippedModules;
         this.excludedUpstreamCount = excludedUpstreamCount;
     }
 
@@ -197,6 +206,40 @@ public final class ScalpelReport {
         }
     }
 
+    /**
+     * A reactor module that was left out of the build set, with the reason it was judged
+     * safe to skip. Enumerating this set is what makes a green trimmed build reviewable.
+     */
+    public static final class SkippedModule {
+        private final String groupId;
+        private final String artifactId;
+        private final String path;
+        private final String reason;
+
+        public SkippedModule(String groupId, String artifactId, String path, String reason) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+            this.path = path;
+            this.reason = reason;
+        }
+
+        public String getGroupId() {
+            return groupId;
+        }
+
+        public String getArtifactId() {
+            return artifactId;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public String getReason() {
+            return reason;
+        }
+    }
+
     public String toJson() {
         StringBuilder sb = new StringBuilder();
         sb.append("{\n");
@@ -232,8 +275,29 @@ public final class ScalpelReport {
             }
             sb.append("  ]");
         }
+        if (!skippedModules.isEmpty()) {
+            sb.append(",\n");
+            sb.append("  \"skippedModules\": [\n");
+            for (int i = 0; i < skippedModules.size(); i++) {
+                appendSkippedModuleJson(sb, skippedModules.get(i));
+                if (i < skippedModules.size() - 1) {
+                    sb.append(",");
+                }
+                sb.append("\n");
+            }
+            sb.append("  ]");
+        }
         sb.append("\n}\n");
         return sb.toString();
+    }
+
+    private static void appendSkippedModuleJson(StringBuilder sb, SkippedModule m) {
+        sb.append("    {\n");
+        sb.append("      \"groupId\": ").append(jsonString(m.groupId)).append(",\n");
+        sb.append("      \"artifactId\": ").append(jsonString(m.artifactId)).append(",\n");
+        sb.append("      \"path\": ").append(jsonString(m.path)).append(",\n");
+        sb.append("      \"reason\": ").append(jsonString(m.reason)).append("\n");
+        sb.append("    }");
     }
 
     private static void appendModuleJson(StringBuilder sb, AffectedModule m) {
@@ -329,6 +393,7 @@ public final class ScalpelReport {
         private final List<String> changedManagedDependencies = new ArrayList<>();
         private final List<String> changedManagedPlugins = new ArrayList<>();
         private final List<AffectedModule> affectedModules = new ArrayList<>();
+        private final List<SkippedModule> skippedModules = new ArrayList<>();
         private int excludedUpstreamCount;
 
         public Builder baseBranch(String baseBranch) {
@@ -371,6 +436,11 @@ public final class ScalpelReport {
             return this;
         }
 
+        public Builder addSkippedModule(SkippedModule module) {
+            this.skippedModules.add(module);
+            return this;
+        }
+
         public Builder excludedUpstreamCount(int count) {
             this.excludedUpstreamCount = count;
             return this;
@@ -389,6 +459,7 @@ public final class ScalpelReport {
                     changedManagedDependencies,
                     changedManagedPlugins,
                     affectedModules,
+                    skippedModules,
                     excludedUpstreamCount);
         }
     }

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -68,6 +68,11 @@
       "type": "array",
       "items": { "$ref": "#/$defs/affectedModule" },
       "description": "Modules affected by the changeset, with reasons and optional metadata."
+    },
+    "skippedModules": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/skippedModule" },
+      "description": "Optional (added without a version bump per the optional-fields policy): reactor modules left out of the build set, each with the reason it was judged safe to skip. Present only when at least one module was skipped."
     }
   },
   "$defs": {
@@ -125,6 +130,29 @@
         "testsSkippedReason": {
           "type": "string",
           "description": "Why tests were skipped on this module (e.g. 'EXCLUDED_DOWNSTREAM' for downstream modules not in the test scope)."
+        }
+      }
+    },
+    "skippedModule": {
+      "type": "object",
+      "required": ["groupId", "artifactId", "path", "reason"],
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Maven groupId of the skipped module."
+        },
+        "artifactId": {
+          "type": "string",
+          "description": "Maven artifactId of the skipped module."
+        },
+        "path": {
+          "type": "string",
+          "description": "Reactor-relative path of the module directory."
+        },
+        "reason": {
+          "type": "string",
+          "enum": ["NOT_AFFECTED"],
+          "description": "Why the module was left out of the build set. NOT_AFFECTED: not affected by the changeset (not direct, transitive, upstream or downstream of any change)."
         }
       }
     }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -45,6 +45,38 @@ class ScalpelReportTest {
     }
 
     @Test
+    void toJson_skippedModuleListedWithReason() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("module-a/src/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE)))
+                .addSkippedModule(new ScalpelReport.SkippedModule(
+                        "com.example", "module-b", "module-b", ScalpelReport.SKIP_REASON_NOT_AFFECTED))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"skippedModules\""), "skippedModules array must be present");
+        assertTrue(json.contains("\"NOT_AFFECTED\""), "skip reason must be serialized");
+        assertTrue(json.contains("\"module-b\""), "skipped module artifactId must be serialized");
+    }
+
+    @Test
+    void toJson_skippedModulesOmittedWhenNothingSkipped() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("module-a/src/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE)))
+                .build();
+
+        String json = report.toJson();
+        assertFalse(json.contains("\"skippedModules\""), "skippedModules must be omitted when nothing is skipped");
+    }
+
+    @Test
     void toJson_transitivelyAffectedModule() {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
@@ -28,6 +28,11 @@ final class AnalysisContext {
     final Set<MavenProject> forceIncluded;
     final Map<MavenProject, List<String>> transitivelyAffected;
     final TrimResult trimResult;
+    /**
+     * The final build set actually passed to {@code session.setProjects()}, after
+     * includePaths filtering. Null when not in trim mode or when includePaths is empty.
+     */
+    final List<MavenProject> filteredBuildSet;
 
     private AnalysisContext(Builder builder) {
         this.changedFiles = builder.changedFiles;
@@ -41,6 +46,7 @@ final class AnalysisContext {
         this.forceIncluded = builder.forceIncluded;
         this.transitivelyAffected = builder.transitivelyAffected;
         this.trimResult = builder.trimResult;
+        this.filteredBuildSet = builder.filteredBuildSet;
     }
 
     static Builder builder(
@@ -77,6 +83,7 @@ final class AnalysisContext {
         private Set<MavenProject> forceIncluded = Set.of();
         private Map<MavenProject, List<String>> transitivelyAffected = Map.of();
         private TrimResult trimResult;
+        private List<MavenProject> filteredBuildSet;
 
         private Builder() {}
 
@@ -112,6 +119,11 @@ final class AnalysisContext {
 
         Builder trimResult(TrimResult trimResult) {
             this.trimResult = trimResult;
+            return this;
+        }
+
+        Builder filteredBuildSet(List<MavenProject> filteredBuildSet) {
+            this.filteredBuildSet = filteredBuildSet;
             return this;
         }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -424,6 +424,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .forceIncluded(forceIncluded)
                                 .transitivelyAffected(transitivelyAffected)
                                 .trimResult(trimResult)
+                                .filteredBuildSet(buildSet)
                                 .build());
             }
 
@@ -974,7 +975,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         Set<MavenProject> included = new LinkedHashSet<>(ctx.directlyAffected);
         included.addAll(ctx.transitivelyAffected.keySet());
         if (ctx.trimResult != null) {
-            included.addAll(ctx.trimResult.getBuildSet());
+            // Use the filtered build set when available (trim mode with includePaths),
+            // so modules removed by the includePaths scope check appear in skippedModules.
+            if (ctx.filteredBuildSet != null) {
+                included.addAll(ctx.filteredBuildSet);
+            } else {
+                included.addAll(ctx.trimResult.getBuildSet());
+            }
         }
         for (MavenProject project : allProjects) {
             if (!included.contains(project)) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -260,6 +260,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     writeReport(
                             config,
                             reactorRoot,
+                            allProjects,
                             AnalysisContext.empty(
                                     changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs));
                 } else if (config.isModeSkipTests()) {
@@ -293,6 +294,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     writeReport(
                             config,
                             reactorRoot,
+                            allProjects,
                             AnalysisContext.empty(
                                     changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs));
                 } else if (config.isModeSkipTests()) {
@@ -331,6 +333,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         writeReport(
                                 config,
                                 reactorRoot,
+                                allProjects,
                                 AnalysisContext.empty(
                                         changedFiles,
                                         changedProperties,
@@ -360,6 +363,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 writeReport(
                         config,
                         reactorRoot,
+                        allProjects,
                         AnalysisContext.builder(
                                         changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
                                 .directlyAffected(directlyAffected)
@@ -405,6 +409,22 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 session.setProjects(buildSet);
                 // Apply per-category args in trim mode
                 applyPerCategoryArgs(trimResult, config);
+                // Write the same JSON report as report mode, so the skipped set (allProjects
+                // minus buildSet) is reviewable alongside the green trimmed build (#91)
+                writeReport(
+                        config,
+                        reactorRoot,
+                        allProjects,
+                        AnalysisContext.builder(
+                                        changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
+                                .directlyAffected(directlyAffected)
+                                .affectedBySource(affectedBySource)
+                                .testOnlyBySource(sourceResult.getTestOnlyAffected())
+                                .affectedByPom(affectedByPom)
+                                .forceIncluded(forceIncluded)
+                                .transitivelyAffected(transitivelyAffected)
+                                .trimResult(trimResult)
+                                .build());
             }
 
         } catch (ScalpelException e) {
@@ -909,7 +929,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private void writeReport(ScalpelConfiguration config, Path reactorRoot, AnalysisContext ctx)
+    private void writeReport(
+            ScalpelConfiguration config, Path reactorRoot, List<MavenProject> allProjects, AnalysisContext ctx)
             throws MavenExecutionException {
         ScalpelReport.Builder builder = ScalpelReport.builder()
                 .baseBranch(config.getBaseBranch())
@@ -931,6 +952,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         addTransitivelyAffectedModules(builder, ctx, config, reactorRoot);
         int excludedUpstream = addTrimResultModules(builder, ctx, config, reactorRoot);
         builder.excludedUpstreamCount(excludedUpstream);
+        addSkippedModules(builder, allProjects, ctx, reactorRoot);
 
         try {
             ScalpelReport report = builder.build();
@@ -938,6 +960,28 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             logger.info("Scalpel: Report written to {}", config.getReportFile());
         } catch (IOException e) {
             throw new MavenExecutionException("Scalpel: Failed to write report", e);
+        }
+    }
+
+    /**
+     * Enumerates reactor modules that were left out of the build set, so a reviewer of a
+     * green trimmed build can see exactly what was skipped and why. A module is skipped
+     * when it is neither directly nor transitively affected, and not part of the trim
+     * build set (upstream prerequisites and downstream dependents are built, not skipped).
+     */
+    private void addSkippedModules(
+            ScalpelReport.Builder builder, List<MavenProject> allProjects, AnalysisContext ctx, Path reactorRoot) {
+        Set<MavenProject> included = new LinkedHashSet<>(ctx.directlyAffected);
+        included.addAll(ctx.transitivelyAffected.keySet());
+        if (ctx.trimResult != null) {
+            included.addAll(ctx.trimResult.getBuildSet());
+        }
+        for (MavenProject project : allProjects) {
+            if (!included.contains(project)) {
+                String path = relativePath(reactorRoot, project);
+                builder.addSkippedModule(new ScalpelReport.SkippedModule(
+                        project.getGroupId(), project.getArtifactId(), path, ScalpelReport.SKIP_REASON_NOT_AFFECTED));
+            }
         }
     }
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -2534,6 +2534,63 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void trimMode_includePathsScopeExcludedModuleAppearsInSkippedModules() throws Exception {
+        // module-a has source changes and matches includePaths.
+        // module-b depends on module-a (downstream) but is outside includePaths.
+        // module-b must appear in skippedModules (NOT_AFFECTED) and NOT in affectedModules.
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPomWithDep("module-b", "module-a");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        // Set up dependency graph: module-b is downstream of module-a
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        ProjectDependencyGraph graph = session.getProjectDependencyGraph();
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        session.getSystemProperties().setProperty("scalpel.includePaths", "module-a/**");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "trim mode should write the JSON report");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // module-b was removed from the trimmed reactor by includePaths:
+        // it must appear in skippedModules with NOT_AFFECTED
+        assertTrue(
+                skippedModuleHasReason(json, "module-b", "NOT_AFFECTED"),
+                "module-b should be in skippedModules with NOT_AFFECTED (downstream but outside includePaths)");
+        // module-a should NOT be in skippedModules (it is in the build set)
+        assertFalse(
+                skippedModulePresent(json, "module-a"),
+                "module-a should NOT be in skippedModules (it is in the filtered build set)");
+        // module-b should NOT be in affectedModules (filtered by report-side includePaths)
+        assertFalse(
+                modulePresent(json, "module-b"), "module-b should NOT be in affectedModules (outside includePaths)");
+    }
+
+    @Test
     void reportMode_includePathsExcludesDownstreamOutsideScope() throws Exception {
         // module-a has source changes and matches includePaths.
         // module-b depends on module-a (downstream) but is outside includePaths.

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -936,6 +936,137 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void trimMode_reportListsSkippedModulesWithNotAffectedReason() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "trim mode should write the JSON report");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+
+        // module-b was trimmed out of the build: it must be enumerated with a reason
+        assertTrue(json.contains("\"skippedModules\""), "report must contain skippedModules array");
+        assertTrue(
+                skippedModuleHasReason(json, "module-b", "NOT_AFFECTED"),
+                "module-b should be in skippedModules with NOT_AFFECTED");
+        // the affected module must not appear in the skipped set
+        assertFalse(
+                skippedModulePresent(json, "module-a"),
+                "module-a should NOT be in skippedModules (it is in the build set)");
+    }
+
+    @Test
+    void trimMode_reportOmitsSkippedModulesWhenNothingSkipped() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        // module-a is directly affected; the parent is force-included so nothing is skipped
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.forceBuildModules", "parent");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "trim mode should write the JSON report");
+
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertFalse(json.contains("\"skippedModules\""), "skippedModules must be omitted when nothing is skipped");
+    }
+
+    private boolean skippedModulePresent(String json, String artifactId) {
+        String skippedSection = extractSection(json, "skippedModules");
+        return skippedSection != null && skippedSection.contains("\"artifactId\": \"" + artifactId + "\"");
+    }
+
+    private boolean skippedModuleHasReason(String json, String artifactId, String reason) {
+        String skippedSection = extractSection(json, "skippedModules");
+        if (skippedSection == null) {
+            return false;
+        }
+        String marker = "\"artifactId\": \"" + artifactId + "\"";
+        int idx = skippedSection.indexOf(marker);
+        if (idx < 0) {
+            return false;
+        }
+        int end = skippedSection.indexOf("}", idx);
+        if (end < 0) {
+            return false;
+        }
+        return skippedSection
+                .substring(idx, end)
+                .contains("\"reason\": \"" + reason + "\"");
+    }
+
+    private String extractSection(String json, String sectionName) {
+        int start = json.indexOf("\"" + sectionName + "\":");
+        if (start < 0) {
+            return null;
+        }
+        int bracketStart = json.indexOf("[", start);
+        if (bracketStart < 0) {
+            return null;
+        }
+        int depth = 0;
+        for (int i = bracketStart; i < json.length(); i++) {
+            if (json.charAt(i) == '[') {
+                depth++;
+            }
+            if (json.charAt(i) == ']') {
+                depth--;
+            }
+            if (depth == 0) {
+                return json.substring(bracketStart, i + 1);
+            }
+        }
+        return null;
+    }
+
+    @Test
     void skipTestsMode_skipsUnaffectedModules() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -1037,9 +1037,7 @@ class ScalpelLifecycleParticipantTest {
         if (end < 0) {
             return false;
         }
-        return skippedSection
-                .substring(idx, end)
-                .contains("\"reason\": \"" + reason + "\"");
+        return skippedSection.substring(idx, end).contains("\"reason\": \"" + reason + "\"");
     }
 
     private String extractSection(String json, String sectionName) {
@@ -2845,9 +2843,11 @@ class ScalpelLifecycleParticipantTest {
 
         participant.afterProjectsRead(session);
 
-        // failSafe=true → should not throw, just return (build all)
+        // failSafe=true → should not throw. The invalid old POM is handled conservatively
+        // (all dependents marked affected), so the normal trim path runs and, since #91,
+        // trim mode writes the JSON report too.
         Path reportFile = root.resolve("target/scalpel-report.json");
-        assertFalse(Files.exists(reportFile));
+        assertTrue(Files.exists(reportFile));
     }
 
     @Test
@@ -3333,21 +3333,26 @@ class ScalpelLifecycleParticipantTest {
     }
 
     private boolean modulePresent(String json, String artifactId) {
-        return json.contains("\"artifactId\": \"" + artifactId + "\"");
+        String affectedSection = extractSection(json, "affectedModules");
+        return affectedSection != null && affectedSection.contains("\"artifactId\": \"" + artifactId + "\"");
     }
 
     private String extractModuleBlock(String json, String artifactId) {
+        String affectedSection = extractSection(json, "affectedModules");
+        if (affectedSection == null) {
+            return null;
+        }
         String marker = "\"artifactId\": \"" + artifactId + "\"";
-        int idx = json.indexOf(marker);
+        int idx = affectedSection.indexOf(marker);
         if (idx < 0) {
             return null;
         }
-        int start = json.lastIndexOf("{", idx);
-        int end = json.indexOf("}", idx);
+        int start = affectedSection.lastIndexOf("{", idx);
+        int end = affectedSection.indexOf("}", idx);
         if (start < 0 || end < 0) {
             return null;
         }
-        return json.substring(start, end + 1);
+        return affectedSection.substring(start, end + 1);
     }
 
     private boolean moduleHasReason(String json, String artifactId, String reason) {


### PR DESCRIPTION
## Problem

As filed in #91: in trim mode the log says "Building N of M modules" and the report lists AFFECTED modules, but nothing enumerates the SKIPPED set with the reason each was judged safe to skip - exactly the list a reviewer needs to trust a green trimmed build.

## Change

- `skippedModules` array in the JSON report: path, groupId, artifactId and a reason per module, populated in trim and report modes. Computed as allProjects minus (directly affected + transitively affected + the FINAL build set after the includePaths scope filter, so scope-excluded downstream modules are listed, not invisible). Optional, additive, omitted when empty - no version bump per the #60 policy; schema updated with a `reason` enum.
- Only `NOT_AFFECTED` ships: it is the one reason reliably computable from existing sets. `EXCLUDED_BY_PATH_FILTER` needs the report-side filter to expose its decisions and `TESTS_SKIPPED_ONLY` describes modules that are built - both deferred as the issue itself suggests. Note: modules dropped by the includePaths scope currently carry NOT_AFFECTED; distinguishing them is the visible schema change of that follow-up.

**Deliberate behavior change**: trim mode now also writes the JSON report (that is what makes the skipped set reviewable where it matters). Two consequences, flagged for review: a report write failure can now fail a trim build (failSafe governs as elsewhere once #89 lands), and the zero-affected early-return paths write no report; happy to align either if you prefer.

## Verification

TDD across three commits (RED on the missing API and on the no-report-in-trim behavior, GREEN, then a review fix threading the filtered build set through with a dedicated includePaths test). Full suites green (core 131, extension3 149).