### PR TITLE
Fix #98: cache scalpel regex patterns and cap match input length

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,18 @@ Use `forceBuildModules` with regex patterns matching artifactIds:
 -Dscalpel.forceBuildModules=.*-it,.*-tests
 ```
 
+Patterns use full-match Java regex semantics against the module's `artifactId`. These regexes and
+`disableOnBranch`/`disableOnBaseBranch` are evaluated against input a pull request author
+influences (artifactIds, branch names), so their match cost is bounded:
+
+- patterns are compiled once per build and cached, not compiled per match attempt;
+- inputs longer than **256 characters** are never matched: the attempt is skipped, a WARN is
+  logged once per input, and the input counts as a non-match.
+
+Keep patterns linear: avoid nested quantifiers such as `(a+)+` or `(.*)*`, which can backtrack
+exponentially even against short input. The documented examples above (`.*-it`, `.*-tests`) are
+linear and safe.
+
 For scheduled/cron builds where no changes may be detected, use `buildAllIfNoChanges` to fall back
 to a full build instead of building nothing:
 
@@ -420,7 +432,10 @@ for CI systems where incremental builds should be skipped on main, release, or m
 ```
 
 Branch patterns are Java regular expressions. For `disableOnBaseBranch`, the remote prefix
-(e.g. `origin/`) is stripped before matching.
+(e.g. `origin/`) is stripped before matching. Branch names are pull-request-influenced input,
+so the same cost bounds as `forceBuildModules` apply: patterns are compiled once per build,
+inputs longer than 256 characters are skipped with a WARN (counted as a non-match), and linear
+patterns without nested quantifiers are strongly preferred.
 
 ### Selected Projects (`-pl`) Handling
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/BoundedRegexMatcher.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/BoundedRegexMatcher.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.slf4j.Logger;
+
+/**
+ * Matches the user-supplied regex options ({@code disableOnBranch}, {@code disableOnBaseBranch},
+ * {@code forceBuildModules}) with bounded cost:
+ *
+ * <ul>
+ *   <li>each pattern is compiled once and cached (an instance is meant to be reused for a build;
+ *       {@link #MAX_CACHED_PATTERNS} bounds the cache so a long-lived instance cannot grow without
+ *       limit; beyond the bound patterns are compiled per call again, which is the unfixed behavior)</li>
+ *   <li>the matched input is capped at {@link #MAX_INPUT_LENGTH} characters; longer inputs are
+ *       never matched (treated as non-match, with a WARN) because branch names and especially
+ *       artifactIds are influenced by pull request authors, and match cost grows with input length</li>
+ *   <li>invalid patterns are reported once per pattern and config key, and treated as non-matching</li>
+ *   <li>{@code null} input or pattern never matches and never throws</li>
+ * </ul>
+ *
+ * <p>The cap bounds the input, not the pattern: a maintainer-supplied pattern with nested
+ * quantifiers can still backtrack heavily against a short input, so patterns should stay linear
+ * (no nested quantifiers like {@code (a+)+}); the README documents this guidance. Match semantics
+ * are those of {@link String#matches(String)}: the whole input must match.
+ */
+public final class BoundedRegexMatcher {
+
+    /**
+     * Branch names and artifactIds longer than this are never matched. Legitimate values are far
+     * shorter (git refs are conventionally limited to a few hundred bytes and real artifactIds
+     * are well under 100 characters), while match cost grows with input length.
+     */
+    public static final int MAX_INPUT_LENGTH = 256;
+
+    /** Upper bound for compiled patterns held by one instance; package-private for tests. */
+    static final int MAX_CACHED_PATTERNS = 256;
+
+    /** How much of an over-long input to echo in the WARN (the input itself is PR-influenced). */
+    private static final int WARN_ECHO_LENGTH = 32;
+
+    /**
+     * Upper bound for one-time-WARN deduplication keys held by one instance: keys are derived
+     * from PR-influenced input, so both their count and their size must stay bounded.
+     */
+    private static final int MAX_WARNED_KEYS = 256;
+
+    private record Compiled(Pattern pattern, String syntaxError) {}
+
+    private final ConcurrentHashMap<String, Compiled> cache = new ConcurrentHashMap<>();
+
+    /** Deduplication keys for one-time WARNs ("input:" / "pattern:" prefix + value). */
+    private final Set<String> warned = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Returns whether {@code value} fully matches {@code pattern}, with the bounded-cost
+     * guarantees described on the class. Never throws for a null input, null pattern, invalid
+     * pattern or over-long input; each of those is a non-match.
+     *
+     * @param value the input to match (branch name, artifactId); null is a non-match
+     * @param pattern the user-supplied regex; null is a non-match
+     * @param configKey the configuration key the pattern came from (used in log messages)
+     * @param logger where WARNs about skipped matches and invalid patterns go
+     */
+    public boolean matches(String value, String pattern, String configKey, Logger logger) {
+        if (pattern == null || value == null) {
+            return false;
+        }
+        if (value.length() > MAX_INPUT_LENGTH) {
+            // the dedup key uses only the echoed prefix, never the full over-long value
+            if (warned.size() < MAX_WARNED_KEYS && warned.add("input:" + configKey + ":" + echo(value))) {
+                logger.warn(
+                        "Scalpel: Skipping {} match: input of length {} exceeds the {} character limit"
+                                + " (starts with '{}'); treating as non-match",
+                        configKey,
+                        value.length(),
+                        MAX_INPUT_LENGTH,
+                        echo(value));
+            }
+            return false;
+        }
+        Compiled compiled = cache.get(pattern);
+        if (compiled == null) {
+            compiled = compile(pattern);
+            if (cache.size() < MAX_CACHED_PATTERNS) {
+                cache.putIfAbsent(pattern, compiled);
+            }
+        }
+        if (compiled.syntaxError() != null) {
+            if (warned.size() < MAX_WARNED_KEYS && warned.add("pattern:" + configKey + ":" + pattern)) {
+                logger.warn(
+                        "Scalpel: Invalid regex pattern '{}' in {}: {}", pattern, configKey, compiled.syntaxError());
+            }
+            return false;
+        }
+        return compiled.pattern().matcher(value).matches();
+    }
+
+    private static Compiled compile(String pattern) {
+        try {
+            return new Compiled(Pattern.compile(pattern), null);
+        } catch (PatternSyntaxException e) {
+            return new Compiled(null, e.getMessage());
+        }
+    }
+
+    private static String echo(String value) {
+        return value.length() <= WARN_ECHO_LENGTH ? value : value.substring(0, WARN_ECHO_LENGTH) + "...";
+    }
+
+    /**
+     * Number of distinct valid patterns currently cached; a test seam proving patterns are
+     * compiled once rather than per call.
+     */
+    int cachedPatternCount() {
+        return (int)
+                cache.values().stream().filter(c -> c.syntaxError() == null).count();
+    }
+}

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -31,6 +30,7 @@ public class ScalpelCore {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final GitChangeDetector gitChangeDetector;
+    private final BoundedRegexMatcher regexMatcher = new BoundedRegexMatcher();
 
     /**
      * Human-readable reason when the last {@link #detectChanges} invocation deliberately skipped
@@ -199,12 +199,7 @@ public class ScalpelCore {
     }
 
     private boolean matchesSafely(String value, String pattern, String configKey) {
-        try {
-            return value.matches(pattern);
-        } catch (PatternSyntaxException e) {
-            logger.warn("Scalpel: Invalid regex pattern '{}' in {}: {}", pattern, configKey, e.getMessage());
-            return false;
-        }
+        return regexMatcher.matches(value, pattern, configKey, logger);
     }
 
     private Repository openRepository(Path reactorRoot) throws IOException {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/BoundedRegexMatcherTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/BoundedRegexMatcherTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class BoundedRegexMatcherTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(BoundedRegexMatcherTest.class);
+
+    @Test
+    void repeatedMatches_samePattern_compiledOnce() {
+        BoundedRegexMatcher matcher = new BoundedRegexMatcher();
+        for (int i = 0; i < 10; i++) {
+            assertTrue(matcher.matches("module-it", ".*-it", "forceBuildModules", logger));
+        }
+        assertEquals(
+                1,
+                matcher.cachedPatternCount(),
+                "the same pattern must be compiled once and reused, not recompiled per call");
+    }
+
+    @Test
+    void repeatedMatches_distinctPatterns_eachCompiledOnce() {
+        BoundedRegexMatcher matcher = new BoundedRegexMatcher();
+        assertTrue(matcher.matches("module-it", ".*-it", "forceBuildModules", logger));
+        assertTrue(matcher.matches("main", "ma.*", "disableOnBranch", logger));
+        assertTrue(matcher.matches("main", "ma.*", "disableOnBranch", logger));
+        assertEquals(2, matcher.cachedPatternCount(), "two distinct patterns mean two cached compiles");
+    }
+
+    @Test
+    void matchSemantics_isFullMatch_notFind() {
+        BoundedRegexMatcher matcher = new BoundedRegexMatcher();
+        assertFalse(matcher.matches("module-x", "module", "disableOnBranch", logger));
+        assertTrue(matcher.matches("module-x", "module.*", "disableOnBranch", logger));
+    }
+
+    @Test
+    void input_atLimit_isMatched() {
+        BoundedRegexMatcher matcher = new BoundedRegexMatcher();
+        String value = "a".repeat(BoundedRegexMatcher.MAX_INPUT_LENGTH);
+        assertTrue(matcher.matches(value, "a*", "disableOnBranch", logger), "input at the limit must still match");
+    }
+
+    @Test
+    void input_overLimit_isSkippedWithSingleWarn() {
+        BoundedRegexMatcher matcher = new BoundedRegexMatcher();
+        String value = "a".repeat(BoundedRegexMatcher.MAX_INPUT_LENGTH + 1);
+        String err = captureStderr(() -> {
+            assertFalse(
+                    matcher.matches(value, ".*", "disableOnBranch", logger),
+                    "an over-limit input must not match, even against '.*'");
+            // second pattern against the same input: the WARN must not repeat
+            assertFalse(matcher.matches(value, ".*-x", "disableOnBranch", logger));
+        });
+        assertTrue(
+                err.contains("exceeds"),
+                "expected a WARN about the over-limit input, and it must name the config key; stderr was: " + err);
+        assertTrue(err.contains("disableOnBranch"), "the cap WARN must name the config key; stderr was: " + err);
+        assertEquals(
+                1,
+                countOccurrences(err, "character limit"),
+                "one cap WARN per over-long input, not one per pattern; stderr was: " + err);
+    }
+
+    @Test
+    void invalidPattern_isNotMatchedAndWarnsOnce() {
+        BoundedRegexMatcher matcher = new BoundedRegexMatcher();
+        String err = captureStderr(() -> {
+            assertFalse(matcher.matches("anything", "[unclosed", "forceBuildModules", logger));
+            assertFalse(matcher.matches("other", "[unclosed", "forceBuildModules", logger));
+        });
+        assertEquals(
+                1,
+                countOccurrences(err, "Invalid regex pattern"),
+                "an invalid pattern must WARN once, not once per call; stderr was: " + err);
+        assertEquals(0, matcher.cachedPatternCount(), "an invalid pattern is not cached as a compiled pattern");
+    }
+
+    @Test
+    void nullInput_isNotMatched() {
+        BoundedRegexMatcher matcher = new BoundedRegexMatcher();
+        assertFalse(matcher.matches(null, ".*", "disableOnBranch", logger));
+        assertFalse(matcher.matches("value", null, "disableOnBranch", logger));
+    }
+
+    @Test
+    void cacheSize_isBounded() {
+        BoundedRegexMatcher matcher = new BoundedRegexMatcher();
+        for (int i = 0; i < BoundedRegexMatcher.MAX_CACHED_PATTERNS + 10; i++) {
+            String value = "v" + i;
+            assertTrue(matcher.matches(value, "v" + i, "forceBuildModules", logger));
+        }
+        assertEquals(
+                BoundedRegexMatcher.MAX_CACHED_PATTERNS,
+                matcher.cachedPatternCount(),
+                "the compiled-pattern cache must stay bounded");
+        // patterns compiled beyond the bound still match (uncached fallback)
+        assertTrue(matcher.matches("late", "la.*", "forceBuildModules", logger));
+    }
+
+    /**
+     * Runs the action with System.err captured (slf4j-simple writes to stderr)
+     * and returns everything that was written during its execution.
+     */
+    private String captureStderr(Runnable action) {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
+    private int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) >= 0) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
+    }
+}

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -9,11 +9,14 @@ package eu.maveniverse.maven.scalpel.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -155,6 +158,85 @@ class ScalpelCoreTest {
 
             assertNull(result, "Should return null when current branch matches disableOnBranch");
         }
+    }
+
+    @Test
+    void detectChanges_baseBranchNameOverLimit_skipsDisableMatchAndWarns() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            // 300-char base branch name: over the documented input cap, would match "b.*"
+            // if the matcher applied the pattern to the full-length value
+            sys.setProperty("scalpel.baseBranch", "b".repeat(300));
+            sys.setProperty("scalpel.disableOnBaseBranch", "b.*");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult[] result = new ChangeDetectionResult[1];
+            String err = captureStderr(() -> {
+                try {
+                    result[0] = core.detectChanges(tempDir, config, Set.of());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            assertNotEquals(
+                    "disabled by disableOnBaseBranch",
+                    core.getLastDetectionSkipReason(),
+                    "an over-limit branch name must not be treated as a match");
+            assertTrue(err.contains("exceeds"), "expected a WARN about the over-limit input but stderr was: " + err);
+            assertFalse(
+                    err.contains("Disabled because base branch"),
+                    "over-limit input must be skipped before matching but stderr was: " + err);
+        }
+    }
+
+    @Test
+    void detectChanges_emptyDisableRegexLists_detectionProceeds() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(tempDir.resolve("new-file.txt"), "world".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("new-file.txt").call();
+            git.commit().setMessage("add new file").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            // unset vs empty-string variants must both behave as "no patterns configured"
+            sys.setProperty("scalpel.disableOnBranch", "");
+            sys.setProperty("scalpel.disableOnBaseBranch", "");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of());
+
+            assertNotNull(result);
+            assertTrue(result.getChangedFiles().contains("new-file.txt"));
+        }
+    }
+
+    /**
+     * Runs the action with System.err captured (slf4j-simple writes to stderr)
+     * and returns everything that was written during its execution.
+     */
+    private String captureStderr(Runnable action) {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
     }
 
     @Test

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -11,6 +11,7 @@ import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
 import static java.util.Objects.requireNonNull;
 
+import eu.maveniverse.maven.scalpel.core.BoundedRegexMatcher;
 import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import eu.maveniverse.maven.scalpel.core.ScalpelCore;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.PatternSyntaxException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -64,6 +64,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     private final PomChangeAnalyzer pomChangeAnalyzer;
     private final ReactorTrimmer reactorTrimmer;
     private final ProjectDependenciesResolver dependenciesResolver;
+    private final BoundedRegexMatcher regexMatcher = new BoundedRegexMatcher();
 
     @Inject
     public ScalpelLifecycleParticipant(
@@ -1578,13 +1579,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private String matchesForceBuild(MavenProject project, List<String> patterns) {
         for (String pattern : patterns) {
-            try {
-                if (project.getArtifactId().matches(pattern)) {
-                    logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
-                    return pattern;
-                }
-            } catch (PatternSyntaxException e) {
-                logger.warn("Scalpel: Invalid regex pattern '{}' in forceBuildModules: {}", pattern, e.getMessage());
+            // artifactId is PR-author-controlled input (including length): match through the
+            // cached, input-bounded matcher, never String.matches()
+            if (regexMatcher.matches(project.getArtifactId(), pattern, "forceBuildModules", logger)) {
+                logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
+                return pattern;
             }
         }
         return null;

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -7,6 +7,7 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -23,7 +24,9 @@ import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
 import eu.maveniverse.maven.scalpel.core.ScalpelCore;
 import eu.maveniverse.maven.scalpel.core.ScalpelException;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -1393,6 +1396,97 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(Files.exists(reportFile));
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
         assertTrue(moduleHasReason(json, "module-b", "FORCE_BUILD"), "module-b should have FORCE_BUILD reason");
+    }
+
+    @Test
+    void reportMode_forceBuildModulesArtifactIdOverLimit_skipsMatchAndWarnsOnce() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // artifactId is fully PR-controlled (module directory name stays short:
+        // filesystems cap file names at 255 bytes, artifactIds have no such cap)
+        String longArtifactId = "m".repeat(300);
+        String longModuleDir = "long-module";
+
+        String parentPom = simpleParentPom("module-a", longModuleDir);
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String longModulePom = simpleChildPom(longArtifactId);
+        writePom(root, longModuleDir + "/pom.xml", longModulePom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject longModule =
+                createProject("com.example", longArtifactId, "1.0", root, longModuleDir + "/pom.xml", longModulePom);
+        longModule.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, longModule);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        // two patterns that would both match the over-long artifactId without an input cap
+        session.getSystemProperties().setProperty("scalpel.forceBuildModules", "zz-never,.*");
+
+        String err = captureStderr(() -> assertDoesNotThrow(() -> participant.afterProjectsRead(session)));
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertFalse(
+                moduleHasReason(json, longArtifactId, "FORCE_BUILD"),
+                "an over-limit artifactId must not be force-included, even against '.*'");
+        assertTrue(err.contains("forceBuildModules"), "the cap WARN must name the config key but stderr was: " + err);
+        assertEquals(
+                1,
+                countOccurrences(err, "character limit"),
+                "one cap WARN per over-long input, not one per pattern; stderr was: " + err);
+    }
+
+    @Test
+    void reportMode_forceBuildModulesEmptyProperty_noForceIncludes() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        // empty-string variant must behave as unset (no patterns, no matching, no failure)
+        session.getSystemProperties().setProperty("scalpel.forceBuildModules", "");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile));
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertFalse(moduleHasReason(json, "module-b", "FORCE_BUILD"), "no FORCE_BUILD expected with an empty list");
     }
 
     @Test
@@ -4136,6 +4230,32 @@ class ScalpelLifecycleParticipantTest {
     private boolean moduleHasReason(String json, String artifactId, String reason) {
         String block = extractModuleBlock(json, artifactId);
         return block != null && block.contains("\"" + reason + "\"");
+    }
+
+    /**
+     * Runs the action with System.err captured (slf4j-simple writes to stderr)
+     * and returns everything that was written during its execution.
+     */
+    private String captureStderr(Runnable action) {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
+    private int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) >= 0) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
     }
 
     private boolean moduleHasAnySourceSet(String json, String artifactId) {


### PR DESCRIPTION
## Problem

As filed in #98: the three regex options (`disableOnBranch`, `disableOnBaseBranch`, `forceBuildModules`) were matched via `String.matches()`, which compiles the pattern on every call - `forceBuildModules` per module per pattern against `project.getArtifactId()`, which a PR author fully controls including length. A maintainer pattern with nested quantifiers plus a crafted artifactId can backtrack exponentially and hang the Maven JVM. Java's glob translation also produces chained `.*` segments (polynomial) for multi-wildcard patterns.

## Change

A new `BoundedRegexMatcher` (one instance per consuming class) now backs both match sites:

- **Compile-once cache**: patterns are compiled into a bounded cache (256 entries; beyond it, degrades silently to per-call compilation, the previous behavior - maintainer-supplied config, so compile cost is not attacker-influenced).
- **Input cap**: branch names and artifactIds longer than 256 characters are skipped with a single WARN naming the config key and the limit, and count as non-matches. The limit is generous against reality: real artifactIds sit well under 100 characters, git refs are conventionally bounded near 255 bytes, and a 256+ character artifactId cannot even pass `mvn install` on mainstream filesystems (filename-component cap of 255 on APFS/ext4/XFS, verified empirically).
- **Invalid/null patterns** are non-matches with one WARN per pattern per key (previously the invalid-pattern WARN fired on every call - log-spam reduction, message text unchanged).
- README documents that these options are user-supplied regexes evaluated against PR-influenced input, with the cap and linear-pattern guidance.

**Design note, flagged for review**: the cap direction is uniform (over-limit = non-match). For the disable options that fails toward "not disabled" (build proceeds, the safe direction per #82's convention). For `forceBuildModules` it means not force-included; the under-build window requires a pre-existing, unchanged module with a 257+ character artifactId that the maintainer force-listed - installable nowhere mainstream and WARNed once. If you weigh "user explicitly asked for this module to always build" as inviolable, a one-line split (force-include on over-limit for forceBuild only) is easy to concede.

**API note**: `BoundedRegexMatcher` is a new public core class (used cross-module by extension3.internal; package-private is impossible cross-artifact). It is exactly the API-surface accretion #127 complains about - happy to relocate to a `core.internal` package as follow-up if you prefer.

## Verification

TDD: RED first (over-limit artifactId force-included and over-limit branch disabling detection, both failing on main; matcher class absent), then GREEN. Full suites green (core 159, extension3 167). Null/empty variants covered for all three option lists; unset maps to the same empty list by parseList.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safer handling for branch and artifact matching patterns.
  * Overly long inputs are skipped and reported with a warning instead of being matched.
  * Invalid patterns no longer interrupt processing and are reported once.
  * Empty matching settings now behave like unset values.
  * Base branch names with remote prefixes are handled correctly.

* **Documentation**
  * Documented matching limits, warning behavior, and recommendations for regex patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->