### PR TITLE
Fix #84: validate module paths written to the impacted log

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ module-b/sub-module
 This works in all modes (trim, skip-tests, report) and is written alongside the JSON report,
 not as a replacement. It contains only directly affected modules (not upstream/downstream).
 
+**Safety.** Module directory names are chosen by whoever authors the repository (or pull request),
+so the log is written defensively: a path is only written when it consists solely of letters,
+digits, `-`, `_`, `.` and `/`, and does not start with `-`. A path containing anything else
+(spaces, quotes, `$`, backticks, `;`, `|`, glob characters, backslashes, newlines, control
+characters) is skipped with a WARN instead of written. Even so, consume the file defensively:
+unquoted expansion word-splits and glob-expands file contents.
+
+```bash
+# Safe: quoted read loop, one module per line
+while IFS= read -r module; do
+  build_module "$module"
+done < target/scalpel-impacted.log
+
+# Safe (GNU xargs): explicit newline delimiter, no word splitting
+xargs -d '\n' build_module < target/scalpel-impacted.log
+
+# Unsafe: unquoted command substitution word-splits and glob-expands the contents
+build_all $(cat target/scalpel-impacted.log)
+```
+
 #### Report Format
 
 The report follows a versioned JSON schema. A [JSON Schema](core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json)
@@ -155,6 +175,18 @@ is published alongside the code. The current version is **2**.
     }
   ]
 }
+```
+
+**Consuming `path` values in scripts:** like the impacted log, the `path` fields of
+`affectedModules` entries carry module directory names chosen by the repository (or pull request)
+author. The values are JSON-encoded, so newlines and quotes cannot corrupt the document, but they
+are not restricted to a safe character set. Keep them quoted end-to-end when feeding them to shell
+commands:
+
+```bash
+# Safe: jq emits one path per line; consume it with a quoted read loop
+jq -r '.affectedModules[].path' target/scalpel-report.json |
+  while IFS= read -r module; do build_module "$module"; done
 ```
 
 **Status-only reports:** when analysis does not complete (failSafe bail-out, unexpected
@@ -268,7 +300,7 @@ Note that properties defined in a project POM's `<properties>` are deliberately 
 | `scalpel.includePaths` | *(none)* | Comma-separated glob patterns; narrows the affected set to matching modules rather than filtering changed files |
 | `scalpel.disableTriggers` | *(none)* | Comma-separated glob patterns; if any changed file matches, Scalpel is disabled entirely |
 | `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report (report mode), relative to reactor root |
-| `scalpel.impactedLog` | *(none)* | Write impacted module paths to this file (one per line) |
+| `scalpel.impactedLog` | *(none)* | Write impacted module paths to this file (one per line; paths outside the safe character set are skipped with a WARN) |
 | `scalpel.forceBuildModules` | *(none)* | Comma-separated regex patterns; always include modules whose artifactId matches |
 | `scalpel.buildAllIfNoChanges` | `false` | Build everything when no changes are detected (useful for cron builds) |
 | `scalpel.disableOnBranch` | *(none)* | Comma-separated regex patterns; disable if current branch matches |

--- a/README.md
+++ b/README.md
@@ -184,8 +184,10 @@ are not restricted to a safe character set. Keep them quoted end-to-end when fee
 commands:
 
 ```bash
-# Safe: jq emits one path per line; consume it with a quoted read loop
-jq -r '.affectedModules[].path' target/scalpel-report.json |
+# Safe: filter to the same character set as the impacted log, then a quoted read loop.
+# The filter matters: jq -r emits embedded newlines raw, so without it a path value
+# containing a newline would be split into two entries by the read loop.
+jq -r '.affectedModules[].path | select(test("^[A-Za-z0-9._/-]+$"))' target/scalpel-report.json |
   while IFS= read -r module; do build_module "$module"; done
 ```
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -1260,6 +1260,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             List<String> lines = new ArrayList<>();
             for (MavenProject project : affectedModules) {
                 String relPath = relativePath(reactorRoot, project);
+                if (relPath.isEmpty()) {
+                    // The reactor root's relative path is the empty string; represent it as
+                    // "." so an affected root stays visible to CI consumers instead of
+                    // disappearing as a blank (or skipped) line (#84).
+                    relPath = ".";
+                }
                 if (!isSafeImpactedLogPath(relPath)) {
                     // The log is one path per line, consumed by CI shell scripts ($(cat ...),
                     // xargs); a module directory name is PR-author-controlled, so a path outside

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -1259,13 +1259,72 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Files.createDirectories(logPath.getParent());
             List<String> lines = new ArrayList<>();
             for (MavenProject project : affectedModules) {
-                lines.add(relativePath(reactorRoot, project));
+                String relPath = relativePath(reactorRoot, project);
+                if (!isSafeImpactedLogPath(relPath)) {
+                    // The log is one path per line, consumed by CI shell scripts ($(cat ...),
+                    // xargs); a module directory name is PR-author-controlled, so a path outside
+                    // the documented safe set is skipped rather than escaped (#84).
+                    logger.warn(
+                            "Scalpel: Skipping module {} in impacted log: path '{}' uses characters outside the"
+                                    + " safe set (letters, digits, '-', '_', '.', '/'; see README)",
+                            key(project),
+                            escapeControlChars(relPath));
+                    continue;
+                }
+                lines.add(relPath);
             }
             Files.write(logPath, lines, StandardCharsets.UTF_8);
             logger.info("Scalpel: Impacted modules written to {}", config.getImpactedLog());
         } catch (IOException e) {
             handleWriteFailure(config, "Failed to write impacted log", e);
         }
+    }
+
+    /**
+     * Safe character set for impacted-log lines. The log holds one relative module path per line
+     * and is consumed by CI shell scripts, so a PR author controlling a module directory name must
+     * not be able to inject shell metacharacters, spaces, quotes, glob characters or
+     * line/control characters into it. Only {@code [A-Za-z0-9._-/]} is accepted; a leading dash
+     * (option injection) and the empty string are rejected too. Control characters and newlines
+     * are rejected by construction: nothing outside this set passes. Backslashes never occur
+     * ({@link #relativePath} normalizes separators to '/') and would be rejected like any other
+     * character.
+     */
+    static boolean isSafeImpactedLogPath(String path) {
+        if (path == null || path.isEmpty() || path.charAt(0) == '-') {
+            return false;
+        }
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            boolean allowed = (c >= 'a' && c <= 'z')
+                    || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9')
+                    || c == '-'
+                    || c == '_'
+                    || c == '.'
+                    || c == '/';
+            if (!allowed) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Escapes control characters (newlines included) so a rejected path cannot forge extra
+     * lines in the skip warning itself.
+     */
+    private static String escapeControlChars(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (Character.isISOControl(c)) {
+                escaped.append(String.format("\\u%04x", (int) c));
+            } else {
+                escaped.append(c);
+            }
+        }
+        return escaped.toString();
     }
 
     /**

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -1325,7 +1325,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         for (int i = 0; i < value.length(); i++) {
             char c = value.charAt(i);
             if (Character.isISOControl(c)) {
-                escaped.append(String.format("\\u%04x", (int) c));
+                escaped.append("\\u%04x".formatted((int) c));
             } else {
                 escaped.append(c);
             }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3615,6 +3615,39 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void impactedLogPathValidation_acceptsSafePaths() {
+        assertTrue(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module-a"), "simple name");
+        assertTrue(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module-a/sub-module"), "nested path");
+        assertTrue(ScalpelLifecycleParticipant.isSafeImpactedLogPath("Module_1.v2/dir"), "mixed charset");
+        assertTrue(ScalpelLifecycleParticipant.isSafeImpactedLogPath("m"), "single character");
+        assertTrue(ScalpelLifecycleParticipant.isSafeImpactedLogPath("a-b_c.d/e"), "all safe separators");
+    }
+
+    @Test
+    void impactedLogPathValidation_rejectsUnsafePaths() {
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath(null), "null path");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath(""), "empty path");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("-module"), "leading dash (option injection)");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module;rm"), "semicolon");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module$(id)"), "command substitution");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module rm"), "space");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module`id`"), "backtick");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("mo'dule"), "single quote");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("mo\"dule"), "double quote");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("mo\\dule"), "backslash");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module*"), "glob star");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("mo?dule"), "glob question mark");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("mo[du]le"), "glob brackets");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module|rm"), "pipe");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("module&rm"), "ampersand");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("evil\nforge"), "newline forges entries");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("evil\rforge"), "carriage return");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("evil\tforge"), "tab");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("evil\0forge"), "NUL byte");
+        assertFalse(ScalpelLifecycleParticipant.isSafeImpactedLogPath("evil\u007Fforge"), "delete character");
+    }
+
+    @Test
     void skipTestsMode_skipTestsForUpstream_skipsUpstreamTests() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3835,7 +3835,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("module-safe/src/main/java/Foo.java");
         changedFiles.add("module;rm/src/main/java/Foo.java");
         changedFiles.add("module$(id)/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3887,7 +3887,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-safe/src/main/java/Foo.java");
         changedFiles.add(evilDir + "/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3925,7 +3925,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3957,7 +3957,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -23,7 +23,9 @@ import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
 import eu.maveniverse.maven.scalpel.core.ScalpelCore;
 import eu.maveniverse.maven.scalpel.core.ScalpelException;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -3442,6 +3444,177 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void impactedLog_skipsModulePathsWithShellMetacharacters() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // module-safe: ordinary directory name; module;rm and module$(id): directory names a
+        // PR author controls, containing shell metacharacters that make $(cat ...) / xargs
+        // consumption of the log injection-prone
+        String parentPom = simpleParentPom("module-safe", "module;rm", "module$(id)");
+        writePom(root, "pom.xml", parentPom);
+        String safePom = simpleChildPom("module-safe");
+        writePom(root, "module-safe/pom.xml", safePom);
+        String semiPom = simpleChildPom("module-semi");
+        writePom(root, "module;rm/pom.xml", semiPom);
+        String cmdSubPom = simpleChildPom("module-cmdsub");
+        writePom(root, "module$(id)/pom.xml", cmdSubPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleSafe =
+                createProject("com.example", "module-safe", "1.0", root, "module-safe/pom.xml", safePom);
+        moduleSafe.setParent(parentProject);
+        MavenProject moduleSemi =
+                createProject("com.example", "module-semi", "1.0", root, "module;rm/pom.xml", semiPom);
+        moduleSemi.setParent(parentProject);
+        MavenProject moduleCmdSub =
+                createProject("com.example", "module-cmdsub", "1.0", root, "module$(id)/pom.xml", cmdSubPom);
+        moduleCmdSub.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleSafe, moduleSemi, moduleCmdSub);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-safe/src/main/java/Foo.java");
+        changedFiles.add("module;rm/src/main/java/Foo.java");
+        changedFiles.add("module$(id)/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.impactedLog", "target/scalpel-impacted.log");
+
+        String stderr = runCapturingStdErr(() -> participant.afterProjectsRead(session));
+
+        Path logFile = root.resolve("target/scalpel-impacted.log");
+        assertTrue(Files.exists(logFile), "Impacted log file should be created even when entries are skipped");
+        List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+        assertEquals(List.of("module-safe"), lines, "Impacted log must contain only the safe module path");
+        assertFalse(lines.toString().contains("module;rm"), "Path with ';' must not reach the impacted log");
+        assertFalse(lines.toString().contains("module$(id)"), "Path with '$' must not reach the impacted log");
+        assertTrue(
+                stderr.contains("module;rm"),
+                "A WARN naming the skipped module path 'module;rm' should be emitted, got: " + stderr);
+        assertTrue(
+                stderr.contains("module$(id)"),
+                "A WARN naming the skipped module path 'module$(id)' should be emitted, got: " + stderr);
+    }
+
+    @Test
+    void impactedLog_newlineInModulePathCannotForgeEntries() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // A newline inside a module directory name would, written verbatim, produce a forged
+        // extra entry ("forge") on its own line in the log
+        String evilDir = "evil\nforge";
+        String parentPom = simpleParentPom("module-safe");
+        writePom(root, "pom.xml", parentPom);
+        String safePom = simpleChildPom("module-safe");
+        writePom(root, "module-safe/pom.xml", safePom);
+        String evilPom = simpleChildPom("module-evil");
+        writePom(root, evilDir + "/pom.xml", evilPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleSafe =
+                createProject("com.example", "module-safe", "1.0", root, "module-safe/pom.xml", safePom);
+        moduleSafe.setParent(parentProject);
+        MavenProject moduleEvil =
+                createProject("com.example", "module-evil", "1.0", root, evilDir + "/pom.xml", evilPom);
+        moduleEvil.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleSafe, moduleEvil);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-safe/src/main/java/Foo.java");
+        changedFiles.add(evilDir + "/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.impactedLog", "target/scalpel-impacted.log");
+
+        String stderr = runCapturingStdErr(() -> participant.afterProjectsRead(session));
+
+        Path logFile = root.resolve("target/scalpel-impacted.log");
+        assertTrue(Files.exists(logFile), "Impacted log file should be created even when entries are skipped");
+        List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+        assertEquals(List.of("module-safe"), lines, "Impacted log must contain only the safe module path");
+        assertFalse(lines.contains("forge"), "Newline in a module path must not forge extra log entries");
+        assertTrue(
+                stderr.contains("impacted log"),
+                "A WARN about the skipped newline-containing path should be emitted, got: " + stderr);
+    }
+
+    @Test
+    void impactedLog_notConfigured_writesNoFile() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        assertFalse(
+                Files.exists(root.resolve("target/scalpel-impacted.log")),
+                "No impacted log must be written when scalpel.impactedLog is unset");
+    }
+
+    @Test
+    void impactedLog_blank_writesNoFile() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        session.getSystemProperties().setProperty("scalpel.impactedLog", "   ");
+
+        participant.afterProjectsRead(session);
+
+        assertFalse(
+                Files.exists(root.resolve("target/scalpel-impacted.log")),
+                "A blank scalpel.impactedLog value must not produce a file");
+    }
+
+    @Test
     void skipTestsMode_skipTestsForUpstream_skipsUpstreamTests() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
@@ -3904,6 +4077,28 @@ class ScalpelLifecycleParticipantTest {
         when(emptyResolution.getDependencyGraph()).thenReturn(createDependencyGraph());
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
                 .thenReturn(emptyResolution);
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    /**
+     * Runs {@code action} with {@code System.err} redirected to an in-memory buffer and returns
+     * everything the participant logged there. slf4j-simple resolves {@code System.err} per call
+     * (verified against the 1.7.36 jar the build resolves), so swapping the stream captures the
+     * WARN output emitted during the run.
+     */
+    private String runCapturingStdErr(ThrowingRunnable action) throws Exception {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
## Problem

As filed in #84: the impacted log writes module directory names verbatim, one per line, with no escaping or character validation. The line content is controlled by a PR author (module directory names come from the reactor, which comes from the PR), and the README advertises the file "for CI scripts (e.g. for GitHub Actions matrix filtering)" - whose natural consumption patterns (`$(cat ...)`, xargs) execute shell metacharacters. Spaces, semicolons, pipes, backticks, command substitution and a leading dash are all legal in directory names.

This is a dangerous-by-default **output contract**: the consumer writes the injectable shell; Scalpel is the component that can make it safe cheaply.

## Change

- Every line is validated against a conservative allowlist (`A-Za-z0-9 - _ . /`, no leading dash). Control characters and newlines are rejected by construction, closing both the injection and the entry-forgery (newline in a module name splitting into extra entries) vectors. Paths outside the set are skipped with a WARN naming the module and the escaped path.
- The reactor root (relative path is the empty string) is written as `.` instead of the old blank line, so an affected root stays visible to consumers.
- README: the impacted-log section carries a warning plus the safe consumption patterns (quoted read loop, `xargs -d '\n'` GNU note), and the jq pattern for the report's `path` field filters to the same character set first - without the filter, `jq -r` emits embedded newlines raw and a read loop splits them into forged entries (empirically verified during review).

**Deliberate behavior changes**: unsafe paths no longer reach the file (WARN instead); the root module appears as `.` instead of a blank line; if every entry is rejected the log is an empty file with a console WARN as the only signal.

## Verification

TDD: RED first - `module;rm`, `module$(id)` written verbatim and a directory named with an embedded newline forging a second entry (tests fail on main exactly as predicted); then the fix, then the review pass (root-as-`.`, jq filter). Full suites green (extension3 166, core 143). NULL-input coverage per the config values the path reads (unset, blank, null, empty).