### PR TITLE
Fix #143: gracefully degrade when git merge-base is unavailable

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -24,6 +24,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.diff.DiffFormatter;
+import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.lib.FileMode;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
@@ -72,6 +73,19 @@ public class GitChangeDetector {
             }
             logger.debug("Merge base between {} and {}: {}", baseBranch, head, mergeBase.getName());
             return mergeBase.getId();
+        } catch (MissingObjectException e) {
+            logger.warn(
+                    "Cannot compute merge base between {} and {}: commit history is incomplete"
+                            + " (shallow clone or missing objects). {}",
+                    baseBranch,
+                    head,
+                    e.getMessage());
+            logger.debug("MissingObjectException details", e);
+            return null;
+        } catch (IOException e) {
+            logger.warn("Cannot compute merge base between {} and {}: {}", baseBranch, head, e.getMessage());
+            logger.debug("Merge base computation error details", e);
+            return null;
         }
     }
 

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.StoredConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -380,6 +381,81 @@ class GitChangeDetectorTest {
     }
 
     // ---- readPomFilesAtCommit ----
+
+    @Test
+    void findMergeBase_shallowClone_returnsNullGracefully() throws Exception {
+        // Set up a bare "remote" repository with two branches diverging from a common base
+        Path bareDir = tempDir.resolve("bare.git");
+        String baseBranchName;
+        try (Git bare = Git.init().setBare(true).setDirectory(bareDir.toFile()).call()) {
+            // nothing to do
+        }
+
+        Path fullWorkDir = tempDir.resolve("full");
+        Files.createDirectories(fullWorkDir);
+        try (Git git = Git.init().setDirectory(fullWorkDir.toFile()).call()) {
+            StoredConfig cfg = git.getRepository().getConfig();
+            cfg.setString("user", null, "name", "Test");
+            cfg.setString("user", null, "email", "test@test.invalid");
+            cfg.save();
+
+            git.remoteAdd()
+                    .setName("origin")
+                    .setUri(new org.eclipse.jgit.transport.URIish(
+                            bareDir.toUri().toString()))
+                    .call();
+
+            // Initial commit (the merge-base)
+            Files.write(fullWorkDir.resolve("base.txt"), "base".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("base.txt").call();
+            git.commit().setMessage("base commit").call();
+            baseBranchName = git.getRepository().getBranch();
+            git.push().setRemote("origin").call();
+
+            // Diverge: add commits on a feature branch
+            git.branchCreate().setName("feature").call();
+            git.checkout().setName("feature").call();
+            // Add enough commits so the shallow clone boundary cuts off the merge-base
+            for (int i = 0; i < 3; i++) {
+                Files.write(fullWorkDir.resolve("f" + i + ".txt"), ("feature-" + i).getBytes(StandardCharsets.UTF_8));
+                git.add().addFilepattern("f" + i + ".txt").call();
+                git.commit().setMessage("feature commit " + i).call();
+            }
+            git.push().setRemote("origin").setForce(true).call();
+        }
+
+        // Shallow clone with depth=1: only the tip commit is available
+        Path shallowDir = tempDir.resolve("shallow");
+        Process cloneProc = new ProcessBuilder(
+                        "git",
+                        "clone",
+                        "--depth",
+                        "1",
+                        "--branch",
+                        "feature",
+                        bareDir.toString(),
+                        shallowDir.toString())
+                .redirectErrorStream(true)
+                .start();
+        cloneProc.getInputStream().readAllBytes();
+        assertEquals(0, cloneProc.waitFor(), "shallow clone should succeed");
+
+        // Fetch the base branch ref so it can be resolved, but with limited depth
+        Process fetchProc = new ProcessBuilder("git", "fetch", "--depth", "1", "origin", baseBranchName)
+                .directory(shallowDir.toFile())
+                .redirectErrorStream(true)
+                .start();
+        fetchProc.getInputStream().readAllBytes();
+        assertEquals(0, fetchProc.waitFor(), "fetch should succeed");
+
+        // Now try to find the merge base — the common ancestor is not reachable
+        try (Git git = Git.open(shallowDir.toFile())) {
+            ObjectId result = detector.findMergeBase(git.getRepository(), "origin/" + baseBranchName, "HEAD");
+
+            // Should return null gracefully instead of throwing MissingObjectException
+            assertNull(result, "findMergeBase should return null in a shallow clone without reachable merge-base");
+        }
+    }
 
     @Test
     void readPomFilesAtCommit_readsMultiplePoms() throws Exception {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
@@ -23,6 +23,7 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -433,27 +434,87 @@ class GitChangeDetectorTest {
                         "1",
                         "--branch",
                         "feature",
-                        bareDir.toString(),
+                        bareDir.toUri().toString(),
                         shallowDir.toString())
                 .redirectErrorStream(true)
                 .start();
         cloneProc.getInputStream().readAllBytes();
         assertEquals(0, cloneProc.waitFor(), "shallow clone should succeed");
 
-        // Fetch the base branch ref so it can be resolved, but with limited depth
-        Process fetchProc = new ProcessBuilder("git", "fetch", "--depth", "1", "origin", baseBranchName)
+        // Fetch the base branch with an explicit refspec so origin/<baseBranch> is created
+        Process fetchProc = new ProcessBuilder(
+                        "git",
+                        "fetch",
+                        "--depth",
+                        "1",
+                        "origin",
+                        "+refs/heads/" + baseBranchName + ":refs/remotes/origin/" + baseBranchName)
                 .directory(shallowDir.toFile())
                 .redirectErrorStream(true)
                 .start();
         fetchProc.getInputStream().readAllBytes();
         assertEquals(0, fetchProc.waitFor(), "fetch should succeed");
 
-        // Now try to find the merge base — the common ancestor is not reachable
+        // Remove .git/shallow so JGit does not treat the shallow boundary as a root.
+        // Without this file JGit will attempt to walk parent commits that were not fetched,
+        // triggering MissingObjectException instead of silently stopping at the boundary.
+        Path shallowFile = shallowDir.resolve(".git/shallow");
+        assertTrue(Files.exists(shallowFile), ".git/shallow should exist after a shallow clone");
+        Files.delete(shallowFile);
+
+        // Now try to find the merge base — both refs resolve, but parent objects are missing
         try (Git git = Git.open(shallowDir.toFile())) {
+            ObjectId baseRef = git.getRepository().resolve("origin/" + baseBranchName);
+            assertNotNull(baseRef, "origin/" + baseBranchName + " should be resolvable after fetch");
+
             ObjectId result = detector.findMergeBase(git.getRepository(), "origin/" + baseBranchName, "HEAD");
 
             // Should return null gracefully instead of throwing MissingObjectException
             assertNull(result, "findMergeBase should return null in a shallow clone without reachable merge-base");
+        }
+    }
+
+    @Test
+    void findMergeBase_corruptedObject_returnsNullGracefully() throws Exception {
+        Path repoDir = tempDir.resolve("corrupt-repo");
+        Files.createDirectories(repoDir);
+        try (Git git = Git.init().setDirectory(repoDir.toFile()).call()) {
+            StoredConfig cfg = git.getRepository().getConfig();
+            cfg.setString("user", null, "name", "Test");
+            cfg.setString("user", null, "email", "test@test.invalid");
+            cfg.save();
+
+            // Create a base commit (this will be the merge-base ancestor)
+            Files.write(repoDir.resolve("base.txt"), "base".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("base.txt").call();
+            RevCommit baseCommit = git.commit().setMessage("base").call();
+            String baseSha = baseCommit.getName();
+
+            // Create branch A from base
+            git.checkout().setCreateBranch(true).setName("branchA").call();
+            Files.write(repoDir.resolve("a.txt"), "a".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("a.txt").call();
+            git.commit().setMessage("commit on A").call();
+
+            // Create branch B from base
+            git.checkout().setName(baseSha).call();
+            git.checkout().setCreateBranch(true).setName("branchB").call();
+            Files.write(repoDir.resolve("b.txt"), "b".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("b.txt").call();
+            git.commit().setMessage("commit on B").call();
+
+            // Corrupt the base commit's loose object file (CorruptObjectException extends IOException,
+            // not MissingObjectException, so this exercises the generic IOException catch)
+            Path objectFile = repoDir.resolve(".git/objects/" + baseSha.substring(0, 2) + "/" + baseSha.substring(2));
+            assertTrue(Files.exists(objectFile), "Loose object file should exist before corruption");
+            objectFile.toFile().setWritable(true);
+            Files.write(objectFile, "CORRUPT".getBytes(StandardCharsets.UTF_8));
+        }
+
+        // Reopen the repository to clear any cached objects
+        try (Git git = Git.open(repoDir.toFile())) {
+            ObjectId result = detector.findMergeBase(git.getRepository(), "branchA", "branchB");
+            assertNull(result, "findMergeBase should return null when git objects are corrupted");
         }
     }
 

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -273,6 +273,66 @@ class ScalpelCoreTest {
         }
     }
 
+    /**
+     * Detector whose findMergeBase returns null (simulating graceful degradation
+     * when the merge-base is unreachable, e.g. shallow clone).
+     */
+    private static final GitChangeDetector MERGE_BASE_NULL_DETECTOR = new GitChangeDetector() {
+        @Override
+        public ObjectId findMergeBase(Repository repository, String baseBranch, String head) {
+            return null;
+        }
+    };
+
+    @Test
+    void detectChanges_mergeBaseUnavailable_failSafe_returnsNull() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(tempDir.resolve("new.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new.txt").call();
+            git.commit().setMessage("change").call();
+
+            ScalpelCore core = new ScalpelCore(MERGE_BASE_NULL_DETECTOR);
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.failSafe", "true");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
+
+            assertNull(result, "failSafe should return null (build all) when merge-base is unavailable");
+        }
+    }
+
+    @Test
+    void detectChanges_mergeBaseUnavailable_failSafeDisabled_throwsScalpelException() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(tempDir.resolve("new.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new.txt").call();
+            git.commit().setMessage("change").call();
+
+            ScalpelCore core = new ScalpelCore(MERGE_BASE_NULL_DETECTOR);
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.failSafe", "false");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            assertThrows(
+                    ScalpelException.class,
+                    () -> core.detectChanges(tempDir, config, Set.of()),
+                    "Should throw when merge-base is unavailable and failSafe is disabled");
+        }
+    }
+
     private static final GitChangeDetector THROWING_DETECTOR = new GitChangeDetector() {
         @Override
         public ObjectId findMergeBase(Repository repository, String baseBranch, String head) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -408,6 +408,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
         } catch (ScalpelException e) {
+            if (config.isFailSafe()) {
+                logger.warn("Scalpel: {}, building all modules", e.getMessage());
+                logger.debug("ScalpelException details", e);
+                return;
+            }
             throw new MavenExecutionException("Scalpel: " + e.getMessage(), e);
         } catch (Exception e) {
             if (config.isFailSafe()) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
 import eu.maveniverse.maven.scalpel.core.ScalpelCore;
+import eu.maveniverse.maven.scalpel.core.ScalpelException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -2717,6 +2718,70 @@ class ScalpelLifecycleParticipantTest {
         // failSafe=true → should not throw, just return (build all)
         Path reportFile = root.resolve("target/scalpel-report.json");
         assertFalse(Files.exists(reportFile));
+    }
+
+    @Test
+    void scalpelException_failSafeTrue_buildsAll() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        // ScalpelCore throws ScalpelException (e.g. merge-base unavailable with failSafe=false in core,
+        // but the lifecycle participant should still respect its own failSafe check)
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenThrow(new ScalpelException("Could not find merge base between origin/main and HEAD"));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.failSafe", "true");
+
+        // Should not throw — failSafe=true should catch ScalpelException gracefully
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertFalse(Files.exists(reportFile));
+    }
+
+    @Test
+    void scalpelException_failSafeDisabled_throws() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenThrow(new ScalpelException("Could not find merge base between origin/main and HEAD"));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.failSafe", "false");
+
+        // Should throw MavenExecutionException when failSafe is disabled
+        assertThrows(
+                MavenExecutionException.class,
+                () -> participant.afterProjectsRead(session),
+                "Should throw MavenExecutionException when ScalpelException occurs with failSafe disabled");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Catch `MissingObjectException` in `GitChangeDetector.findMergeBase()` so shallow clones and incomplete git history log a warning and return `null` (triggering full-reactor fallback) instead of crashing Maven with exit code 1
- Make `ScalpelLifecycleParticipant`'s `ScalpelException` handler respect `failSafe` — previously it always rethrew as `MavenExecutionException`, bypassing the `failSafe` flag
- Add comprehensive tests: shallow-clone integration test for `GitChangeDetector`, mock-based tests for `ScalpelCore` with null merge-base, and `ScalpelLifecycleParticipant` tests for `ScalpelException` + `failSafe` interaction

Closes #143

## Test plan

- [x] `GitChangeDetectorTest.findMergeBase_shallowClone_returnsNullGracefully` — creates a real shallow clone (`git clone --depth 1`) and verifies `findMergeBase` returns `null` instead of throwing
- [x] `ScalpelCoreTest.detectChanges_mergeBaseUnavailable_failSafe_returnsNull` — verifies `detectChanges` returns `null` when merge-base is unavailable with `failSafe=true`
- [x] `ScalpelCoreTest.detectChanges_mergeBaseUnavailable_failSafeDisabled_throwsScalpelException` — verifies `ScalpelException` is thrown when `failSafe=false`
- [x] `ScalpelLifecycleParticipantTest.scalpelException_failSafeTrue_buildsAll` — verifies lifecycle participant continues when `failSafe=true`
- [x] `ScalpelLifecycleParticipantTest.scalpelException_failSafeDisabled_throws` — verifies `MavenExecutionException` when `failSafe=false`
- [x] All 148 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or shallow Git histories when determining changes.
  * Builds now continue with all modules in fail-safe mode when change detection cannot determine a merge base.
  * When fail-safe mode is disabled, merge-base failures continue to stop the build with an error.

* **Tests**
  * Added coverage for shallow clones and fail-safe lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->