### PR TITLE
Fix #109: integration tests for includePaths, disableOnBaseBranch, failSafe=false, CI base detection

### DIFF
--- a/it/extension3-its/src/it/ci-base-detection/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/ci-base-detection/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/ci-base-detection/invoker.properties
+++ b/it/extension3-its/src/it/ci-base-detection/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = validate
+invoker.environmentVariables.GITHUB_BASE_REF = base

--- a/it/extension3-its/src/it/ci-base-detection/module-a/pom.xml
+++ b/it/extension3-its/src/it/ci-base-detection/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.cibasedetection</groupId>
+        <artifactId>ci-base-detection</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/ci-base-detection/module-b/pom.xml
+++ b/it/extension3-its/src/it/ci-base-detection/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.cibasedetection</groupId>
+        <artifactId>ci-base-detection</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/ci-base-detection/pom.xml
+++ b/it/extension3-its/src/it/ci-base-detection/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.cibasedetection</groupId>
+    <artifactId>ci-base-detection</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/ci-base-detection/setup.groovy
+++ b/it/extension3-its/src/it/ci-base-detection/setup.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Create a bare remote repo with a "base" branch and a working repo using it as
+// origin, so the ref origin/base exists locally. GITHUB_BASE_REF=base is set in
+// invoker.properties; Scalpel must auto-detect the base branch as origin/base
+// (no -Dscalpel.baseBranch) and trim the build to the changed module.
+def dir = basedir
+def remoteDir = new File(basedir.parentFile, 'ci-base-detection-remote.git')
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+def execIn = { File workDir, String... args ->
+    def proc = args.execute(null, workDir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+// 1. Create a bare remote repo
+execIn(basedir.parentFile, 'git', 'init', '--bare', remoteDir.absolutePath)
+
+// 2. Initialize working repo
+exec('git', 'init', '-b', 'main')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'remote', 'add', 'origin', remoteDir.absolutePath)
+
+// 3. Commit initial state and push (creates local origin/main tracking ref)
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'push', 'origin', 'HEAD:refs/heads/main')
+
+// 4. Create "base" branch on remote at the same commit (origin/base exists locally)
+exec('git', 'push', 'origin', 'HEAD:refs/heads/base')
+
+// 5. Make a source change and commit on the working branch
+new File(dir, 'module-a/src/main/java').mkdirs()
+new File(dir, 'module-a/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-a')

--- a/it/extension3-its/src/it/ci-base-detection/verify.groovy
+++ b/it/extension3-its/src/it/ci-base-detection/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated
+assert log.contains('Scalpel')
+
+// The base branch must have been auto-detected from GITHUB_BASE_REF; if it had
+// not been, Scalpel would log "No base branch configured or detected".
+assert !log.contains('No base branch configured or detected') : \
+    "Expected base branch to be auto-detected from GITHUB_BASE_REF, log: $log"
+
+// module-a changed; with origin/base detected, module-b must be trimmed out
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine != null : "Expected 'directly affected' log line"
+assert directlyAffectedLine.contains('module-a') : "module-a should be directly affected"
+
+def buildingLine = log.readLines().find { it.contains('Scalpel: Building') && it.contains('of 3 modules') }
+assert buildingLine != null : "Expected 'Scalpel: Building X of 3 modules' log line"
+assert buildingLine.contains('module-a') : "module-a should be in the build set"
+assert !buildingLine.contains('module-b') : "module-b should NOT be in the build set"

--- a/it/extension3-its/src/it/disable-on-base-branch/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/disable-on-base-branch/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/disable-on-base-branch/invoker.properties
+++ b/it/extension3-its/src/it/disable-on-base-branch/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.disableOnBaseBranch=base

--- a/it/extension3-its/src/it/disable-on-base-branch/module-a/pom.xml
+++ b/it/extension3-its/src/it/disable-on-base-branch/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.disableonbasebranch</groupId>
+        <artifactId>disable-on-base-branch</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/disable-on-base-branch/module-b/pom.xml
+++ b/it/extension3-its/src/it/disable-on-base-branch/module-b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.disableonbasebranch</groupId>
+        <artifactId>disable-on-base-branch</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/disable-on-base-branch/pom.xml
+++ b/it/extension3-its/src/it/disable-on-base-branch/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.disableonbasebranch</groupId>
+    <artifactId>disable-on-base-branch</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/disable-on-base-branch/setup.groovy
+++ b/it/extension3-its/src/it/disable-on-base-branch/setup.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, then add a source file in module-b
+// that would normally trigger trimming. disableOnBaseBranch matches the
+// configured base branch, so Scalpel must disable itself and build everything.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Add a source file change (would normally trigger trimming)
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension3-its/src/it/disable-on-base-branch/verify.groovy
+++ b/it/extension3-its/src/it/disable-on-base-branch/verify.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated but then disabled because the base branch matches
+assert log.contains('Scalpel')
+assert log.contains("Disabled because base branch 'base' matches pattern") : \
+    "Expected Scalpel to be disabled due to base branch matching, log: $log"
+
+// All modules should be built (no trimming happened)
+assert !log.contains('directly affected') : "Scalpel should not have computed affected modules"

--- a/it/extension3-its/src/it/fail-safe-disabled/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/fail-safe-disabled/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/fail-safe-disabled/invoker.properties
+++ b/it/extension3-its/src/it/fail-safe-disabled/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = validate -Dscalpel.baseBranch=nonexistent-branch -Dscalpel.failSafe=false
+invoker.buildResult = failure

--- a/it/extension3-its/src/it/fail-safe-disabled/pom.xml
+++ b/it/extension3-its/src/it/fail-safe-disabled/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.failsafedisabled</groupId>
+    <artifactId>fail-safe-disabled</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>

--- a/it/extension3-its/src/it/fail-safe-disabled/setup.groovy
+++ b/it/extension3-its/src/it/fail-safe-disabled/setup.groovy
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo with a base branch, but point scalpel.baseBranch at a
+// nonexistent ref via invoker.properties. With failSafe=false the merge-base
+// failure must abort the build instead of silently building all modules.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')

--- a/it/extension3-its/src/it/fail-safe-disabled/verify.groovy
+++ b/it/extension3-its/src/it/fail-safe-disabled/verify.groovy
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// The build must have failed (asserted by invoker.buildResult = failure);
+// here we assert it failed with the Scalpel error, not some unrelated cause.
+assert log.contains('Could not find merge base between nonexistent-branch') : \
+    "Expected Scalpel merge-base failure message, log: $log"
+assert log.contains('[ERROR] Scalpel: Could not find merge base') : "Expected Scalpel error line in log"

--- a/it/extension3-its/src/it/include-paths/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/include-paths/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/include-paths/invoker.properties
+++ b/it/extension3-its/src/it/include-paths/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = package -Dscalpel.baseBranch=base -Dscalpel.includePaths=module-a/**

--- a/it/extension3-its/src/it/include-paths/module-a/pom.xml
+++ b/it/extension3-its/src/it/include-paths/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.includepaths</groupId>
+        <artifactId>include-paths</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/include-paths/module-b/pom.xml
+++ b/it/extension3-its/src/it/include-paths/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.includepaths</groupId>
+        <artifactId>include-paths</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.includepaths</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/include-paths/pom.xml
+++ b/it/extension3-its/src/it/include-paths/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.includepaths</groupId>
+    <artifactId>include-paths</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/include-paths/setup.groovy
+++ b/it/extension3-its/src/it/include-paths/setup.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, then change a source file in module-a.
+// module-b depends on module-a (downstream) but lies outside the includePaths filter,
+// so with includePaths=module-a/** it must be dropped from the trimmed build set.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Add a source file in module-a (inside includePaths)
+new File(dir, 'module-a/src/main/java').mkdirs()
+new File(dir, 'module-a/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-a')

--- a/it/extension3-its/src/it/include-paths/verify.groovy
+++ b/it/extension3-its/src/it/include-paths/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// Scalpel should have been activated
+assert log.contains('Scalpel')
+
+// module-a source changed -> module-a is directly affected
+assert log.contains('1 modules directly affected') : "Expected exactly 1 module directly affected"
+def directlyAffectedLine = log.readLines().find { it.contains('directly affected') }
+assert directlyAffectedLine != null : "Expected 'directly affected' log line"
+assert directlyAffectedLine.contains('module-a') : "module-a should be directly affected (source changed)"
+assert !directlyAffectedLine.contains('module-b') : "module-b should not be directly affected"
+
+// module-b is downstream of module-a but outside includePaths -> NOT in the build set
+def buildingLine = log.readLines().find { it.contains('Scalpel: Building') && it.contains('of 3 modules') }
+assert buildingLine != null : "Expected 'Scalpel: Building X of 3 modules' log line"
+assert buildingLine.contains('module-a') : "module-a should be in the build set"
+assert !buildingLine.contains('module-b') : "module-b should be excluded by includePaths filter"


### PR DESCRIPTION
## Problem

As filed in #109: several configuration paths shipped and documented but never exercised end to end - `includePaths` (the newest feature, four code paths, zero ITs), `disableOnBaseBranch`, `failSafe=false` (no IT in the suite asserted a failure outcome), and CI base-branch auto-detection (the primary production path).

## Change

Four new scenarios in `it/extension3-its/src/it/`:

- **include-paths**: runs `package` (one of the few ITs doing more than validate) with `scalpel.includePaths=module-a/**`; asserts module-a directly affected and built, downstream module-b excluded from the Building line. Control run without the filter builds all 3 - the IT detects the difference.
- **disable-on-base-branch**: pattern matching the configured base branch; asserts the disable log and that no affected-set computation runs.
- **fail-safe-disabled**: `invoker.buildResult = failure` with a nonexistent baseBranch and `failSafe=false`; asserts the build fails with the Scalpel error line (the first IT in the suite asserting a failure outcome).
- **ci-base-detection**: `GITHUB_BASE_REF` propagated via `invoker.environmentVariables`, no explicit baseBranch; a bare origin with `origin/base` pushed. Detection is proven by elimination: trimming happened, which requires a resolved merge base, and the "No base branch configured" log is absent.

## Verification

Fresh targeted run: 4/4 pass; full extension3-its suite (28 ITs) green; unit suites green. Two harness findings baked into the scenarios: commas in invoker.properties goal lines get mangled (single patterns used), and a MavenExecutionException from the extension aborts before the BUILD FAILURE footer, so the failure IT asserts on the `[ERROR] Scalpel:` line.