### PR TITLE
Fix #111: integration-test the extension artifact users install

### DIFF
--- a/it/extension-its/pom.xml
+++ b/it/extension-its/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) Maveniverse Org.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    https://www.eclipse.org/legal/epl-v20.html
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>eu.maveniverse.maven.scalpel.it</groupId>
+    <artifactId>it</artifactId>
+    <version>${nisse.jgit.dynamicVersion}</version>
+  </parent>
+
+  <artifactId>extension-its</artifactId>
+  <packaging>pom</packaging>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>eu.maveniverse.maven.scalpel</groupId>
+      <artifactId>extension</artifactId>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>run-its</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-maven-distro</id>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <phase>generate-test-resources</phase>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.apache.maven</groupId>
+                      <artifactId>apache-maven</artifactId>
+                      <version>${maven3Version}</version>
+                      <classifier>bin</classifier>
+                      <type>zip</type>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <configuration>
+              <mavenHome>${project.build.directory}/dependency/apache-maven-${maven3Version}</mavenHome>
+              <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+              <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+              <cloneClean>true</cloneClean>
+              <pomIncludes>
+                <pomInclude>*/pom.xml</pomInclude>
+              </pomIncludes>
+              <preBuildHookScript>setup</preBuildHookScript>
+              <postBuildHookScript>verify</postBuildHookScript>
+              <addTestClassPath>false</addTestClassPath>
+              <extraArtifacts>
+                <extraArtifact>eu.maveniverse.maven.scalpel:scalpel:${project.version}:pom</extraArtifact>
+              </extraArtifacts>
+            </configuration>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <phase>none</phase>
+              </execution>
+              <execution>
+                <id>run-its</id>
+                <goals>
+                  <goal>install</goal>
+                  <goal>run</goal>
+                </goals>
+                <phase>integration-test</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/it/extension-its/src/it/report-mode/.mvn/extensions.xml
+++ b/it/extension-its/src/it/report-mode/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension-its/src/it/report-mode/invoker.properties
+++ b/it/extension-its/src/it/report-mode/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.mode=report

--- a/it/extension-its/src/it/report-mode/module-a/pom.xml
+++ b/it/extension-its/src/it/report-mode/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.extreport</groupId>
+        <artifactId>report-mode</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension-its/src/it/report-mode/module-b/pom.xml
+++ b/it/extension-its/src/it/report-mode/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.extreport</groupId>
+        <artifactId>report-mode</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.extreport</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension-its/src/it/report-mode/pom.xml
+++ b/it/extension-its/src/it/report-mode/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.extreport</groupId>
+    <artifactId>report-mode</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension-its/src/it/report-mode/setup.groovy
+++ b/it/extension-its/src/it/report-mode/setup.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, switch to feature branch, modify source in module-b
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Create a source file in module-b
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension-its/src/it/report-mode/verify.groovy
+++ b/it/extension-its/src/it/report-mode/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated in report mode
+assert log.contains('Scalpel')
+assert log.contains('mode=report')
+
+// Report should have been written
+assert log.contains('Report written to')
+
+// All modules should still be present in reactor (no trimming)
+assert log.contains('BUILD SUCCESS')
+
+// Check the report file exists and has valid content
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists() : "Report file should have been created at target/scalpel-report.json"
+
+String json = reportFile.text
+assert json.contains('"version": "2"') : "Report should contain version field"
+assert json.contains('"fullBuildTriggered": false') : "fullBuildTriggered should be false"
+assert json.contains('"affectedModules"') : "Report should contain affectedModules"
+assert json.contains('"module-b"') : "module-b should appear in the report as affected"
+assert json.contains('"SOURCE_CHANGE"') : "module-b should have SOURCE_CHANGE reason"

--- a/it/extension-its/src/it/smoke/.mvn/extensions.xml
+++ b/it/extension-its/src/it/smoke/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension-its/src/it/smoke/invoker.properties
+++ b/it/extension-its/src/it/smoke/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base

--- a/it/extension-its/src/it/smoke/module-a/pom.xml
+++ b/it/extension-its/src/it/smoke/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.extsmoke</groupId>
+        <artifactId>smoke</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension-its/src/it/smoke/module-b/pom.xml
+++ b/it/extension-its/src/it/smoke/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.extsmoke</groupId>
+        <artifactId>smoke</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.extsmoke</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension-its/src/it/smoke/pom.xml
+++ b/it/extension-its/src/it/smoke/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.extsmoke</groupId>
+    <artifactId>smoke</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension-its/src/it/smoke/setup.groovy
+++ b/it/extension-its/src/it/smoke/setup.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, switch to feature branch, modify source in module-b
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Create a source file in module-b
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension-its/src/it/smoke/verify.groovy
+++ b/it/extension-its/src/it/smoke/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// The extension artifact (not extension3) must have been loaded via .mvn/extensions.xml
+assert log.contains('Scalpel') : "Scalpel extension should have been activated"
+
+// module-b was changed -> it should be the only directly affected module
+assert log.contains('1 modules directly affected') : "Expected exactly 1 module directly affected"
+
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine != null : "Expected 'directly affected' log line"
+assert directlyAffectedLine.contains('module-b') : "module-b should be directly affected (source changed)"
+
+// Trivial two-module reactor: module-a is upstream of the changed module-b, so all modules stay in the build
+def scalpelBuildingLine = log.readLines().find { it.contains('Scalpel') && it.contains('of 3 modules') }
+assert scalpelBuildingLine != null : "Expected Scalpel 'Building X of 3 modules' log line"
+assert scalpelBuildingLine.contains('module-a') : "module-a should remain in the build set (upstream of changed module-b)"
+assert scalpelBuildingLine.contains('module-b') : "module-b should remain in the build set"
+assert log.contains('BUILD SUCCESS')

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -26,6 +26,7 @@
   <modules>
     <module>extension3-its</module>
     <module>extension4-its</module>
+    <module>extension-its</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
## Problem

As filed in #111: the README tells users to put `eu.maveniverse.maven.scalpel:extension` in `.mvn/extensions.xml`, but the `extension` module has no `src/` and no test consumes that artifact - the coordinate every adopter except Quarkus actually installs was never exercised by any test.

## Change

New `it/extension-its` module (invoker wiring identical to `extension3-its`, dependency switched to the `extension` artifact), registered in `it/pom.xml`. Two scenarios consume the artifact exactly as a user would, via the invoker project's own `.mvn/extensions.xml` at `@project.version@`:

- **smoke**: two-module reactor; asserts Scalpel activation, the directly-affected line, and the correct Building N of M with the upstream module retained.
- **report-mode**: base-branch setup mirrored from extension3-its; asserts the report is written with version 2, `fullBuildTriggered:false`, and the SOURCE_CHANGE entry.

Control evidence: with the extensions.xml reference deliberately broken (nonexistent artifactId) the IT fails at extension resolution; restored, both scenarios pass. The extension module is a POM-only shim pulling in extension3 - noted in the issue - so beyond resolution there is no separate code path to cover; its `maven-model-builder` provided dependency remains unexercised by any code in the reactor (left in place, flagged for your call).

## Verification

Fresh full run of the new module passes (2/2 scenarios); extension3-its re-run unaffected; unit suites green.