### PR TITLE
Fix #104: generate a CycloneDX SBOM on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
-          ./mvnw -B deploy -Dnjord.autoPublish -Pmaveniverse-release -s .github/release-settings.xml
+          ./mvnw -B deploy -Dnjord.autoPublish -Pmaveniverse-release,cyclonedx-sbom -s .github/release-settings.xml
 
       - name: Post release
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
 
     <version.slf4j>1.7.36</version.slf4j>
     <version.jacoco>0.8.15</version.jacoco>
+    <version.cyclonedx>2.9.3</version.cyclonedx>
   </properties>
 
   <dependencyManagement>
@@ -226,4 +227,37 @@
       </plugin>
     </plugins>
   </build>
+
+  <!--
+    Generate a CycloneDX SBOM for the release: a single aggregate BOM (JSON + XML,
+    spec version 1.6 as per plugin default) covering the whole reactor, attached with
+    the "cyclonedx" classifier so that it gets deployed with the released artifacts.
+    Modules that are not deployed (like it) are skipped by the plugin's default
+    skipNotDeployed setting. Invoked by the release workflow, see .github/workflows/release.yml
+  -->
+  <profiles>
+    <profile>
+      <id>cyclonedx-sbom</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>${version.cyclonedx}</version>
+            <executions>
+              <execution>
+                <id>generate-aggregate-sbom</id>
+                <goals>
+                  <goal>makeAggregateBom</goal>
+                </goals>
+                <configuration>
+                  <outputReactorProjects>false</outputReactorProjects>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Problem

As re-scoped on issue #104: Dependabot and the action pinning are done (merged), the JGit CVE waiver is moot on 7.7.1 (fresh OSV query returns nothing for the exact pinned build, and even the naive NVD prose bounds exclude it). The one genuinely open item is the SBOM: nothing in the repository generates one today.

## Change

- A dedicated `cyclonedx-sbom` profile wires `cyclonedx-maven-plugin` 2.9.3 (latest per Maven Central metadata) with `makeAggregateBom`: one aggregate SBOM per release at the reactor root, attached with the `cyclonedx` classifier so it deploys to Central alongside the artifacts. No per-module SBOMs.
- The release workflow's deploy line adds the profile (`-Pmaveniverse-release,cyclonedx-sbom`); `ci.yml` and `deploy-snapshot.yml` are untouched, so normal builds pay nothing.
- The plugin's default `skipNotDeployed=true` auto-excludes non-deploying modules (covers `it`).

## Verification

Full-reactor local run with the profile: BUILD SUCCESS, 149+165 tests green, `target/bom.json` + `bom.xml` produced, schema-validated (CycloneDX spec 1.6), attached as `scalpel-<version>-cyclonedx.{json,xml}`. The aggregate content was inspected: 40 components including all three deployable scalpel modules, JGit 7.7.1, Maven 3.9.16, Resolver 1.9.27, slf4j 1.7.36. Plugin behavior confirmed against its source at the 2.9.3 tag rather than documentation memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now generate aggregate CycloneDX software bills of materials (SBOMs) in JSON and XML formats.
  * SBOM files are attached to released artifacts for improved software transparency and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->