### PR TITLE
Fix #93: explain mode with per-module decision evidence

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -27,6 +27,7 @@ public final class ScalpelConfiguration {
     public static final String FULL_BUILD_TRIGGERS = PREFIX + "fullBuildTriggers";
     public static final String FAIL_SAFE = PREFIX + "failSafe";
     public static final String MODE = PREFIX + "mode";
+    public static final String EXPLAIN = PREFIX + "explain";
 
     public static final String DISABLE_ON_BRANCH = PREFIX + "disableOnBranch";
     public static final String DISABLE_ON_BASE_BRANCH = PREFIX + "disableOnBaseBranch";
@@ -69,6 +70,7 @@ public final class ScalpelConfiguration {
             FULL_BUILD_TRIGGERS,
             FAIL_SAFE,
             MODE,
+            EXPLAIN,
             DISABLE_ON_BRANCH,
             DISABLE_ON_BASE_BRANCH,
             EXCLUDE_PATHS,
@@ -112,6 +114,7 @@ public final class ScalpelConfiguration {
     private final String impactedLog;
     private final boolean failSafe;
     private final String mode;
+    private final boolean explain;
     private final String reportFile;
     private final long maxResourceFileSize;
     private final List<String> warnings;
@@ -141,6 +144,7 @@ public final class ScalpelConfiguration {
             String impactedLog,
             boolean failSafe,
             String mode,
+            boolean explain,
             String reportFile,
             long maxResourceFileSize,
             List<String> warnings) {
@@ -168,6 +172,7 @@ public final class ScalpelConfiguration {
         this.impactedLog = impactedLog;
         this.failSafe = failSafe;
         this.mode = mode;
+        this.explain = explain;
         this.reportFile = reportFile;
         this.maxResourceFileSize = maxResourceFileSize;
         this.warnings = warnings;
@@ -212,6 +217,7 @@ public final class ScalpelConfiguration {
             throw new IllegalArgumentException("Invalid scalpel.mode '" + mode + "', expected one of: " + MODE_TRIM
                     + ", " + MODE_SKIP_TESTS + ", " + MODE_REPORT);
         }
+        boolean explain = parseStrictBoolean(EXPLAIN, resolve(system, user, EXPLAIN, "false"));
         String reportFile = resolve(system, user, REPORT_FILE, DEFAULT_REPORT_FILE);
         String maxResourceFileSizeStr = resolve(system, user, MAX_RESOURCE_FILE_SIZE, null);
         long maxResourceFileSize = DEFAULT_MAX_RESOURCE_FILE_SIZE;
@@ -255,6 +261,7 @@ public final class ScalpelConfiguration {
                 impactedLog,
                 failSafe,
                 mode,
+                explain,
                 reportFile,
                 maxResourceFileSize,
                 warnings);
@@ -472,6 +479,10 @@ public final class ScalpelConfiguration {
         return failSafe;
     }
 
+    public boolean isExplain() {
+        return explain;
+    }
+
     public String getMode() {
         return mode;
     }
@@ -507,6 +518,7 @@ public final class ScalpelConfiguration {
                 + ", baseBranch='" + baseBranch + '\''
                 + ", head='" + head + '\''
                 + ", mode='" + mode + '\''
+                + ", explain=" + explain
                 + ", alsoMake=" + alsoMake
                 + ", alsoMakeDependents=" + alsoMakeDependents
                 + ", fullBuildTriggers=" + fullBuildTriggers

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -88,6 +88,7 @@ public final class ScalpelReport {
         private final String category;
         private final String sourceSet;
         private final String testsSkippedReason;
+        private final List<String> evidence;
 
         public AffectedModule(String groupId, String artifactId, String path, List<String> reasons) {
             this(groupId, artifactId, path, reasons, null, null, null);
@@ -115,6 +116,18 @@ public final class ScalpelReport {
                 String category,
                 String sourceSet,
                 String testsSkippedReason) {
+            this(groupId, artifactId, path, reasons, category, sourceSet, testsSkippedReason, null);
+        }
+
+        public AffectedModule(
+                String groupId,
+                String artifactId,
+                String path,
+                List<String> reasons,
+                String category,
+                String sourceSet,
+                String testsSkippedReason,
+                List<String> evidence) {
             if (sourceSet != null && !"main".equals(sourceSet) && !"test".equals(sourceSet)) {
                 throw new IllegalArgumentException("sourceSet must be 'main', 'test', or null");
             }
@@ -125,6 +138,7 @@ public final class ScalpelReport {
             this.category = category;
             this.sourceSet = sourceSet;
             this.testsSkippedReason = testsSkippedReason;
+            this.evidence = evidence;
         }
 
         public String getGroupId() {
@@ -155,6 +169,10 @@ public final class ScalpelReport {
             return testsSkippedReason;
         }
 
+        public List<String> getEvidence() {
+            return evidence;
+        }
+
         public static ModuleBuilder moduleBuilder(
                 String groupId, String artifactId, String path, List<String> reasons) {
             return new ModuleBuilder(groupId, artifactId, path, reasons);
@@ -168,6 +186,7 @@ public final class ScalpelReport {
             private String category;
             private String sourceSet;
             private String testsSkippedReason;
+            private List<String> evidence;
 
             ModuleBuilder(String groupId, String artifactId, String path, List<String> reasons) {
                 this.groupId = groupId;
@@ -191,8 +210,14 @@ public final class ScalpelReport {
                 return this;
             }
 
+            public ModuleBuilder evidence(List<String> evidence) {
+                this.evidence = evidence;
+                return this;
+            }
+
             public AffectedModule build() {
-                return new AffectedModule(groupId, artifactId, path, reasons, category, sourceSet, testsSkippedReason);
+                return new AffectedModule(
+                        groupId, artifactId, path, reasons, category, sourceSet, testsSkippedReason, evidence);
             }
         }
     }
@@ -248,6 +273,10 @@ public final class ScalpelReport {
             sb.append(",\n");
             sb.append("      \"testsSkipped\": true");
             appendOptionalField(sb, "testsSkippedReason", m.testsSkippedReason);
+        }
+        if (m.evidence != null) {
+            sb.append(",\n");
+            sb.append("      \"evidence\": ").append(jsonStringArray(m.evidence));
         }
         sb.append("\n");
         sb.append("    }");

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -125,6 +125,11 @@
         "testsSkippedReason": {
           "type": "string",
           "description": "Why tests were skipped on this module (e.g. 'EXCLUDED_DOWNSTREAM' for downstream modules not in the test scope)."
+        },
+        "evidence": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Specific inputs behind this module's decision, emitted only with -Dscalpel.explain=true (e.g. a changed file path, 'property <name>', 'managed dep <groupId:artifactId>', 'managed plugin <groupId:artifactId>', 'downstream of <groupId:artifactId>')."
         }
       }
     }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -60,6 +60,27 @@ class ScalpelConfigurationTest {
         assertFalse(defaultConfig().isBuildAllIfNoChanges());
     }
 
+    @Test
+    void defaultExplain_isFalse() {
+        assertFalse(defaultConfig().isExplain());
+    }
+
+    @Test
+    void explain_trueParsedFromProperties() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.explain", "true");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertTrue(config.isExplain());
+    }
+
+    @Test
+    void explain_isAKnownKey() {
+        Properties sys = new Properties();
+        sys.setProperty("scalpel.explain", "true");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+        assertTrue(config.getWarnings().isEmpty(), "scalpel.explain must not be reported as an unknown key");
+    }
+
     // ---------------------------------------------------------------
     // Default values for list fields (empty)
     // ---------------------------------------------------------------

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -388,6 +388,45 @@ class ScalpelReportTest {
     }
 
     // ---------------------------------------------------------------
+    // Evidence (explain mode, #93)
+    // ---------------------------------------------------------------
+
+    @Test
+    void toJson_evidenceIncludedWhenPresent() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("module-a/src/main/java/Foo.java"))
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE))
+                        .category(ScalpelReport.CATEGORY_DIRECT)
+                        .evidence(List.of("module-a/src/main/java/Foo.java"))
+                        .build())
+                .build();
+
+        String json = report.toJson();
+        assertTrue(
+                json.contains("\"evidence\": [\"module-a/src/main/java/Foo.java\"]"),
+                "evidence array must be emitted when present");
+    }
+
+    @Test
+    void toJson_evidenceOmittedWhenNull() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("module-a/src/main/java/Foo.java"))
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE))
+                        .category(ScalpelReport.CATEGORY_DIRECT)
+                        .build())
+                .build();
+
+        String json = report.toJson();
+        assertFalse(json.contains("evidence"), "evidence must not appear when not set");
+    }
+
+    // ---------------------------------------------------------------
     // Golden-file and schema tests
     // ---------------------------------------------------------------
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
@@ -27,6 +27,7 @@ final class AnalysisContext {
     final Set<MavenProject> affectedByPom;
     final Set<MavenProject> forceIncluded;
     final Map<MavenProject, List<String>> transitivelyAffected;
+    final Map<MavenProject, List<String>> evidence;
     final TrimResult trimResult;
 
     private AnalysisContext(Builder builder) {
@@ -40,6 +41,7 @@ final class AnalysisContext {
         this.affectedByPom = builder.affectedByPom;
         this.forceIncluded = builder.forceIncluded;
         this.transitivelyAffected = builder.transitivelyAffected;
+        this.evidence = builder.evidence;
         this.trimResult = builder.trimResult;
     }
 
@@ -76,6 +78,7 @@ final class AnalysisContext {
         private Set<MavenProject> affectedByPom = Set.of();
         private Set<MavenProject> forceIncluded = Set.of();
         private Map<MavenProject, List<String>> transitivelyAffected = Map.of();
+        private Map<MavenProject, List<String>> evidence = Map.of();
         private TrimResult trimResult;
 
         private Builder() {}
@@ -107,6 +110,11 @@ final class AnalysisContext {
 
         Builder transitivelyAffected(Map<MavenProject, List<String>> transitivelyAffected) {
             this.transitivelyAffected = transitivelyAffected;
+            return this;
+        }
+
+        Builder evidence(Map<MavenProject, List<String>> evidence) {
+            this.evidence = evidence;
             return this;
         }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -26,10 +26,15 @@ class ModuleMapper {
     static class Result {
         private final Set<MavenProject> mainAffected;
         private final Set<MavenProject> testOnlyAffected;
+        private final Map<MavenProject, Set<String>> triggeringFiles;
 
-        Result(Set<MavenProject> mainAffected, Set<MavenProject> testOnlyAffected) {
+        Result(
+                Set<MavenProject> mainAffected,
+                Set<MavenProject> testOnlyAffected,
+                Map<MavenProject, Set<String>> triggeringFiles) {
             this.mainAffected = mainAffected;
             this.testOnlyAffected = testOnlyAffected;
+            this.triggeringFiles = triggeringFiles;
         }
 
         Set<MavenProject> getAllAffected() {
@@ -45,11 +50,20 @@ class ModuleMapper {
         Set<MavenProject> getTestOnlyAffected() {
             return testOnlyAffected;
         }
+
+        /**
+         * Files that mapped each module into the affected set (explain-mode evidence).
+         */
+        Map<MavenProject, Set<String>> getTriggeringFiles() {
+            return triggeringFiles;
+        }
     }
 
     public Result mapToProjectsClassified(Set<String> changedFiles, List<MavenProject> projects, Path reactorRoot) {
         // Track for each project whether it has any main (non-test) source changes
         Map<MavenProject, Boolean> hasMainChange = new LinkedHashMap<>();
+        // Track which changed file triggered each project (explain-mode evidence)
+        Map<MavenProject, Set<String>> triggeringFiles = new LinkedHashMap<>();
 
         // Sort projects by basedir depth (most specific first)
         List<MavenProject> sortedProjects = new ArrayList<>(projects);
@@ -68,6 +82,9 @@ class ModuleMapper {
                     } else if (!isTest) {
                         hasMainChange.put(project, Boolean.TRUE);
                     }
+                    triggeringFiles
+                            .computeIfAbsent(project, k -> new LinkedHashSet<>())
+                            .add(changedFile);
                     break;
                 }
             }
@@ -83,7 +100,7 @@ class ModuleMapper {
             }
         }
 
-        return new Result(mainAffected, testOnlyAffected);
+        return new Result(mainAffected, testOnlyAffected, triggeringFiles);
     }
 
     public Set<MavenProject> mapToProjects(Set<String> changedFiles, List<MavenProject> projects, Path reactorRoot) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -60,6 +60,11 @@ class ModuleMapper {
     }
 
     public Result mapToProjectsClassified(Set<String> changedFiles, List<MavenProject> projects, Path reactorRoot) {
+        return mapToProjectsClassified(changedFiles, projects, reactorRoot, true);
+    }
+
+    public Result mapToProjectsClassified(
+            Set<String> changedFiles, List<MavenProject> projects, Path reactorRoot, boolean explain) {
         // Track for each project whether it has any main (non-test) source changes
         Map<MavenProject, Boolean> hasMainChange = new LinkedHashMap<>();
         // Track which changed file triggered each project (explain-mode evidence)
@@ -82,9 +87,11 @@ class ModuleMapper {
                     } else if (!isTest) {
                         hasMainChange.put(project, Boolean.TRUE);
                     }
-                    triggeringFiles
-                            .computeIfAbsent(project, k -> new LinkedHashSet<>())
-                            .add(changedFile);
+                    if (explain) {
+                        triggeringFiles
+                                .computeIfAbsent(project, k -> new LinkedHashSet<>())
+                                .add(changedFile);
+                    }
                     break;
                 }
             }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -65,7 +65,13 @@ class PomChangeAnalyzer {
                 Set<String> changedManagedDependencyGAs,
                 Set<String> changedManagedPluginGAs,
                 Set<String> changedProperties) {
-            this(affectedProjects, changedManagedDependencyGAs, changedManagedPluginGAs, changedProperties, Map.of(), List.of());
+            this(
+                    affectedProjects,
+                    changedManagedDependencyGAs,
+                    changedManagedPluginGAs,
+                    changedProperties,
+                    Map.of(),
+                    List.of());
         }
 
         Result(
@@ -256,7 +262,12 @@ class PomChangeAnalyzer {
                 allChangedManagedDepGAs,
                 allChangedManagedPluginGAs);
         return new Result(
-                affected, allChangedManagedDepGAs, allChangedManagedPluginGAs, allChangedProperties, evidence, unmatchedPomPaths);
+                affected,
+                allChangedManagedDepGAs,
+                allChangedManagedPluginGAs,
+                allChangedProperties,
+                evidence,
+                unmatchedPomPaths);
     }
 
     private static void addEvidence(Map<MavenProject, Set<String>> evidence, MavenProject project, String item) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -57,16 +57,27 @@ class PomChangeAnalyzer {
         private final Set<String> changedManagedDependencyGAs;
         private final Set<String> changedManagedPluginGAs;
         private final Set<String> changedProperties;
+        private final Map<MavenProject, Set<String>> evidence;
 
         Result(
                 Set<MavenProject> affectedProjects,
                 Set<String> changedManagedDependencyGAs,
                 Set<String> changedManagedPluginGAs,
                 Set<String> changedProperties) {
+            this(affectedProjects, changedManagedDependencyGAs, changedManagedPluginGAs, changedProperties, Map.of());
+        }
+
+        Result(
+                Set<MavenProject> affectedProjects,
+                Set<String> changedManagedDependencyGAs,
+                Set<String> changedManagedPluginGAs,
+                Set<String> changedProperties,
+                Map<MavenProject, Set<String>> evidence) {
             this.affectedProjects = affectedProjects;
             this.changedManagedDependencyGAs = changedManagedDependencyGAs;
             this.changedManagedPluginGAs = changedManagedPluginGAs;
             this.changedProperties = changedProperties;
+            this.evidence = evidence;
         }
 
         Set<MavenProject> getAffectedProjects() {
@@ -83,6 +94,14 @@ class PomChangeAnalyzer {
 
         Set<String> getChangedProperties() {
             return changedProperties;
+        }
+
+        /**
+         * Specific inputs that triggered each affected module (explain-mode evidence),
+         * e.g. "property foo.version" or "managed dep g:a".
+         */
+        Map<MavenProject, Set<String>> getEvidence() {
+            return evidence;
         }
     }
 
@@ -117,6 +136,7 @@ class PomChangeAnalyzer {
             long maxResourceFileSize) {
 
         Set<MavenProject> affected = new LinkedHashSet<>();
+        Map<MavenProject, Set<String>> evidence = new LinkedHashMap<>();
         Set<String> allChangedManagedDepGAs = new LinkedHashSet<>();
         Set<String> allChangedManagedPluginGAs = new LinkedHashSet<>();
         Set<String> allChangedProperties = new LinkedHashSet<>();
@@ -149,6 +169,7 @@ class PomChangeAnalyzer {
                 // Leaf module: its own POM changed, mark it as affected
                 logger.debug("Leaf module POM changed: {}", key(project));
                 affected.add(project);
+                addEvidence(evidence, project, "own pom " + changedPomPath + " changed");
                 continue;
             }
 
@@ -161,6 +182,10 @@ class PomChangeAnalyzer {
                 }
                 affected.add(project);
                 affected.addAll(dependents);
+                addEvidence(evidence, project, "new pom " + changedPomPath);
+                for (MavenProject dependent : dependents) {
+                    addEvidence(evidence, dependent, "new pom " + changedPomPath);
+                }
                 continue;
             }
 
@@ -171,6 +196,7 @@ class PomChangeAnalyzer {
                         dependents,
                         reactorRoot,
                         affected,
+                        evidence,
                         allChangedManagedDepGAs,
                         allChangedManagedPluginGAs,
                         allChangedProperties,
@@ -183,6 +209,10 @@ class PomChangeAnalyzer {
                         e.getMessage());
                 affected.add(project);
                 affected.addAll(dependents);
+                addEvidence(evidence, project, "unparseable old pom " + changedPomPath);
+                for (MavenProject dependent : dependents) {
+                    addEvidence(evidence, dependent, "unparseable old pom " + changedPomPath);
+                }
             }
         }
 
@@ -192,7 +222,12 @@ class PomChangeAnalyzer {
                 allChangedProperties,
                 allChangedManagedDepGAs,
                 allChangedManagedPluginGAs);
-        return new Result(affected, allChangedManagedDepGAs, allChangedManagedPluginGAs, allChangedProperties);
+        return new Result(
+                affected, allChangedManagedDepGAs, allChangedManagedPluginGAs, allChangedProperties, evidence);
+    }
+
+    private static void addEvidence(Map<MavenProject, Set<String>> evidence, MavenProject project, String item) {
+        evidence.computeIfAbsent(project, k -> new LinkedHashSet<>()).add(item);
     }
 
     private void analyzeParentPomChange(
@@ -201,6 +236,7 @@ class PomChangeAnalyzer {
             List<MavenProject> dependentProjects,
             Path reactorRoot,
             Set<MavenProject> affected,
+            Map<MavenProject, Set<String>> evidence,
             Set<String> allChangedManagedDepGAs,
             Set<String> allChangedManagedPluginGAs,
             Set<String> allChangedProperties,
@@ -280,6 +316,8 @@ class PomChangeAnalyzer {
 
         if (parentSelfAffected) {
             affected.add(parentProject);
+            addEvidence(
+                    evidence, parentProject, "pom " + parentProject.getFile().getName() + " direct content changed");
         }
 
         // Resolve property indirection: if a managed dep/plugin uses a changed property
@@ -340,6 +378,7 @@ class PomChangeAnalyzer {
                     for (String prop : changedProperties) {
                         if (childPomText.contains("${" + prop + "}")) {
                             logger.debug("Child {} references changed property {}", key(child), prop);
+                            addEvidence(evidence, child, "property " + prop);
                             childAffected = true;
                             break;
                         }
@@ -354,6 +393,7 @@ class PomChangeAnalyzer {
                     String ga = dep.getGroupId() + ":" + dep.getArtifactId();
                     if (changedManagedDeps.contains(ga)) {
                         logger.debug("Child {} uses changed managed dependency {}", key(child), ga);
+                        addEvidence(evidence, child, "managed dep " + ga);
                         childAffected = true;
                         break;
                     }
@@ -367,6 +407,7 @@ class PomChangeAnalyzer {
                     String ga = plugin.getGroupId() + ":" + plugin.getArtifactId();
                     if (changedManagedPlugins.contains(ga)) {
                         logger.debug("Child {} uses changed managed plugin {}", key(child), ga);
+                        addEvidence(evidence, child, "managed plugin " + ga);
                         childAffected = true;
                         break;
                     }
@@ -378,6 +419,7 @@ class PomChangeAnalyzer {
                     && !changedProperties.isEmpty()
                     && hasFilteredResourcesWithChangedProperty(child, changedProperties, maxResourceFileSize)) {
                 logger.debug("Child {} has filtered resources referencing changed properties", key(child));
+                addEvidence(evidence, child, "filtered resources referencing changed properties");
                 childAffected = true;
             }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -134,6 +134,16 @@ class PomChangeAnalyzer {
             List<MavenProject> allProjects,
             Path reactorRoot,
             long maxResourceFileSize) {
+        return analyzeChanges(changedPomPaths, oldPomContents, allProjects, reactorRoot, maxResourceFileSize, true);
+    }
+
+    public Result analyzeChanges(
+            Set<String> changedPomPaths,
+            Map<String, byte[]> oldPomContents,
+            List<MavenProject> allProjects,
+            Path reactorRoot,
+            long maxResourceFileSize,
+            boolean explain) {
 
         Set<MavenProject> affected = new LinkedHashSet<>();
         Map<MavenProject, Set<String>> evidence = new LinkedHashMap<>();
@@ -169,7 +179,9 @@ class PomChangeAnalyzer {
                 // Leaf module: its own POM changed, mark it as affected
                 logger.debug("Leaf module POM changed: {}", key(project));
                 affected.add(project);
-                addEvidence(evidence, project, "own pom " + changedPomPath + " changed");
+                if (explain) {
+                    addEvidence(evidence, project, "own pom " + changedPomPath + " changed");
+                }
                 continue;
             }
 
@@ -182,9 +194,11 @@ class PomChangeAnalyzer {
                 }
                 affected.add(project);
                 affected.addAll(dependents);
-                addEvidence(evidence, project, "new pom " + changedPomPath);
-                for (MavenProject dependent : dependents) {
-                    addEvidence(evidence, dependent, "new pom " + changedPomPath);
+                if (explain) {
+                    addEvidence(evidence, project, "new pom " + changedPomPath);
+                    for (MavenProject dependent : dependents) {
+                        addEvidence(evidence, dependent, "new pom " + changedPomPath);
+                    }
                 }
                 continue;
             }
@@ -200,7 +214,8 @@ class PomChangeAnalyzer {
                         allChangedManagedDepGAs,
                         allChangedManagedPluginGAs,
                         allChangedProperties,
-                        maxResourceFileSize);
+                        maxResourceFileSize,
+                        explain);
             } catch (Exception e) {
                 // If we can't parse the old POM, be conservative and mark all dependents
                 logger.warn(
@@ -209,9 +224,11 @@ class PomChangeAnalyzer {
                         e.getMessage());
                 affected.add(project);
                 affected.addAll(dependents);
-                addEvidence(evidence, project, "unparseable old pom " + changedPomPath);
-                for (MavenProject dependent : dependents) {
-                    addEvidence(evidence, dependent, "unparseable old pom " + changedPomPath);
+                if (explain) {
+                    addEvidence(evidence, project, "unparseable old pom " + changedPomPath);
+                    for (MavenProject dependent : dependents) {
+                        addEvidence(evidence, dependent, "unparseable old pom " + changedPomPath);
+                    }
                 }
             }
         }
@@ -240,7 +257,8 @@ class PomChangeAnalyzer {
             Set<String> allChangedManagedDepGAs,
             Set<String> allChangedManagedPluginGAs,
             Set<String> allChangedProperties,
-            long maxResourceFileSize)
+            long maxResourceFileSize,
+            boolean explain)
             throws IOException, XmlPullParserException {
 
         MavenXpp3Reader reader = new MavenXpp3Reader();
@@ -316,8 +334,12 @@ class PomChangeAnalyzer {
 
         if (parentSelfAffected) {
             affected.add(parentProject);
-            addEvidence(
-                    evidence, parentProject, "pom " + parentProject.getFile().getName() + " direct content changed");
+            if (explain) {
+                addEvidence(
+                        evidence,
+                        parentProject,
+                        "pom " + parentProject.getFile().getName() + " direct content changed");
+            }
         }
 
         // Resolve property indirection: if a managed dep/plugin uses a changed property
@@ -378,7 +400,9 @@ class PomChangeAnalyzer {
                     for (String prop : changedProperties) {
                         if (childPomText.contains("${" + prop + "}")) {
                             logger.debug("Child {} references changed property {}", key(child), prop);
-                            addEvidence(evidence, child, "property " + prop);
+                            if (explain) {
+                                addEvidence(evidence, child, "property " + prop);
+                            }
                             childAffected = true;
                             break;
                         }
@@ -393,7 +417,9 @@ class PomChangeAnalyzer {
                     String ga = dep.getGroupId() + ":" + dep.getArtifactId();
                     if (changedManagedDeps.contains(ga)) {
                         logger.debug("Child {} uses changed managed dependency {}", key(child), ga);
-                        addEvidence(evidence, child, "managed dep " + ga);
+                        if (explain) {
+                            addEvidence(evidence, child, "managed dep " + ga);
+                        }
                         childAffected = true;
                         break;
                     }
@@ -407,7 +433,9 @@ class PomChangeAnalyzer {
                     String ga = plugin.getGroupId() + ":" + plugin.getArtifactId();
                     if (changedManagedPlugins.contains(ga)) {
                         logger.debug("Child {} uses changed managed plugin {}", key(child), ga);
-                        addEvidence(evidence, child, "managed plugin " + ga);
+                        if (explain) {
+                            addEvidence(evidence, child, "managed plugin " + ga);
+                        }
                         childAffected = true;
                         break;
                     }
@@ -419,7 +447,9 @@ class PomChangeAnalyzer {
                     && !changedProperties.isEmpty()
                     && hasFilteredResourcesWithChangedProperty(child, changedProperties, maxResourceFileSize)) {
                 logger.debug("Child {} has filtered resources referencing changed properties", key(child));
-                addEvidence(evidence, child, "filtered resources referencing changed properties");
+                if (explain) {
+                    addEvidence(evidence, child, "filtered resources referencing changed properties");
+                }
                 childAffected = true;
             }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -11,8 +11,10 @@ import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -43,6 +45,7 @@ class ReactorTrimmer {
         Set<MavenProject> downstreamOnly = new LinkedHashSet<>();
         Set<MavenProject> downstreamTestOnly = new LinkedHashSet<>();
         Set<MavenProject> upstreamOnly = new LinkedHashSet<>();
+        Map<MavenProject, List<String>> buildReasons = new LinkedHashMap<>();
 
         if (config.isAlsoMakeDependents()) {
             for (MavenProject project : new ArrayList<>(directlyAffected)) {
@@ -62,6 +65,7 @@ class ReactorTrimmer {
                             continue;
                         }
                         if (buildSet.add(ds)) {
+                            addReason(buildReasons, ds, "downstream of " + key(project));
                             // Check if downstream depends on the changed module via test scope only
                             String scope = getDependencyScope(ds, project);
                             if ("test".equals(scope)) {
@@ -88,6 +92,7 @@ class ReactorTrimmer {
                                 && !downstreamTestOnly.contains(us)
                                 && buildSet.add(us)) {
                             upstreamOnly.add(us);
+                            addReason(buildReasons, us, "upstream of " + key(project));
                             newUpstream++;
                         }
                     }
@@ -119,7 +124,11 @@ class ReactorTrimmer {
             }
         }
 
-        return new TrimResult(result, directlyAffected, upstreamOnly, downstreamOnly, downstreamTestOnly);
+        return new TrimResult(result, directlyAffected, upstreamOnly, downstreamOnly, downstreamTestOnly, buildReasons);
+    }
+
+    private static void addReason(Map<MavenProject, List<String>> reasons, MavenProject project, String reason) {
+        reasons.computeIfAbsent(project, k -> new ArrayList<>()).add(reason);
     }
 
     /**

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -65,7 +65,9 @@ class ReactorTrimmer {
                             continue;
                         }
                         if (buildSet.add(ds)) {
-                            addReason(buildReasons, ds, "downstream of " + key(project));
+                            if (config.isExplain()) {
+                                addReason(buildReasons, ds, "downstream of " + key(project));
+                            }
                             // Check if downstream depends on the changed module via test scope only
                             String scope = getDependencyScope(ds, project);
                             if ("test".equals(scope)) {
@@ -92,7 +94,9 @@ class ReactorTrimmer {
                                 && !downstreamTestOnly.contains(us)
                                 && buildSet.add(us)) {
                             upstreamOnly.add(us);
-                            addReason(buildReasons, us, "upstream of " + key(project));
+                            if (config.isExplain()) {
+                                addReason(buildReasons, us, "upstream of " + key(project));
+                            }
                             newUpstream++;
                         }
                     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -181,7 +181,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Map source changes to modules (classifying test-only vs main changes)
             ModuleMapper.Result sourceResult =
-                    moduleMapper.mapToProjectsClassified(sourceChanges, allProjects, reactorRoot);
+                    moduleMapper.mapToProjectsClassified(sourceChanges, allProjects, reactorRoot, config.isExplain());
             Set<MavenProject> affectedBySource = sourceResult.getAllAffected();
             logger.debug("Modules affected by source changes: {}", keys(affectedBySource));
             if (!sourceResult.getTestOnlyAffected().isEmpty()) {
@@ -203,7 +203,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             result.getOldPomContents(),
                             allProjects,
                             reactorRoot,
-                            config.getMaxResourceFileSize());
+                            config.getMaxResourceFileSize(),
+                            config.isExplain());
                     affectedByPom = pomResult.getAffectedProjects();
                     changedManagedDepGAs = pomResult.getChangedManagedDependencyGAs();
                     changedManagedPluginGAs = pomResult.getChangedManagedPluginGAs();
@@ -292,6 +293,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     changedManagedPluginGAs,
                     session,
                     collectCache,
+                    config.isExplain(),
                     transitiveEvidence);
 
             // Explain-mode evidence: which specific input triggered each module
@@ -557,6 +559,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedPluginGAs,
             MavenSession session,
             Map<MavenProject, DependencyResolutionResult> collectCache,
+            boolean explain,
             Map<MavenProject, List<String>> returnEvidence) {
         Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
         Map<MavenProject, List<String>> transitiveEvidence = new LinkedHashMap<>();
@@ -574,10 +577,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 continue;
             }
             TransitiveMatch match = computeTransitiveMatch(
-                    project, changedManagedDepGAs, changedManagedPluginGAs, session, collectCache);
+                    project, changedManagedDepGAs, changedManagedPluginGAs, session, collectCache, explain);
             if (!match.reasons.isEmpty()) {
                 transitivelyAffected.put(project, match.reasons);
-                transitiveEvidence.put(project, match.evidence);
+                if (explain) {
+                    transitiveEvidence.put(project, match.evidence);
+                }
             }
         }
         if (!transitivelyAffected.isEmpty()) {
@@ -605,14 +610,17 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs,
             MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> collectCache) {
+            Map<MavenProject, DependencyResolutionResult> collectCache,
+            boolean explain) {
         List<String> reasons = new ArrayList<>();
-        List<String> evidence = new ArrayList<>();
+        List<String> evidence = explain ? new ArrayList<>() : List.of();
         if (!changedManagedPluginGAs.isEmpty()) {
             String changedPlugin = findChangedPlugin(project, changedManagedPluginGAs);
             if (changedPlugin != null) {
                 reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
-                evidence.add("managed plugin " + changedPlugin);
+                if (explain) {
+                    evidence.add("managed plugin " + changedPlugin);
+                }
             }
         }
         if (!changedManagedDepGAs.isEmpty()) {
@@ -624,7 +632,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 } else {
                     reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
                 }
-                evidence.add("managed dep " + match.ga);
+                if (explain) {
+                    evidence.add("managed dep " + match.ga);
+                }
             }
         }
         return new TransitiveMatch(reasons, evidence);

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -194,6 +194,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedDepGAs = new LinkedHashSet<>();
             Set<String> changedManagedPluginGAs = new LinkedHashSet<>();
             Set<String> changedProperties = new LinkedHashSet<>();
+            Map<MavenProject, Set<String>> pomEvidence = Map.of();
             if (!pomChanges.isEmpty()) {
                 logger.debug("POM changes detected: {}", pomChanges);
                 try {
@@ -207,6 +208,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     changedManagedDepGAs = pomResult.getChangedManagedDependencyGAs();
                     changedManagedPluginGAs = pomResult.getChangedManagedPluginGAs();
                     changedProperties = pomResult.getChangedProperties();
+                    pomEvidence = pomResult.getEvidence();
                 } catch (Exception e) {
                     if (config.isFailSafe()) {
                         logger.warn("Scalpel: Error analyzing POM changes, building all modules: {}", e.getMessage());
@@ -239,14 +241,17 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Force-include modules matching forceBuildModules patterns
             Set<MavenProject> forceIncluded = new LinkedHashSet<>();
+            Map<MavenProject, String> forceBuildPatterns = new LinkedHashMap<>();
             if (!config.getForceBuildModules().isEmpty()) {
                 for (MavenProject project : allProjects) {
                     if (directlyAffected.contains(project)) {
                         continue;
                     }
-                    if (matchesForceBuild(project, config.getForceBuildModules())) {
+                    String pattern = matchesForceBuild(project, config.getForceBuildModules());
+                    if (pattern != null) {
                         directlyAffected.add(project);
                         forceIncluded.add(project);
+                        forceBuildPatterns.put(project, pattern);
                     }
                 }
             }
@@ -279,13 +284,25 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Map<MavenProject, DependencyResolutionResult> collectCache = new LinkedHashMap<>();
 
             // Compute transitively affected modules (via changed managed deps/plugins)
+            Map<MavenProject, List<String>> transitiveEvidence = new LinkedHashMap<>();
             Map<MavenProject, List<String>> transitivelyAffected = computeTransitivelyAffected(
                     allProjects,
                     directlyAffected,
                     changedManagedDepGAs,
                     changedManagedPluginGAs,
                     session,
-                    collectCache);
+                    collectCache,
+                    transitiveEvidence);
+
+            // Explain-mode evidence: which specific input triggered each module
+            Map<MavenProject, List<String>> evidence = config.isExplain()
+                    ? buildEvidence(
+                            sourceResult.getTriggeringFiles(),
+                            pomEvidence,
+                            transitiveEvidence,
+                            forceIncluded,
+                            forceBuildPatterns)
+                    : Map.of();
 
             if (directlyAffected.isEmpty() && transitivelyAffected.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
@@ -356,6 +373,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         ? null
                         : reactorTrimmer.computeBuildSet(
                                 directlyAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
+                if (trimResult != null && config.isExplain()) {
+                    mergeTrimReasons(evidence, trimResult);
+                }
 
                 writeReport(
                         config,
@@ -368,14 +388,26 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .affectedByPom(affectedByPom)
                                 .forceIncluded(forceIncluded)
                                 .transitivelyAffected(transitivelyAffected)
+                                .evidence(evidence)
                                 .trimResult(trimResult)
                                 .build());
+                if (config.isExplain()) {
+                    Set<MavenProject> reportedModules = new LinkedHashSet<>(allAffected);
+                    if (trimResult != null) {
+                        reportedModules.addAll(trimResult.getDownstreamOnly());
+                        reportedModules.addAll(trimResult.getDownstreamTestOnly());
+                    }
+                    logExplainDecisions(allProjects, reportedModules, evidence);
+                }
                 return;
             }
 
             // Compute full build set with upstream/downstream
             TrimResult trimResult = reactorTrimmer.computeBuildSet(
                     allAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
+            if (config.isExplain()) {
+                mergeTrimReasons(evidence, trimResult);
+            }
 
             if (config.isModeSkipTests()) {
                 applySkipTests(
@@ -388,6 +420,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         includeMatchers,
                         reactorRoot,
                         collectCache);
+                if (config.isExplain()) {
+                    logExplainDecisions(allProjects, new LinkedHashSet<>(trimResult.getBuildSet()), evidence);
+                }
             } else {
                 // trim mode: remove unaffected projects from reactor
                 List<MavenProject> buildSet = trimResult.getBuildSet();
@@ -405,6 +440,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 session.setProjects(buildSet);
                 // Apply per-category args in trim mode
                 applyPerCategoryArgs(trimResult, config);
+                if (config.isExplain()) {
+                    logExplainDecisions(allProjects, new LinkedHashSet<>(buildSet), evidence);
+                }
             }
 
         } catch (ScalpelException e) {
@@ -518,8 +556,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs,
             MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> collectCache) {
+            Map<MavenProject, DependencyResolutionResult> collectCache,
+            Map<MavenProject, List<String>> returnEvidence) {
         Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
+        Map<MavenProject, List<String>> transitiveEvidence = new LinkedHashMap<>();
         if (changedManagedDepGAs.isEmpty() && changedManagedPluginGAs.isEmpty()) {
             logger.debug("Skipping transitive analysis: no changed managed dependencies or plugins to check against");
             return transitivelyAffected;
@@ -533,10 +573,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (directlyAffected.contains(project)) {
                 continue;
             }
-            List<String> reasons = computeTransitiveReasons(
+            TransitiveMatch match = computeTransitiveMatch(
                     project, changedManagedDepGAs, changedManagedPluginGAs, session, collectCache);
-            if (!reasons.isEmpty()) {
-                transitivelyAffected.put(project, reasons);
+            if (!match.reasons.isEmpty()) {
+                transitivelyAffected.put(project, match.reasons);
+                transitiveEvidence.put(project, match.evidence);
             }
         }
         if (!transitivelyAffected.isEmpty()) {
@@ -545,30 +586,48 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     transitivelyAffected.size(),
                     keys(transitivelyAffected.keySet()));
         }
+        returnEvidence.putAll(transitiveEvidence);
         return transitivelyAffected;
     }
 
-    private List<String> computeTransitiveReasons(
+    private static final class TransitiveMatch {
+        final List<String> reasons;
+        final List<String> evidence;
+
+        TransitiveMatch(List<String> reasons, List<String> evidence) {
+            this.reasons = reasons;
+            this.evidence = evidence;
+        }
+    }
+
+    private TransitiveMatch computeTransitiveMatch(
             MavenProject project,
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs,
             MavenSession session,
             Map<MavenProject, DependencyResolutionResult> collectCache) {
         List<String> reasons = new ArrayList<>();
-        if (!changedManagedPluginGAs.isEmpty() && usesChangedPlugin(project, changedManagedPluginGAs)) {
-            reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
+        List<String> evidence = new ArrayList<>();
+        if (!changedManagedPluginGAs.isEmpty()) {
+            String changedPlugin = findChangedPlugin(project, changedManagedPluginGAs);
+            if (changedPlugin != null) {
+                reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
+                evidence.add("managed plugin " + changedPlugin);
+            }
         }
         if (!changedManagedDepGAs.isEmpty()) {
-            String depScope = getChangedTransitiveDependencyScope(project, session, changedManagedDepGAs, collectCache);
-            if (depScope != null) {
-                if ("test".equals(depScope)) {
+            ChangedDependencyMatch match =
+                    getChangedTransitiveDependencyMatch(project, session, changedManagedDepGAs, collectCache);
+            if (match != null) {
+                if ("test".equals(match.scope)) {
                     reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
                 } else {
                     reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
                 }
+                evidence.add("managed dep " + match.ga);
             }
         }
-        return reasons;
+        return new TransitiveMatch(reasons, evidence);
     }
 
     private void applySkipTests(
@@ -718,14 +777,21 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     }
 
     private boolean usesChangedPlugin(MavenProject project, Set<String> changedPluginGAs) {
+        return findChangedPlugin(project, changedPluginGAs) != null;
+    }
+
+    /**
+     * Returns the first changed managed plugin GA used by the project, or null.
+     */
+    private String findChangedPlugin(MavenProject project, Set<String> changedPluginGAs) {
         for (Plugin plugin : project.getBuildPlugins()) {
             String ga = plugin.getGroupId() + ":" + plugin.getArtifactId();
             if (changedPluginGAs.contains(ga)) {
                 logger.debug("Module {} uses changed managed plugin {}", key(project), ga);
-                return true;
+                return ga;
             }
         }
-        return false;
+        return null;
     }
 
     private boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
@@ -774,7 +840,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             MavenSession session,
             Set<String> changedGAs,
             Map<MavenProject, DependencyResolutionResult> collectCache) {
-        return getChangedTransitiveDependencyScope(project, session, changedGAs, collectCache) != null;
+        return getChangedTransitiveDependencyMatch(project, session, changedGAs, collectCache) != null;
     }
 
     /**
@@ -796,7 +862,17 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
      * Uses a reject-all DependencyFilter so that only the dependency graph is collected
      * without downloading any artifact files — we only need GA coordinates and scopes.
      */
-    private String getChangedTransitiveDependencyScope(
+    private static final class ChangedDependencyMatch {
+        final String ga;
+        final String scope;
+
+        ChangedDependencyMatch(String ga, String scope) {
+            this.ga = ga;
+            this.scope = scope;
+        }
+    }
+
+    private ChangedDependencyMatch getChangedTransitiveDependencyMatch(
             MavenProject project,
             MavenSession session,
             Set<String> changedGAs,
@@ -833,15 +909,17 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         if (root == null) {
             return null;
         }
-        return findChangedDependencyScope(root, changedGAs, project);
+        return findChangedDependency(root, changedGAs, project);
     }
 
     /**
      * Walks the dependency graph tree to find any dependency matching the changed GAs,
-     * returning the narrowest non-test scope found (or "test" if only test-scoped matches).
+     * returning the match with the narrowest non-test scope (or "test" if only test-scoped matches).
      */
-    private String findChangedDependencyScope(DependencyNode root, Set<String> changedGAs, MavenProject project) {
+    private ChangedDependencyMatch findChangedDependency(
+            DependencyNode root, Set<String> changedGAs, MavenProject project) {
         String narrowestScope = null;
+        String narrowestGa = null;
         Set<String> visited = new HashSet<>();
         List<DependencyNode> stack = new ArrayList<>();
         stack.addAll(root.getChildren());
@@ -863,13 +941,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         ga,
                         scope);
                 if (scope == null || !"test".equals(scope)) {
-                    return scope != null ? scope : "compile";
+                    return new ChangedDependencyMatch(ga, scope != null ? scope : "compile");
                 }
-                narrowestScope = "test";
+                if (narrowestScope == null) {
+                    narrowestScope = "test";
+                    narrowestGa = ga;
+                }
             }
             stack.addAll(node.getChildren());
         }
-        return narrowestScope;
+        return narrowestScope != null ? new ChangedDependencyMatch(narrowestGa, narrowestScope) : null;
     }
 
     private void writeImpactedLog(ScalpelConfiguration config, Path reactorRoot, Set<MavenProject> affectedModules)
@@ -968,6 +1049,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             project.getGroupId(), project.getArtifactId(), path, reasons)
                     .category(ScalpelReport.CATEGORY_DIRECT)
                     .sourceSet(sourceSet)
+                    .evidence(ctx.evidence.get(project))
                     .build());
         }
     }
@@ -998,6 +1080,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             project.getGroupId(), project.getArtifactId(), path, entry.getValue())
                     .category(category)
                     .testsSkippedReason(testsSkippedReason)
+                    .evidence(ctx.evidence.get(project))
                     .build());
         }
     }
@@ -1077,6 +1160,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 project.getGroupId(), project.getArtifactId(), path, List.of(reason))
                         .category(ScalpelReport.CATEGORY_DOWNSTREAM)
                         .testsSkippedReason(testsSkippedReason)
+                        .evidence(ctx.evidence.get(project))
                         .build());
             }
         }
@@ -1117,18 +1201,72 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private boolean matchesForceBuild(MavenProject project, List<String> patterns) {
+    private String matchesForceBuild(MavenProject project, List<String> patterns) {
         for (String pattern : patterns) {
             try {
                 if (project.getArtifactId().matches(pattern)) {
                     logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
-                    return true;
+                    return pattern;
                 }
             } catch (PatternSyntaxException e) {
                 logger.warn("Scalpel: Invalid regex pattern '{}' in forceBuildModules: {}", pattern, e.getMessage());
             }
         }
-        return false;
+        return null;
+    }
+
+    /**
+     * Assembles explain-mode evidence per module: the specific input (changed file, property,
+     * managed dep/plugin GA, force pattern, upstream/downstream relationship) that put each
+     * module into the affected/build set.
+     */
+    private static Map<MavenProject, List<String>> buildEvidence(
+            Map<MavenProject, Set<String>> triggeringFiles,
+            Map<MavenProject, Set<String>> pomEvidence,
+            Map<MavenProject, List<String>> transitiveEvidence,
+            Set<MavenProject> forceIncluded,
+            Map<MavenProject, String> forceBuildPatterns) {
+        Map<MavenProject, List<String>> evidence = new LinkedHashMap<>();
+        for (Map.Entry<MavenProject, Set<String>> entry : triggeringFiles.entrySet()) {
+            evidence.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).addAll(entry.getValue());
+        }
+        for (Map.Entry<MavenProject, Set<String>> entry : pomEvidence.entrySet()) {
+            evidence.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).addAll(entry.getValue());
+        }
+        for (Map.Entry<MavenProject, List<String>> entry : transitiveEvidence.entrySet()) {
+            evidence.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).addAll(entry.getValue());
+        }
+        for (MavenProject project : forceIncluded) {
+            String pattern = forceBuildPatterns.get(project);
+            evidence.computeIfAbsent(project, k -> new ArrayList<>())
+                    .add("forced by forceBuildModules pattern " + pattern);
+        }
+        return evidence;
+    }
+
+    private void mergeTrimReasons(Map<MavenProject, List<String>> evidence, TrimResult trimResult) {
+        for (Map.Entry<MavenProject, List<String>> entry :
+                trimResult.getBuildReasons().entrySet()) {
+            evidence.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).addAll(entry.getValue());
+        }
+    }
+
+    /**
+     * Logs a per-module BUILD/SKIP decision with the specific evidence (explain mode).
+     */
+    private void logExplainDecisions(
+            List<MavenProject> allProjects, Set<MavenProject> buildSet, Map<MavenProject, List<String>> evidence) {
+        for (MavenProject project : allProjects) {
+            if (buildSet.contains(project)) {
+                List<String> items = evidence.get(project);
+                String because = items == null || items.isEmpty()
+                        ? "affected (no specific input recorded)"
+                        : String.join("; ", items);
+                logger.info("Scalpel explain: BUILD {} because: {}", key(project), because);
+            } else {
+                logger.info("Scalpel explain: SKIP {} (not affected by changeset)", key(project));
+            }
+        }
     }
 
     private void skipTestsOnAll(List<MavenProject> projects) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
@@ -9,8 +9,10 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.maven.project.MavenProject;
 
@@ -26,6 +28,7 @@ final class TrimResult {
     private final Set<MavenProject> upstreamOnly;
     private final Set<MavenProject> downstreamOnly;
     private final Set<MavenProject> downstreamTestOnly;
+    private final Map<MavenProject, java.util.List<String>> buildReasons;
 
     TrimResult(
             List<MavenProject> buildSet,
@@ -41,11 +44,22 @@ final class TrimResult {
             Set<MavenProject> upstreamOnly,
             Set<MavenProject> downstreamOnly,
             Set<MavenProject> downstreamTestOnly) {
+        this(buildSet, directlyAffected, upstreamOnly, downstreamOnly, downstreamTestOnly, Map.of());
+    }
+
+    TrimResult(
+            List<MavenProject> buildSet,
+            Set<MavenProject> directlyAffected,
+            Set<MavenProject> upstreamOnly,
+            Set<MavenProject> downstreamOnly,
+            Set<MavenProject> downstreamTestOnly,
+            Map<MavenProject, java.util.List<String>> buildReasons) {
         this.buildSet = Collections.unmodifiableList(new ArrayList<>(buildSet));
         this.directlyAffected = Collections.unmodifiableSet(new LinkedHashSet<>(directlyAffected));
         this.upstreamOnly = Collections.unmodifiableSet(new LinkedHashSet<>(upstreamOnly));
         this.downstreamOnly = Collections.unmodifiableSet(new LinkedHashSet<>(downstreamOnly));
         this.downstreamTestOnly = Collections.unmodifiableSet(new LinkedHashSet<>(downstreamTestOnly));
+        this.buildReasons = Collections.unmodifiableMap(new LinkedHashMap<>(buildReasons));
     }
 
     List<MavenProject> getBuildSet() {
@@ -66,5 +80,13 @@ final class TrimResult {
 
     Set<MavenProject> getDownstreamTestOnly() {
         return downstreamTestOnly;
+    }
+
+    /**
+     * Why each non-direct module is in the build set (explain-mode evidence),
+     * e.g. "downstream of g:a" or "upstream of g:a".
+     */
+    Map<MavenProject, java.util.List<String>> getBuildReasons() {
+        return buildReasons;
     }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3125,7 +3125,8 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(Files.exists(reportFile));
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
         String block = extractModuleBlock(json, "module-a");
-        assertTrue(block != null && block.contains("\"module-a/src/main/java/Foo.java\""),
+        assertTrue(
+                block != null && block.contains("\"module-a/src/main/java/Foo.java\""),
                 "module-a evidence must name the triggering changed file");
     }
 
@@ -3190,7 +3191,8 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(Files.exists(reportFile));
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
         String block = extractModuleBlock(json, "module-x");
-        assertTrue(block != null && block.contains("property foo.version"),
+        assertTrue(
+                block != null && block.contains("property foo.version"),
                 "module-x evidence must name the changed property, block was: " + block);
         assertFalse(modulePresent(json, "module-y"), "module-y does not reference the property, must not be affected");
     }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3087,6 +3087,172 @@ class ScalpelLifecycleParticipantTest {
                 "Report should show 1 excluded upstream module (module-a)");
     }
 
+    // ---------------------------------------------------------------
+    // Explain mode (#93): per-module decision evidence
+    // ---------------------------------------------------------------
+
+    @Test
+    void explainMode_directlyAffectedModuleCarriesTriggeringFile() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        writePom(root, "module-b/pom.xml", simpleChildPom("module-b"));
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB =
+                createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", simpleChildPom("module-b"));
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.explain", "true");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        String block = extractModuleBlock(json, "module-a");
+        assertTrue(block != null && block.contains("\"module-a/src/main/java/Foo.java\""),
+                "module-a evidence must name the triggering changed file");
+    }
+
+    @Test
+    void explainMode_pomPropertyChildCarriesPropertyEvidence() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-x</module><module>module-y</module></modules>
+                  <properties>
+                    <foo.version>1.0</foo.version>
+                  </properties>
+                </project>
+                """;
+        String newParentPom = oldParentPom.replace("<foo.version>1.0</foo.version>", "<foo.version>2.0</foo.version>");
+        writePom(root, "pom.xml", newParentPom);
+
+        String moduleXPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-x</artifactId>
+                  <dependencies>
+                    <dependency><groupId>org.example</groupId><artifactId>lib</artifactId><version>${foo.version}</version></dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "module-x/pom.xml", moduleXPom);
+        String moduleYPom = simpleChildPom("module-y");
+        writePom(root, "module-y/pom.xml", moduleYPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleX = createProject("com.example", "module-x", "1.0", root, "module-x/pom.xml", moduleXPom);
+        moduleX.setParent(parentProject);
+        MavenProject moduleY = createProject("com.example", "module-y", "1.0", root, "module-y/pom.xml", moduleYPom);
+        moduleY.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleX, moduleY);
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.explain", "true");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        String block = extractModuleBlock(json, "module-x");
+        assertTrue(block != null && block.contains("property foo.version"),
+                "module-x evidence must name the changed property, block was: " + block);
+        assertFalse(modulePresent(json, "module-y"), "module-y does not reference the property, must not be affected");
+    }
+
+    @Test
+    void explainDisabled_reportHasNoEvidenceField() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-x</module></modules>
+                  <properties>
+                    <foo.version>1.0</foo.version>
+                  </properties>
+                </project>
+                """;
+        String newParentPom = oldParentPom.replace("<foo.version>1.0</foo.version>", "<foo.version>2.0</foo.version>");
+        writePom(root, "pom.xml", newParentPom);
+
+        String moduleXPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-x</artifactId>
+                  <dependencies>
+                    <dependency><groupId>org.example</groupId><artifactId>lib</artifactId><version>${foo.version}</version></dependency>
+                  </dependencies>
+                </project>
+                """;
+        writePom(root, "module-x/pom.xml", moduleXPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", newParentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleX = createProject("com.example", "module-x", "1.0", root, "module-x/pom.xml", moduleXPom);
+        moduleX.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleX);
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertFalse(json.contains("evidence"), "report must be unchanged (no evidence field) when explain=false");
+    }
+
     // --- Helper methods ---
 
     private void setupEmptyDependencyResolution() throws Exception {


### PR DESCRIPTION
## Problem

As filed in #93: today answering "why did Scalpel skip/build this module?" requires reading the source. The report's `reasons` array gives the category (SOURCE_CHANGE etc.) but not the specific input that triggered it.

## Change

`-Dscalpel.explain=true`, valid in every mode:

- Report module entries gain an optional `evidence` array naming the specific input: the triggering changed file(s), `property <name>`, `managed dep <ga>`, `managed plugin <ga>`, `filtered resources referencing changed properties`, `downstream of <ga>`, `upstream of <ga>`, `forced by forceBuildModules pattern <p>`. Emitted only when explain=true; with explain=false the report is byte-identical (the golden-file test passes unchanged).
- A per-module INFO line per decision in every mode (`Scalpel explain: BUILD module-x because: ...`).
- Schema gains the optional evidence array (no version bump, per the #60 policy).
- Evidence collection is gated on the flag: no string building or map population runs on builds that did not ask for it (a review pass caught the initial version collecting unconditionally).

**Honest scope notes**: parent-self-affected entries currently carry no specific input (the parent-diff block computes six independent booleans; naming which one fired needs a small restructuring of that block); BOM-importer children get the same evidence as inheritance children; multi-hop chains name the immediate neighbor, not the originating module. All are natural follow-ups if you want them.

## Verification

TDD (RED on the missing API, GREEN, plus the gating review commit); full suites green (core 134, extension3 149) including the golden-file byte-identity test.