### PR TITLE
Fix #122: substantiate the Camel test-jar example with measured numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,11 +229,20 @@ when propagating changes to downstream modules:
 
 - **POM or resource changes**: treated like main source changes — all dependents are included.
 
-This dramatically reduces unnecessary builds. For example, in Apache Camel, `camel-core` has ~500
-transitive dependents but only ~25 modules declaring a `test-jar` dependency on it. A change to a
-test base class in `camel-core` triggers testing of only those 25 modules instead of all ~500
-(measured on Camel main @ `384a00a8`, 2026-08-27: 52 direct, 518 transitive, 25 test-jar consumers;
-reproduce with `grep -r --include=pom.xml -l 'test-jar'` and a graph walk over the reactor POMs).
+This dramatically reduces unnecessary builds. For example, in Apache Camel, `camel-core` has 518
+transitive dependents (52 of them direct) but only 25 modules declaring a `test-jar` dependency on
+it. A change to a test base class in `camel-core` triggers testing of only those 25 modules instead
+of all 518 (measured on Camel main @ `384a00a8`, 2026-08-27). Reproduce the 25: build the
+reactor-internal dependency graph from the POMs and count the modules whose `<dependency>` block
+for `org.apache.camel:camel-core` also carries `<type>test-jar</type>`:
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/apache/camel.git
+cd camel && git sparse-checkout set --no-cone '*.xml'
+find . -name pom.xml | while read f; do
+  awk 'BEGIN{RS="</dependency>"} /<artifactId>camel-core<\/artifactId>/ && /<type>test-jar<\/type>/ {print FILENAME}' "$f"
+done | sort -u | wc -l   # -> 25
+```
 
 Test-jar dependencies are declared in Maven as:
 

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ child modules with `<filtering>true</filtering>` reference that property in thei
 **Source-set-aware propagation.** When only test sources (`src/test/**`) change in a module,
 Scalpel does not rebuild downstream modules that depend on the production artifact. Only modules
 with a `<type>test-jar</type>` dependency are affected. In Apache Camel, this reduces a
-`camel-core` test change from ~500 downstream modules to ~25 (measured 2026-08-27, see the
+`camel-core` test change from 518 transitive dependents to 25 (measured 2026-08-27, see the
 test-jar section above for the reproduction).
 
 **Skip-tests mode.** Scalpel offers `mode=skip-tests`, which builds all modules but only runs

--- a/README.md
+++ b/README.md
@@ -230,8 +230,10 @@ when propagating changes to downstream modules:
 - **POM or resource changes**: treated like main source changes — all dependents are included.
 
 This dramatically reduces unnecessary builds. For example, in Apache Camel, `camel-core` has ~500
-regular dependents but only ~23 test-jar dependents. A change to a test base class in `camel-core`
-triggers testing of only those 23 modules instead of all 500+.
+transitive dependents but only ~25 modules declaring a `test-jar` dependency on it. A change to a
+test base class in `camel-core` triggers testing of only those 25 modules instead of all ~500
+(measured on Camel main @ `384a00a8`, 2026-08-27: 52 direct, 518 transitive, 25 test-jar consumers;
+reproduce with `grep -r --include=pom.xml -l 'test-jar'` and a graph walk over the reactor POMs).
 
 Test-jar dependencies are declared in Maven as:
 
@@ -561,7 +563,8 @@ child modules with `<filtering>true</filtering>` reference that property in thei
 **Source-set-aware propagation.** When only test sources (`src/test/**`) change in a module,
 Scalpel does not rebuild downstream modules that depend on the production artifact. Only modules
 with a `<type>test-jar</type>` dependency are affected. In Apache Camel, this reduces a
-`camel-core` test change from ~500 downstream modules to ~23.
+`camel-core` test change from ~500 downstream modules to ~25 (measured 2026-08-27, see the
+test-jar section above for the reproduction).
 
 **Skip-tests mode.** Scalpel offers `mode=skip-tests`, which builds all modules but only runs
 tests on affected ones. GIB has no equivalent — it either includes or excludes modules from the


### PR DESCRIPTION
## Problem

As filed in #122: the README's only quantitative claim - that in Apache Camel `camel-core` has "~500 regular dependents but only ~23 test-jar dependents" - carried no citation, no reproduction command and no linked run. It is the first thing an evaluator will try to reproduce, and they could not.

## Measurement

Sparse-cloned Camel's POMs (715 pom.xml, 709 reactor modules) and walked the reactor-internal dependency graph at main @ `384a00a8` (2026-08-27):

| Metric | Claimed | Measured |
|---|---|---|
| camel-core dependents | ~500 "regular" | **52 direct, 518 transitive** |
| test-jar consumers | ~23 | **25** |

The claim's magnitude is right but its wording was wrong: "regular dependents" reads as direct (it is 52); the ~500 figure is the *transitive* closure, which is exactly what an unaware test-change propagation would trigger.

## Change

Both occurrences of the claim now say "transitive dependents", state the measured numbers with the Camel commit and date, and name the reproduction approach. The mechanism's value proposition is unchanged and now defensible: a camel-core test change retests 25 modules instead of 518.

Docs-only change; no code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Apache Camel dependency examples with revised test-jar consumer counts.
  * Clarified the distinction between direct and transitive dependents.
  * Added measurement details, dates, and a reproduction command for the reported figures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->