### PR TITLE
Fix #94: consolidate the v2 schema, validate reports against it, document the compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ is published alongside the code. The current version is **2**.
   "baseBranch": "origin/main",
   "fullBuildTriggered": false,
   "triggerFile": null,
-  "changedFiles": ["module-a/src/main/java/Foo.java", "module-b/src/test/java/BarTest.java"],
+  "changedFiles": ["module-a/src/main/java/Foo.java", "module-b/src/test/java/BarTest.java", "gated-module/pom.xml"],
   "changedProperties": [],
   "changedManagedDependencies": [],
   "changedManagedPlugins": [],
+  "unmatchedPomPaths": ["gated-module/pom.xml"],
   "excludedUpstreamCount": 0,
   "affectedModules": [
     {
@@ -134,7 +135,8 @@ is published alongside the code. The current version is **2**.
       "path": "module-a",
       "reasons": ["SOURCE_CHANGE"],
       "category": "DIRECT",
-      "sourceSet": "main"
+      "sourceSet": "main",
+      "evidence": ["module-a/src/main/java/Foo.java"]
     },
     {
       "groupId": "com.example",
@@ -153,9 +155,25 @@ is published alongside the code. The current version is **2**.
       "testsSkipped": true,
       "testsSkippedReason": "EXCLUDED_DOWNSTREAM"
     }
+  ],
+  "skippedModules": [
+    {
+      "groupId": "com.example",
+      "artifactId": "module-d",
+      "path": "module-d",
+      "reason": "NOT_AFFECTED"
+    }
   ]
 }
 ```
+
+**Optional fields:** `unmatchedPomPaths` lists changed POMs that match no reactor project
+(profile-gated or `-pl`-excluded modules; their changes are ignored, with a warning).
+`skippedModules` enumerates reactor modules left out of the build set, each with the reason
+it was judged safe to skip (`NOT_AFFECTED`); it makes a green trimmed build reviewable.
+`evidence` on a module entry lists the specific inputs behind that module's decision (a
+changed file path, `property <name>`, `managed dep <ga>`, `managed plugin <ga>`, `downstream
+of <ga>`) and is emitted only with `-Dscalpel.explain=true`. All three are omitted when empty.
 
 **Status-only reports:** when analysis does not complete (failSafe bail-out, unexpected
 error) or is deliberately skipped (no changes detected, disabled by
@@ -169,12 +187,15 @@ e.g. `"no changes detected"`). Both fields are absent from normal full reports.
 
 | Version | Changes |
 |---------|---------|
-| `2` | Added `category`, `sourceSet`, `excludedUpstreamCount`, `testsSkipped`, `testsSkippedReason` |
+| `2` | Added `category`, `sourceSet`, `excludedUpstreamCount`, `testsSkipped`, `testsSkippedReason`. Later additive (no bump): `status`, `reason` (#137), `unmatchedPomPaths` (#138), `skippedModules` (#139), `evidence` (#142) |
 | `1` | Initial schema |
 
-**Compatibility:** new optional fields may be added within a major version. Consumers
-should ignore unknown fields. A version bump signals structural changes that existing
-consumers may need to handle.
+**Compatibility policy:** within a schema version, Scalpel may add new *optional* fields and
+new enum values; consumers must tolerate both (ignore unknown fields, treat unrecognized enum
+values as unknown). A version bump is required when a change breaks such consumers: removing
+or renaming a field, changing a field's type, making an optional field required, or removing
+an enum value. Reports are validated against the checked-in schema by
+`core`'s unit tests, so the schema cannot silently drift from what the code emits.
 
 **Affected module reasons:**
 
@@ -186,10 +207,12 @@ consumers may need to handle.
 | `TRANSITIVE_DEPENDENCY` | A changed managed dependency reaches this module transitively (compile/runtime scope) |
 | `TRANSITIVE_DEPENDENCY_TEST` | A changed managed dependency reaches this module transitively via test scope only |
 | `MANAGED_PLUGIN` | This module uses a plugin whose managed version changed |
-| `UPSTREAM_DEPENDENCY` | *(deprecated)* Included as an upstream dependency (via `alsoMake`) |
 | `DOWNSTREAM_DEPENDENT` | Included as a downstream dependent (via `alsoMakeDependents`) |
 | `DOWNSTREAM_TEST` | Included as a downstream dependent via test-scoped dependency only |
 | `FORCE_BUILD` | This module was force-included via `forceBuildModules` |
+
+Upstream build-prerequisite modules are not listed with a reason; they are excluded from
+`affectedModules` and only counted in `excludedUpstreamCount` (see #39).
 
 **Affected module source sets** (present on directly affected modules with source changes):
 
@@ -213,7 +236,14 @@ consumers may need to handle.
 |-------|------|-------------|
 | `excludedUpstreamCount` | integer | *(top-level)* Number of upstream build-prerequisite modules excluded from `affectedModules` |
 | `testsSkipped` | boolean | Present and `true` when tests are skipped for this module |
-| `testsSkippedReason` | string | Why tests were skipped (e.g. `EXCLUDED_DOWNSTREAM`) |
+| `testsSkippedReason` | string | Why tests were skipped; see values below |
+| `evidence` | array of strings | Explain-mode inputs behind this module's decision (requires `-Dscalpel.explain=true`) |
+
+**Test-skip reasons** (value of `testsSkippedReason`):
+
+| Value | Description |
+|-------|-------------|
+| `EXCLUDED_DOWNSTREAM` | The module is a downstream dependent that matched `skipTestsForDownstreamModules`, so it is built without tests |
 
 ## Source-Set-Aware Downstream Propagation
 

--- a/README.md
+++ b/README.md
@@ -194,8 +194,13 @@ e.g. `"no changes detected"`). Both fields are absent from normal full reports.
 new enum values; consumers must tolerate both (ignore unknown fields, treat unrecognized enum
 values as unknown). A version bump is required when a change breaks such consumers: removing
 or renaming a field, changing a field's type, making an optional field required, or removing
-an enum value. Reports are validated against the checked-in schema by
-`core`'s unit tests, so the schema cannot silently drift from what the code emits.
+an enum value that the schema ever declared and could have been emitted; removing an enum
+value that no released schema ever carried and that the code no longer emits (such as the
+never-emitted `UPSTREAM_DEPENDENCY` removed from the v2 enum in this change) does not break
+any consumer and needs no bump. Reports are validated against the checked-in schema by
+`core`'s unit tests, guarding required fields and enum values against drift in both
+directions; a newly emitted *optional* field still requires a deliberate schema edit, which
+the drift guard surfaces through the enum and required-field checks.
 
 **Affected module reasons:**
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -18,8 +18,10 @@ import java.util.List;
 public final class ScalpelReport {
 
     /**
-     * Report schema version. Bump this whenever the report JSON structure changes
-     * (new fields, removed fields, or semantic changes to existing fields).
+     * Report schema version. Bump this on breaking changes only: removing or renaming fields,
+     * changing a field's type, making an optional field required, or removing enum values.
+     * Adding optional fields (and new enum values consumers must tolerate) does not bump the
+     * version; see the compatibility policy in the README's Report Format section.
      * <p>
      * v1 → v2: added {@code category}, {@code sourceSet}, {@code excludedUpstreamCount},
      *           {@code testsSkipped}, {@code testsSkippedReason}.
@@ -31,13 +33,6 @@ public final class ScalpelReport {
     public static final String REASON_TRANSITIVE_DEPENDENCY = "TRANSITIVE_DEPENDENCY";
     public static final String REASON_MANAGED_PLUGIN = "MANAGED_PLUGIN";
     public static final String REASON_FORCE_BUILD = "FORCE_BUILD";
-    /**
-     * @deprecated Upstream modules are no longer included in report mode (see #39).
-     *             They are build-order prerequisites, not genuinely affected modules.
-     */
-    @Deprecated
-    public static final String REASON_UPSTREAM_DEPENDENCY = "UPSTREAM_DEPENDENCY";
-
     public static final String REASON_DOWNSTREAM_DEPENDENT = "DOWNSTREAM_DEPENDENT";
     public static final String REASON_TEST_CHANGE = "TEST_CHANGE";
     public static final String REASON_DOWNSTREAM_TEST = "DOWNSTREAM_TEST";

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -21,7 +21,7 @@
     "version": {
       "type": "string",
       "const": "2",
-      "description": "Report schema version. '2' indicates the v2 format with category, sourceSet, excludedUpstreamCount, testsSkipped, and testsSkippedReason fields."
+      "description": "Report schema version. '2' indicates the v2 format with category, sourceSet, excludedUpstreamCount, testsSkipped, and testsSkippedReason fields, plus the optional fields added within v2 under the compatibility policy: status, reason, unmatchedPomPaths, skippedModules, and evidence."
     },
     "scalpelVersion": {
       "type": "string",
@@ -74,12 +74,11 @@
       "items": { "$ref": "#/$defs/affectedModule" },
       "description": "Modules affected by the changeset, with reasons and optional metadata."
     },
-<<<<<<< HEAD
     "skippedModules": {
       "type": "array",
       "items": { "$ref": "#/$defs/skippedModule" },
       "description": "Optional (added without a version bump per the optional-fields policy): reactor modules left out of the build set, each with the reason it was judged safe to skip. Present only when at least one module was skipped."
-=======
+    },
     "status": {
       "type": "string",
       "enum": ["failed", "skipped"],
@@ -88,7 +87,6 @@
     "reason": {
       "type": "string",
       "description": "Human-readable explanation accompanying an optional status field (e.g. 'no changes detected')."
->>>>>>> origin/main
     }
   },
   "$defs": {
@@ -119,7 +117,6 @@
               "TRANSITIVE_DEPENDENCY",
               "TRANSITIVE_DEPENDENCY_TEST",
               "MANAGED_PLUGIN",
-              "UPSTREAM_DEPENDENCY",
               "DOWNSTREAM_DEPENDENT",
               "DOWNSTREAM_TEST",
               "FORCE_BUILD"

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -216,14 +216,17 @@ class ScalpelReportSchemaTest {
 
     private static List<String> moduleReasonsEnum() {
         Map<String, Object> affectedModule = cast(defs().get("affectedModule"), "$defs.affectedModule");
-        Map<String, Object> reasons = cast(affectedModule.get("reasons"), "affectedModule.reasons");
-        return cast(reasons.get("enum"), "affectedModule.reasons.enum");
+        Map<String, Object> properties = cast(affectedModule.get("properties"), "affectedModule.properties");
+        Map<String, Object> reasons = cast(properties.get("reasons"), "affectedModule.properties.reasons");
+        Map<String, Object> items = cast(reasons.get("items"), "affectedModule.properties.reasons.items");
+        return cast(items.get("enum"), "affectedModule.properties.reasons.items.enum");
     }
 
     private static List<String> skippedModuleReasonsEnum() {
         Map<String, Object> skippedModule = cast(defs().get("skippedModule"), "$defs.skippedModule");
-        Map<String, Object> reason = cast(skippedModule.get("reason"), "skippedModule.reason");
-        return cast(reason.get("enum"), "skippedModule.reason.enum");
+        Map<String, Object> properties = cast(skippedModule.get("properties"), "skippedModule.properties");
+        Map<String, Object> reason = cast(properties.get("reason"), "skippedModule.properties.reason");
+        return cast(reason.get("enum"), "skippedModule.properties.reason.enum");
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -1,0 +1,612 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates the JSON emitted by {@link ScalpelReport#toJson()} against the checked-in
+ * scalpel-report-v2.schema.json, so the schema cannot drift from what the code emits.
+ *
+ * <p>Validator choice: core ships as part of a Maven extension and has no JSON library on its
+ * compile or test classpath (only slf4j, javax.inject, sisu, jgit, junit). Rather than growing
+ * the dependency footprint with a JSON parser plus a schema validator (e.g.
+ * com.networknt:json-schema-validator and its Jackson transitives) for one test, this class
+ * carries a compact JSON reader and a validator for the exact JSON Schema subset the schema
+ * uses: {@code $ref} into {@code $defs}, {@code type}, {@code const}, {@code enum},
+ * {@code required}, {@code properties}, {@code items}, {@code minimum}, {@code minItems}.
+ * The validator reports any keyword it does not implement as an error, so a future schema
+ * keyword cannot silently weaken this test.
+ */
+class ScalpelReportSchemaTest {
+
+    private static Map<String, Object> schema;
+
+    @BeforeAll
+    static void loadSchema() throws IOException {
+        try (InputStream is = ScalpelReportSchemaTest.class.getResourceAsStream(
+                "/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json")) {
+            assertNotNull(is, "scalpel-report-v2.schema.json must be on the classpath");
+            String text = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertTrue(
+                    !text.contains("<<<<<<<") && !text.contains("=======") && !text.contains(">>>>>>>"),
+                    "schema file must not contain git merge conflict markers");
+            schema = cast(Json.parse(text), "schema root");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Schema validation of emitted reports
+    // ---------------------------------------------------------------
+
+    @Test
+    void representativeReportWithAllOptionalFields_validatesAgainstSchema() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .status("skipped")
+                .reason("integration test fixture")
+                .fullBuildTriggered(false)
+                .changedFiles(List.of("module-a/src/main/java/Foo.java", "gated-module/pom.xml"))
+                .changedProperties(List.of("kafka.version"))
+                .changedManagedDependencies(List.of("org.apache.kafka:kafka-clients"))
+                .changedManagedPlugins(List.of("org.apache.maven.plugins:maven-compiler-plugin"))
+                .unmatchedPomPaths(List.of("gated-module/pom.xml"))
+                .excludedUpstreamCount(1)
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE))
+                        .category(ScalpelReport.CATEGORY_DIRECT)
+                        .sourceSet("main")
+                        .evidence(List.of("module-a/src/main/java/Foo.java"))
+                        .build())
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example",
+                                "module-b",
+                                "module-b",
+                                List.of(ScalpelReport.REASON_DOWNSTREAM_DEPENDENT))
+                        .category(ScalpelReport.CATEGORY_DOWNSTREAM)
+                        .testsSkippedReason(ScalpelReport.REASON_EXCLUDED_DOWNSTREAM)
+                        .build())
+                .addSkippedModule(new ScalpelReport.SkippedModule(
+                        "com.example", "module-c", "module-c", ScalpelReport.SKIP_REASON_NOT_AFFECTED))
+                .build();
+
+        assertEquals(List.of(), validate(report), "report with every optional field populated must validate");
+    }
+
+    @Test
+    void minimalReportWithoutOptionalFields_validatesAgainstSchema() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE)))
+                .build();
+
+        assertEquals(List.of(), validate(report), "minimal report must validate");
+    }
+
+    @Test
+    void statusOnlyReport_validatesAgainstSchema() {
+        // Mirrors ScalpelLifecycleParticipant.writeStatusReport: the minimal document written
+        // when analysis did not complete or was deliberately skipped.
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("(unconfigured)")
+                .status("skipped")
+                .reason("no changes detected")
+                .fullBuildTriggered(true)
+                .build();
+
+        assertEquals(List.of(), validate(report), "status-only report must validate");
+    }
+
+    @Test
+    void schema_rejectsInvalidReports() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .excludedUpstreamCount(1)
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE))
+                        .category(ScalpelReport.CATEGORY_DIRECT)
+                        .build())
+                .addSkippedModule(new ScalpelReport.SkippedModule(
+                        "com.example", "module-c", "module-c", ScalpelReport.SKIP_REASON_NOT_AFFECTED))
+                .build();
+
+        // Negative controls: prove the validator actually validates, not vacuously passes.
+        assertTrue(
+                validate(mutate(report, m -> m.remove("affectedModules"))).stream()
+                        .anyMatch(e -> e.contains("affectedModules")),
+                "missing required field must be rejected");
+        assertTrue(
+                validate(mutate(report, m -> m.put("fullBuildTriggered", "yes"))).stream()
+                        .anyMatch(e -> e.contains("fullBuildTriggered")),
+                "wrong type must be rejected");
+        assertTrue(
+                validate(mutate(report, m -> m.put("status", "pending"))).stream()
+                        .anyMatch(e -> e.contains("status")),
+                "unknown status enum value must be rejected");
+        assertTrue(
+                validate(mutate(report, m -> m.put("excludedUpstreamCount", -1L))).stream()
+                        .anyMatch(e -> e.contains("excludedUpstreamCount")),
+                "excludedUpstreamCount below minimum must be rejected");
+        assertTrue(
+                validate(mutate(report, m -> {
+                            List<Object> modules = cast(m.get("affectedModules"), "affectedModules");
+                            Map<String, Object> module = cast(modules.get(0), "affectedModules[0]");
+                            module.put("reasons", List.of("BOGUS_REASON"));
+                        }))
+                        .stream()
+                        .anyMatch(e -> e.contains("BOGUS_REASON")),
+                "unknown module reason must be rejected");
+        assertTrue(
+                validate(mutate(report, m -> {
+                            List<Object> modules = cast(m.get("skippedModules"), "skippedModules");
+                            Map<String, Object> module = cast(modules.get(0), "skippedModules[0]");
+                            module.put("reason", "WHATEVER");
+                        }))
+                        .stream()
+                        .anyMatch(e -> e.contains("WHATEVER")),
+                "unknown skipped-module reason must be rejected");
+    }
+
+    // ---------------------------------------------------------------
+    // Schema/code drift guards
+    // ---------------------------------------------------------------
+
+    @Test
+    void schemaModuleReasons_matchEmittableConstants() {
+        // Every REASON_* constant that can appear in affectedModules.reasons, and nothing else.
+        List<String> expected = List.of(
+                ScalpelReport.REASON_SOURCE_CHANGE,
+                ScalpelReport.REASON_TEST_CHANGE,
+                ScalpelReport.REASON_POM_CHANGE,
+                ScalpelReport.REASON_TRANSITIVE_DEPENDENCY,
+                ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST,
+                ScalpelReport.REASON_MANAGED_PLUGIN,
+                ScalpelReport.REASON_DOWNSTREAM_DEPENDENT,
+                ScalpelReport.REASON_DOWNSTREAM_TEST,
+                ScalpelReport.REASON_FORCE_BUILD);
+        assertEquals(expected, moduleReasonsEnum());
+    }
+
+    @Test
+    void schemaSkippedReasons_matchEmittableConstants() {
+        assertEquals(List.of(ScalpelReport.SKIP_REASON_NOT_AFFECTED), skippedModuleReasonsEnum());
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private interface Mutation {
+        void apply(Map<String, Object> document);
+    }
+
+    private static List<String> validate(ScalpelReport report) {
+        return new JsonSchema(schema).validate(Json.parse(report.toJson()));
+    }
+
+    private static List<String> validate(Map<String, Object> document) {
+        return new JsonSchema(schema).validate(document);
+    }
+
+    private static Map<String, Object> mutate(ScalpelReport report, Mutation mutation) {
+        Map<String, Object> document = cast(Json.parse(report.toJson()), "document");
+        mutation.apply(document);
+        return document;
+    }
+
+    private static List<String> moduleReasonsEnum() {
+        Map<String, Object> affectedModule = cast(defs().get("affectedModule"), "$defs.affectedModule");
+        Map<String, Object> reasons = cast(affectedModule.get("reasons"), "affectedModule.reasons");
+        return cast(reasons.get("enum"), "affectedModule.reasons.enum");
+    }
+
+    private static List<String> skippedModuleReasonsEnum() {
+        Map<String, Object> skippedModule = cast(defs().get("skippedModule"), "$defs.skippedModule");
+        Map<String, Object> reason = cast(skippedModule.get("reason"), "skippedModule.reason");
+        return cast(reason.get("enum"), "skippedModule.reason.enum");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> defs() {
+        return cast(schema.get("$defs"), "$defs");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T cast(Object value, String what) {
+        if (value == null) {
+            throw new IllegalStateException("expected " + what + " but found null");
+        }
+        return (T) value;
+    }
+
+    /**
+     * Minimal recursive-descent JSON reader. Produces {@code Map<String,Object>} (insertion
+     * ordered), {@code List<Object>}, {@code String}, {@code Long}, {@code Double},
+     * {@code Boolean}, and {@code null}. Enough for the report and the schema; not a
+     * general-purpose parser.
+     */
+    static final class Json {
+        private final String text;
+        private int pos;
+
+        private Json(String text) {
+            this.text = text;
+        }
+
+        static Object parse(String text) {
+            Json parser = new Json(text);
+            parser.skipWhitespace();
+            Object value = parser.parseValue();
+            parser.skipWhitespace();
+            if (parser.pos != parser.text.length()) {
+                throw parser.error("trailing content");
+            }
+            return value;
+        }
+
+        private Object parseValue() {
+            if (pos >= text.length()) {
+                throw error("unexpected end of input");
+            }
+            char c = text.charAt(pos);
+            switch (c) {
+                case '{':
+                    return parseObject();
+                case '[':
+                    return parseArray();
+                case '"':
+                    return parseString();
+                case 't':
+                    expect("true");
+                    return Boolean.TRUE;
+                case 'f':
+                    expect("false");
+                    return Boolean.FALSE;
+                case 'n':
+                    expect("null");
+                    return null;
+                default:
+                    if (c == '-' || (c >= '0' && c <= '9')) {
+                        return parseNumber();
+                    }
+                    throw error("unexpected character '" + c + "'");
+            }
+        }
+
+        private Map<String, Object> parseObject() {
+            Map<String, Object> result = new LinkedHashMap<>();
+            pos++; // '{'
+            skipWhitespace();
+            if (peek() == '}') {
+                pos++;
+                return result;
+            }
+            while (true) {
+                skipWhitespace();
+                if (peek() != '"') {
+                    throw error("expected object key");
+                }
+                String key = parseString();
+                skipWhitespace();
+                if (peek() != ':') {
+                    throw error("expected ':'");
+                }
+                pos++;
+                skipWhitespace();
+                result.put(key, parseValue());
+                skipWhitespace();
+                char c = peek();
+                if (c == ',') {
+                    pos++;
+                } else if (c == '}') {
+                    pos++;
+                    return result;
+                } else {
+                    throw error("expected ',' or '}'");
+                }
+            }
+        }
+
+        private List<Object> parseArray() {
+            List<Object> result = new ArrayList<>();
+            pos++; // '['
+            skipWhitespace();
+            if (peek() == ']') {
+                pos++;
+                return result;
+            }
+            while (true) {
+                skipWhitespace();
+                result.add(parseValue());
+                skipWhitespace();
+                char c = peek();
+                if (c == ',') {
+                    pos++;
+                } else if (c == ']') {
+                    pos++;
+                    return result;
+                } else {
+                    throw error("expected ',' or ']'");
+                }
+            }
+        }
+
+        private String parseString() {
+            StringBuilder sb = new StringBuilder();
+            pos++; // opening '"'
+            while (true) {
+                if (pos >= text.length()) {
+                    throw error("unterminated string");
+                }
+                char c = text.charAt(pos++);
+                if (c == '"') {
+                    return sb.toString();
+                }
+                if (c == '\\') {
+                    if (pos >= text.length()) {
+                        throw error("unterminated escape");
+                    }
+                    char escaped = text.charAt(pos++);
+                    switch (escaped) {
+                        case '"':
+                            sb.append('"');
+                            break;
+                        case '\\':
+                            sb.append('\\');
+                            break;
+                        case '/':
+                            sb.append('/');
+                            break;
+                        case 'b':
+                            sb.append('\b');
+                            break;
+                        case 'f':
+                            sb.append('\f');
+                            break;
+                        case 'n':
+                            sb.append('\n');
+                            break;
+                        case 'r':
+                            sb.append('\r');
+                            break;
+                        case 't':
+                            sb.append('\t');
+                            break;
+                        case 'u':
+                            if (pos + 4 > text.length()) {
+                                throw error("truncated unicode escape");
+                            }
+                            sb.append((char) Integer.parseInt(text.substring(pos, pos + 4), 16));
+                            pos += 4;
+                            break;
+                        default:
+                            throw error("invalid escape '\\" + escaped + "'");
+                    }
+                } else {
+                    sb.append(c);
+                }
+            }
+        }
+
+        private Object parseNumber() {
+            int start = pos;
+            while (pos < text.length()) {
+                char c = text.charAt(pos);
+                if ((c >= '0' && c <= '9') || c == '-' || c == '+' || c == '.' || c == 'e' || c == 'E') {
+                    pos++;
+                } else {
+                    break;
+                }
+            }
+            String literal = text.substring(start, pos);
+            if (literal.indexOf('.') < 0 && literal.indexOf('e') < 0 && literal.indexOf('E') < 0) {
+                return Long.parseLong(literal);
+            }
+            return Double.parseDouble(literal);
+        }
+
+        private void expect(String literal) {
+            if (!text.startsWith(literal, pos)) {
+                throw error("expected '" + literal + "'");
+            }
+            pos += literal.length();
+        }
+
+        private char peek() {
+            if (pos >= text.length()) {
+                throw error("unexpected end of input");
+            }
+            return text.charAt(pos);
+        }
+
+        private void skipWhitespace() {
+            while (pos < text.length() && Character.isWhitespace(text.charAt(pos))) {
+                pos++;
+            }
+        }
+
+        private IllegalArgumentException error(String message) {
+            int from = Math.max(0, pos - 20);
+            int to = Math.min(text.length(), pos + 20);
+            return new IllegalArgumentException(
+                    message + " at offset " + pos + " (near \"" + text.substring(from, to) + "\")");
+        }
+    }
+
+    /**
+     * Validates an instance against the JSON Schema subset used by the checked-in schema.
+     * Unknown structural keywords are reported as errors on purpose (see class javadoc).
+     */
+    static final class JsonSchema {
+        private static final List<String> SUPPORTED_KEYWORDS = List.of(
+                "$schema",
+                "$id",
+                "title",
+                "description",
+                "$defs",
+                "$ref",
+                "type",
+                "const",
+                "enum",
+                "required",
+                "properties",
+                "items",
+                "minimum",
+                "minItems");
+
+        private final Map<String, Object> root;
+
+        JsonSchema(Map<String, Object> root) {
+            this.root = root;
+        }
+
+        List<String> validate(Object instance) {
+            List<String> errors = new ArrayList<>();
+            validateSchema(root, instance, "$", errors);
+            return errors;
+        }
+
+        @SuppressWarnings("unchecked")
+        private void validateSchema(Map<String, Object> schema, Object instance, String path, List<String> errors) {
+            for (String keyword : schema.keySet()) {
+                if (!SUPPORTED_KEYWORDS.contains(keyword)) {
+                    errors.add(path + ": schema uses unsupported keyword '" + keyword
+                            + "' (extend the test validator or the schema deliberately)");
+                }
+            }
+            if (schema.containsKey("$ref")) {
+                String ref = cast(schema.get("$ref"), path + ".$ref");
+                if (!ref.startsWith("#/$defs/")) {
+                    errors.add(path + ": unsupported $ref '" + ref + "' (only '#/$defs/<name>' is supported)");
+                    return;
+                }
+                Map<String, Object> defs = cast(root.get("$defs"), "$defs");
+                Map<String, Object> target = cast(defs.get(ref.substring("#/$defs/".length())), ref);
+                validateSchema(target, instance, path, errors);
+                return;
+            }
+            checkType(schema, instance, path, errors);
+            if (schema.containsKey("const")) {
+                Object expected = schema.get("const");
+                if (!java.util.Objects.equals(expected, instance)) {
+                    errors.add(path + ": expected const " + expected + " but found " + display(instance));
+                }
+            }
+            if (schema.containsKey("enum")) {
+                List<Object> allowed = cast(schema.get("enum"), path + ".enum");
+                if (!allowed.contains(instance)) {
+                    errors.add(path + ": " + display(instance) + " is not one of " + allowed);
+                }
+            }
+            if (instance instanceof Map) {
+                Map<String, Object> object = cast(instance, path);
+                List<String> required = cast(schema.getOrDefault("required", List.of()), path + ".required");
+                for (String name : required) {
+                    if (!object.containsKey(name)) {
+                        errors.add(path + ": missing required property '" + name + "'");
+                    }
+                }
+                Map<String, Object> properties =
+                        cast(schema.getOrDefault("properties", Map.of()), path + ".properties");
+                for (Map.Entry<String, Object> property : properties.entrySet()) {
+                    if (object.containsKey(property.getKey())) {
+                        validateSchema(
+                                cast(property.getValue(), path + "." + property.getKey()),
+                                object.get(property.getKey()),
+                                path + "." + property.getKey(),
+                                errors);
+                    }
+                }
+            }
+            if (instance instanceof List) {
+                List<Object> array = cast(instance, path);
+                Number minItems = (Number) schema.get("minItems");
+                if (minItems != null && array.size() < minItems.intValue()) {
+                    errors.add(path + ": expected at least " + minItems + " items but found " + array.size());
+                }
+                if (schema.containsKey("items")) {
+                    Map<String, Object> items = cast(schema.get("items"), path + ".items");
+                    for (int i = 0; i < array.size(); i++) {
+                        validateSchema(items, array.get(i), path + "[" + i + "]", errors);
+                    }
+                }
+            }
+            if (instance instanceof Number && schema.containsKey("minimum")) {
+                double minimum = ((Number) schema.get("minimum")).doubleValue();
+                if (((Number) instance).doubleValue() < minimum) {
+                    errors.add(path + ": " + instance + " is below minimum " + minimum);
+                }
+            }
+        }
+
+        private void checkType(Map<String, Object> schema, Object instance, String path, List<String> errors) {
+            Object declared = schema.get("type");
+            if (declared == null) {
+                return;
+            }
+            List<String> types = declared instanceof List ? cast(declared, path + ".type") : List.of((String) declared);
+            for (String type : types) {
+                if (matchesType(type, instance)) {
+                    return;
+                }
+            }
+            errors.add(path + ": " + display(instance) + " does not match type " + types);
+        }
+
+        private boolean matchesType(String type, Object instance) {
+            switch (type) {
+                case "object":
+                    return instance instanceof Map;
+                case "array":
+                    return instance instanceof List;
+                case "string":
+                    return instance instanceof String;
+                case "boolean":
+                    return instance instanceof Boolean;
+                case "integer":
+                    return instance instanceof Long
+                            || instance instanceof Double d && d == Math.floor(d) && !d.isInfinite();
+                case "number":
+                    return instance instanceof Number;
+                case "null":
+                    return instance == null;
+                default:
+                    throw new IllegalStateException("unknown JSON type '" + type + "'");
+            }
+        }
+
+        private static String display(Object instance) {
+            return instance == null
+                    ? "null"
+                    : instance instanceof String ? "\"" + instance + "\"" : instance.toString();
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <T> T cast(Object value, String what) {
+            if (value == null) {
+                throw new IllegalStateException("expected " + what + " but found null");
+            }
+            return (T) value;
+        }
+    }
+}

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -520,8 +520,8 @@ class ScalpelReportTest {
         assertEquals(
                 expected,
                 normalised,
-                "Report JSON structure has changed — update the golden file and "
-                        + "bump REPORT_VERSION if the schema changed.");
+                "Report JSON structure has changed: update the golden file, and bump "
+                        + "REPORT_VERSION if the change is not an optional additive field.");
     }
 
     @Test


### PR DESCRIPTION
## Heads-up first: upstream main's schema file is currently broken

The temporary merge behind #142 (commit 4a0f418) left git conflict markers inside `core/src/main/resources/.../scalpel-report-v2.schema.json` between the `skippedModules` property (#139's side) and `status`/`reason` (#137's side): the file is not valid JSON on main right now. No release ever shipped the schema (the resources directory did not exist in any tagged build), but the next release would. This PR resolves the collision keeping all three property sets.

## Change (per the plan on the issue)

- **Schema consolidated**: all optional additive fields from the merged wave are declared (status/reason, unmatchedPomPaths, skippedModules with its reason enum, module evidence); the file parses and its 15 top-level properties exactly match what `toJson()` emits.
- **Validation test**: a new core test builds representative reports (all-optional and minimal) and validates the emitted JSON against the checked-in schema, plus negative controls (missing required field, wrong type, invalid status/module/skip reasons, below-minimum count) proving the validator is not vacuous, and drift guards asserting the schema's enum lists equal the emittable constants. No new dependency: core has no JSON library, so the test carries a compact reader and a validator for the exact schema subset in use, failing loudly on any unrecognized keyword.
- **Compatibility policy documented**: optional fields and enum values may be added within a version; removals, renames, type changes, required-ification, or removing an emittable enum value force a bump - with the explicit carve-out for never-emitted values (applied here to `UPSTREAM_DEPENDENCY`, deprecated since 0.3.6 and never emitted in any v2 report).
- **Cleanup**: `REASON_UPSTREAM_DEPENDENCY` constant and README row removed (upstream prerequisites are counted in `excludedUpstreamCount`); README example and reason tables brought in sync, including the previously missing `EXCLUDED_DOWNSTREAM` as a test-skip reason.

## Verification

TDD: the RED commit is the new test failing on main's conflict markers (the BeforeAll parse fails deterministically); GREEN resolves the schema and passes everything. Full suites green (core 148, extension3 164). The branch's real `toJson()` outputs were additionally cross-validated with an independent JSON-Schema library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded report documentation with unmatched paths, skipped modules, explain-mode evidence, test-skip reasons, and upstream prerequisite handling.
  * Added compatibility guidance for optional fields and enum values.

* **Schema**
  * Documented optional report fields and removed the deprecated upstream-dependency reason.
  * Preserved support for skipped-module details.

* **Tests**
  * Added comprehensive validation for valid and invalid report structures, fields, and enum values.
  * Improved guidance for handling schema compatibility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->