### PR TITLE
chore: add release-drafter for automated changelogs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+name-template: 'Scalpel $RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+
+categories:
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🚀 Enhancements'
+    labels:
+      - 'enhancement'
+  - title: '📖 Documentation'
+    labels:
+      - 'documentation'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'dependencies'
+      - 'github_actions'
+      - 'java'
+
+exclude-labels:
+  - 'duplicate'
+  - 'invalid'
+  - 'wontfix'
+  - 'question'
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'dependencies'
+      - 'github_actions'
+      - 'java'
+      - 'documentation'
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,7 @@ categories:
       - 'documentation'
   - title: '🧰 Maintenance'
     labels:
+      - 'maintenance'
       - 'dependencies'
       - 'github_actions'
       - 'java'
@@ -30,6 +31,12 @@ autolabeler:
     files:
       - '*.md'
       - 'docs/**'
+  - label: 'maintenance'
+    branch:
+      - '/chore\/.+/'
+      - '/quick-fix\/.+/'
+    title:
+      - '/chore/i'
   - label: 'github_actions'
     files:
       - '.github/workflows/**'
@@ -60,6 +67,7 @@ version-resolver:
   patch:
     labels:
       - 'bug'
+      - 'maintenance'
       - 'dependencies'
       - 'github_actions'
       - 'java'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,6 +17,29 @@ categories:
       - 'github_actions'
       - 'java'
 
+autolabeler:
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+  - label: 'documentation'
+    files:
+      - '*.md'
+      - 'docs/**'
+  - label: 'github_actions'
+    files:
+      - '.github/workflows/**'
+      - '.github/**/*.yml'
+  - label: 'java'
+    files:
+      - '**/*.java'
+      - 'pom.xml'
+      - '**/pom.xml'
+
 exclude-labels:
   - 'duplicate'
   - 'invalid'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,6 +20,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,5 +99,12 @@ jobs:
           fi
 
           name="Scalpel"
-          echo "Creating release \"$name $version\" from tag"
-          gh release create $version --verify-tag --notes-from-tag --title "$name $version" || echo "Release already exists, skipping creation"
+          # If release-drafter already created a draft, publish it with the tag;
+          # otherwise fall back to creating a new release from the tag annotation.
+          if gh release view $version > /dev/null 2>&1; then
+            echo "Publishing existing draft release \"$name $version\""
+            gh release edit $version --draft=false --verify-tag --title "$name $version"
+          else
+            echo "Creating release \"$name $version\" from tag"
+            gh release create $version --verify-tag --notes-from-tag --title "$name $version" || echo "Release already exists, skipping creation"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,15 @@ on:
     tags:
       - '[0-9]*.[0-9]*.[0-9]*'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release to Maven Central
+    permissions:
+      contents: write
+      issues: write
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
     steps:
@@ -106,5 +112,5 @@ jobs:
             gh release edit $version --draft=false --verify-tag --title "$name $version"
           else
             echo "Creating release \"$name $version\" from tag"
-            gh release create $version --verify-tag --notes-from-tag --title "$name $version" || echo "Release already exists, skipping creation"
+            gh release create $version --verify-tag --notes-from-tag --title "$name $version"
           fi


### PR DESCRIPTION
## Summary

- Add release-drafter config (`.github/release-drafter.yml`) that categorizes merged PRs by label:
  - 🐛 **Bug Fixes** → `bug`
  - 🚀 **Enhancements** → `enhancement`
  - 📖 **Documentation** → `documentation`
  - 🧰 **Maintenance** → `dependencies`, `github_actions`, `java`
- Add release-drafter workflow (`.github/workflows/release-drafter.yml`) that updates a draft release on every push to `main` and auto-labels PRs
- Update release workflow to publish the existing draft release when a tag is pushed, falling back to `--notes-from-tag` if no draft exists

## Test plan

- [x] Verify release-drafter workflow triggers on push to `main` and `pull_request_target`
- [ ] After merge, check that a draft release appears under GitHub Releases
- [ ] On next tag push, verify the release workflow publishes the draft with the correct changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated draft release management and versioning based on change labels.
  * Improved release publishing by updating existing drafts or creating releases automatically.

* **Bug Fixes**
  * Builds now handle incomplete or corrupted Git histories gracefully.
  * Fail-safe mode allows builds to continue when change detection encounters recoverable errors.

* **Tests**
  * Added coverage for shallow clones, corrupted Git objects, unavailable merge bases, and fail-safe lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->