### PR TITLE
Fix #105: size-cap git blob reads for old-POM comparison

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -153,7 +153,22 @@ public class GitChangeDetector {
         return changedFiles;
     }
 
-    public byte[] readFileAtCommit(Repository repository, ObjectId commitId, String path) throws IOException {
+    /**
+     * Reads the file content at the given path in the commit's tree.
+     * <p>
+     * The blob is read only when its size does not exceed {@code maxFileSize}: an oversized
+     * blob is skipped with a WARN and {@code null} is returned, the same value used for a
+     * path absent at the commit, so callers treat it conservatively (as changed/affected)
+     * instead of loading unbounded content into memory.
+     *
+     * @param maxFileSize maximum blob size in bytes to read (the
+     * {@code scalpel.maxResourceFileSize} cap); must be positive
+     * @return the file content, or null when the path is absent at the commit or its blob
+     * exceeds {@code maxFileSize}
+     */
+    public byte[] readFileAtCommit(Repository repository, ObjectId commitId, String path, long maxFileSize)
+            throws IOException {
+        requirePositiveMaxFileSize(maxFileSize);
         try (RevWalk revWalk = new RevWalk(repository)) {
             RevCommit commit = revWalk.parseCommit(commitId);
             try (TreeWalk treeWalk = TreeWalk.forPath(repository, path, commit.getTree())) {
@@ -161,6 +176,9 @@ public class GitChangeDetector {
                     return null;
                 }
                 ObjectLoader loader = repository.open(treeWalk.getObjectId(0));
+                if (isOverSizeCap(path, loader.getSize(), maxFileSize)) {
+                    return null;
+                }
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 loader.copyTo(out);
                 return out.toByteArray();
@@ -169,6 +187,26 @@ public class GitChangeDetector {
             warnIfShallow(repository, commitId.getName(), path);
             throw e;
         }
+    }
+
+    private static void requirePositiveMaxFileSize(long maxFileSize) {
+        if (maxFileSize <= 0) {
+            throw new IllegalArgumentException("maxFileSize must be positive, got " + maxFileSize);
+        }
+    }
+
+    private boolean isOverSizeCap(String path, long blobSize, long maxFileSize) {
+        if (blobSize > maxFileSize) {
+            logger.warn(
+                    "Skipping blob {}: size {} bytes exceeds scalpel.maxResourceFileSize ({} bytes);"
+                            + " treating the change conservatively as affected."
+                            + " Raise -Dscalpel.maxResourceFileSize to read this blob",
+                    path,
+                    blobSize,
+                    maxFileSize);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -274,9 +312,18 @@ public class GitChangeDetector {
      * Reads multiple files at the given commit in a single TreeWalk pass.
      * Uses a PathFilterGroup so the TreeWalk only visits matching entries,
      * and shares a single ObjectReader/RevWalk across all reads.
+     * <p>
+     * Blobs larger than {@code maxFileSize} are skipped with a WARN and omitted from the
+     * result, the same treatment as a path absent at the commit: POM-change analysis then
+     * marks the module and its dependents as affected rather than loading unbounded
+     * content into memory.
+     *
+     * @param maxFileSize maximum blob size in bytes to read (the
+     * {@code scalpel.maxResourceFileSize} cap); must be positive
      */
-    public Map<String, byte[]> readPomFilesAtCommit(Repository repository, ObjectId commitId, Set<String> paths)
-            throws IOException {
+    public Map<String, byte[]> readPomFilesAtCommit(
+            Repository repository, ObjectId commitId, Set<String> paths, long maxFileSize) throws IOException {
+        requirePositiveMaxFileSize(maxFileSize);
         if (paths.isEmpty()) {
             return Map.of();
         }
@@ -295,6 +342,9 @@ public class GitChangeDetector {
                             || treeWalk.getFileMode(0) == FileMode.EXECUTABLE_FILE) {
                         String path = treeWalk.getPathString();
                         ObjectLoader loader = reader.open(treeWalk.getObjectId(0));
+                        if (isOverSizeCap(path, loader.getSize(), maxFileSize)) {
+                            continue;
+                        }
                         ByteArrayOutputStream out = new ByteArrayOutputStream();
                         loader.copyTo(out);
                         result.put(path, out.toByteArray());

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -166,6 +166,14 @@ public class GitChangeDetector {
      * @return the file content, or null when the path is absent at the commit or its blob
      * exceeds {@code maxFileSize}
      */
+    /**
+     * Backward-compatible overload delegating to {@link #readFileAtCommit(Repository, ObjectId, String, long)}
+     * with the documented default cap ({@code scalpel.maxResourceFileSize}, 10 MiB).
+     */
+    public byte[] readFileAtCommit(Repository repository, ObjectId commitId, String path) throws IOException {
+        return readFileAtCommit(repository, commitId, path, ScalpelConfiguration.DEFAULT_MAX_RESOURCE_FILE_SIZE);
+    }
+
     public byte[] readFileAtCommit(Repository repository, ObjectId commitId, String path, long maxFileSize)
             throws IOException {
         requirePositiveMaxFileSize(maxFileSize);

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -154,6 +154,14 @@ public class GitChangeDetector {
     }
 
     /**
+     * Backward-compatible overload delegating to {@link #readFileAtCommit(Repository, ObjectId, String, long)}
+     * with the documented default cap ({@code scalpel.maxResourceFileSize}, 10 MiB).
+     */
+    public byte[] readFileAtCommit(Repository repository, ObjectId commitId, String path) throws IOException {
+        return readFileAtCommit(repository, commitId, path, ScalpelConfiguration.DEFAULT_MAX_RESOURCE_FILE_SIZE);
+    }
+
+    /**
      * Reads the file content at the given path in the commit's tree.
      * <p>
      * The blob is read only when its size does not exceed {@code maxFileSize}: an oversized
@@ -166,14 +174,6 @@ public class GitChangeDetector {
      * @return the file content, or null when the path is absent at the commit or its blob
      * exceeds {@code maxFileSize}
      */
-    /**
-     * Backward-compatible overload delegating to {@link #readFileAtCommit(Repository, ObjectId, String, long)}
-     * with the documented default cap ({@code scalpel.maxResourceFileSize}, 10 MiB).
-     */
-    public byte[] readFileAtCommit(Repository repository, ObjectId commitId, String path) throws IOException {
-        return readFileAtCommit(repository, commitId, path, ScalpelConfiguration.DEFAULT_MAX_RESOURCE_FILE_SIZE);
-    }
-
     public byte[] readFileAtCommit(Repository repository, ObjectId commitId, String path, long maxFileSize)
             throws IOException {
         requirePositiveMaxFileSize(maxFileSize);
@@ -314,6 +314,16 @@ public class GitChangeDetector {
         } catch (GitAPIException | JGitInternalException e) {
             throw new IOException("Failed to fetch " + baseBranch, e);
         }
+    }
+
+    /**
+     * Backward-compatible overload delegating to
+     * {@link #readPomFilesAtCommit(Repository, ObjectId, Set, long)}
+     * with the documented default cap ({@code scalpel.maxResourceFileSize}, 10 MiB).
+     */
+    public Map<String, byte[]> readPomFilesAtCommit(Repository repository, ObjectId commitId, Set<String> paths)
+            throws IOException {
+        return readPomFilesAtCommit(repository, commitId, paths, ScalpelConfiguration.DEFAULT_MAX_RESOURCE_FILE_SIZE);
     }
 
     /**

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -174,9 +174,10 @@ public final class ScalpelConfiguration {
     public static final String REPORT_FILE = PREFIX + "reportFile";
 
     /**
-     * System property {@code scalpel.maxResourceFileSize}: maximum size in bytes for a resource file
-     * to be scanned during source mapping; larger files are skipped. Default:
-     * {@link #DEFAULT_MAX_RESOURCE_FILE_SIZE}.
+     * System property {@code scalpel.maxResourceFileSize}: maximum size in bytes of a git blob
+     * read for change analysis (old-POM content at the merge base). Larger blobs are skipped
+     * with a WARN and the affected analysis treats the module conservatively as affected.
+     * Default: {@link #DEFAULT_MAX_RESOURCE_FILE_SIZE}.
      */
     public static final String MAX_RESOURCE_FILE_SIZE = PREFIX + "maxResourceFileSize";
 
@@ -684,8 +685,9 @@ public final class ScalpelConfiguration {
     }
 
     /**
-     * Returns the maximum size in bytes for a resource file to be scanned during source mapping.
-     * Default: {@link #DEFAULT_MAX_RESOURCE_FILE_SIZE}.
+     * Returns the maximum size in bytes of a git blob read for change analysis (old-POM
+     * content at the merge base); larger blobs are skipped with a WARN and treated
+     * conservatively as affected. Default: {@link #DEFAULT_MAX_RESOURCE_FILE_SIZE}.
      */
     public long getMaxResourceFileSize() {
         return maxResourceFileSize;

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -185,8 +185,8 @@ public class ScalpelCore {
                     changedPomPaths.add(path);
                 }
             }
-            Map<String, byte[]> oldPomContents =
-                    gitChangeDetector.readPomFilesAtCommit(repository, mergeBase, changedPomPaths);
+            Map<String, byte[]> oldPomContents = gitChangeDetector.readPomFilesAtCommit(
+                    repository, mergeBase, changedPomPaths, config.getMaxResourceFileSize());
 
             return new ChangeDetectionResult(changedFiles, oldPomContents);
         } catch (ScalpelException e) {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
@@ -21,6 +21,8 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.ObjectId;
@@ -276,7 +278,8 @@ class GitChangeDetectorTest {
             git.commit().setMessage("add data").call();
 
             ObjectId commitId = git.getRepository().resolve("HEAD");
-            byte[] read = detector.readFileAtCommit(git.getRepository(), commitId, "data.txt");
+            byte[] read = detector.readFileAtCommit(
+                    git.getRepository(), commitId, "data.txt", ScalpelConfiguration.DEFAULT_MAX_RESOURCE_FILE_SIZE);
 
             assertNotNull(read);
             assertEquals(content, new String(read, StandardCharsets.UTF_8));
@@ -291,9 +294,79 @@ class GitChangeDetectorTest {
             git.commit().setMessage("initial").call();
 
             ObjectId commitId = git.getRepository().resolve("HEAD");
-            byte[] read = detector.readFileAtCommit(git.getRepository(), commitId, "nonexistent.txt");
+            byte[] read = detector.readFileAtCommit(
+                    git.getRepository(),
+                    commitId,
+                    "nonexistent.txt",
+                    ScalpelConfiguration.DEFAULT_MAX_RESOURCE_FILE_SIZE);
 
             assertNull(read, "Should return null for a file not present at the commit");
+        }
+    }
+
+    @Test
+    void readFileAtCommit_oversizeBlob_returnsNullWithWarn() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            byte[] blob = new byte[300];
+            Arrays.fill(blob, (byte) 'x');
+            Files.write(tempDir.resolve("data.txt"), blob);
+            git.add().addFilepattern("data.txt").call();
+            git.commit().setMessage("add data").call();
+
+            ObjectId commitId = git.getRepository().resolve("HEAD");
+            String err = captureStderr(() -> {
+                byte[] read;
+                try {
+                    read = detector.readFileAtCommit(git.getRepository(), commitId, "data.txt", 200);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                assertNull(read, "Blob over the cap must be skipped (null), not read into memory");
+            });
+
+            assertTrue(err.contains("WARN "), "expected a WARN about the oversized blob but stderr was: " + err);
+            assertTrue(err.contains("data.txt"), "WARN should name the blob path but stderr was: " + err);
+            assertTrue(err.contains("300"), "WARN should name the blob size but stderr was: " + err);
+            assertTrue(err.contains("200"), "WARN should name the cap but stderr was: " + err);
+            assertTrue(
+                    err.contains("scalpel.maxResourceFileSize"),
+                    "WARN should name how to raise the cap but stderr was: " + err);
+        }
+    }
+
+    @Test
+    void readFileAtCommit_blobAtExactCap_stillReads() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            byte[] blob = new byte[200];
+            Arrays.fill(blob, (byte) 'x');
+            Files.write(tempDir.resolve("data.txt"), blob);
+            git.add().addFilepattern("data.txt").call();
+            git.commit().setMessage("add data").call();
+
+            ObjectId commitId = git.getRepository().resolve("HEAD");
+            byte[] read = detector.readFileAtCommit(git.getRepository(), commitId, "data.txt", 200);
+
+            assertNotNull(read, "A blob exactly at the cap must still be read (only strictly larger is skipped)");
+            assertEquals(200, read.length);
+        }
+    }
+
+    @Test
+    void readFileAtCommit_nonPositiveCap_rejected() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("file.txt"), "x".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("file.txt").call();
+            git.commit().setMessage("initial").call();
+
+            ObjectId commitId = git.getRepository().resolve("HEAD");
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> detector.readFileAtCommit(git.getRepository(), commitId, "file.txt", 0),
+                    "A zero cap must be rejected up front");
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> detector.readFileAtCommit(git.getRepository(), commitId, "file.txt", -1),
+                    "A negative cap must be rejected up front");
         }
     }
 
@@ -533,7 +606,10 @@ class GitChangeDetectorTest {
 
             ObjectId commitId = git.getRepository().resolve("HEAD");
             var result = detector.readPomFilesAtCommit(
-                    git.getRepository(), commitId, Set.of("pom.xml", "sub/pom.xml", "missing/pom.xml"));
+                    git.getRepository(),
+                    commitId,
+                    Set.of("pom.xml", "sub/pom.xml", "missing/pom.xml"),
+                    ScalpelConfiguration.DEFAULT_MAX_RESOURCE_FILE_SIZE);
 
             assertEquals(2, result.size(), "Should read two existing poms, skip the missing one");
             assertTrue(result.containsKey("pom.xml"));
@@ -541,6 +617,59 @@ class GitChangeDetectorTest {
             assertFalse(result.containsKey("missing/pom.xml"), "Missing pom should not be in the map");
             assertEquals("<project/>", new String(result.get("pom.xml"), StandardCharsets.UTF_8));
             assertEquals("<module/>", new String(result.get("sub/pom.xml"), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    void readPomFilesAtCommit_oversizeBlob_omitsEntryWithWarn() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            byte[] bigPom = new byte[300];
+            Arrays.fill(bigPom, (byte) 'x');
+            Files.write(tempDir.resolve("pom.xml"), bigPom);
+            Files.createDirectories(tempDir.resolve("sub"));
+            Files.write(tempDir.resolve("sub/pom.xml"), "<module/>".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.add().addFilepattern("sub/pom.xml").call();
+            git.commit().setMessage("add poms").call();
+
+            ObjectId commitId = git.getRepository().resolve("HEAD");
+            String err = captureStderr(() -> {
+                Map<String, byte[]> result;
+                try {
+                    result = detector.readPomFilesAtCommit(
+                            git.getRepository(), commitId, Set.of("pom.xml", "sub/pom.xml"), 200);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                assertFalse(result.containsKey("pom.xml"), "Oversized pom blob must be omitted from the map");
+                assertTrue(result.containsKey("sub/pom.xml"), "Pom under the cap must still be read");
+                assertEquals(1, result.size());
+            });
+
+            assertTrue(err.contains("WARN "), "expected a WARN about the oversized blob but stderr was: " + err);
+            assertTrue(err.contains("pom.xml"), "WARN should name the blob path but stderr was: " + err);
+            assertTrue(
+                    err.contains("scalpel.maxResourceFileSize"),
+                    "WARN should name how to raise the cap but stderr was: " + err);
+        }
+    }
+
+    @Test
+    void readPomFilesAtCommit_nonPositiveCap_rejected() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("pom.xml"), "<project/>".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("add pom").call();
+
+            ObjectId commitId = git.getRepository().resolve("HEAD");
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> detector.readPomFilesAtCommit(git.getRepository(), commitId, Set.of("pom.xml"), 0),
+                    "A zero cap must be rejected up front");
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> detector.readPomFilesAtCommit(git.getRepository(), commitId, Set.of("pom.xml"), -5),
+                    "A negative cap must be rejected up front");
         }
     }
 

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/GitChangeDetectorTest.java
@@ -15,9 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -655,6 +653,19 @@ class GitChangeDetectorTest {
     }
 
     @Test
+    void readFileAtCommit_threeArgOverload_usesDefaultCap() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("data.txt"), "x".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("data.txt").call();
+            git.commit().setMessage("initial").call();
+            ObjectId commitId = git.getRepository().resolve("HEAD");
+            // small file reads fine through the backward-compatible 3-arg form
+            byte[] read = detector.readFileAtCommit(git.getRepository(), commitId, "data.txt");
+            assertNotNull(read, "3-arg overload must read a file under the default cap");
+        }
+    }
+
+    @Test
     void readPomFilesAtCommit_nonPositiveCap_rejected() throws Exception {
         try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
             Files.write(tempDir.resolve("pom.xml"), "<project/>".getBytes(StandardCharsets.UTF_8));
@@ -735,15 +746,7 @@ class GitChangeDetectorTest {
      * and returns everything that was written during its execution.
      */
     private String captureStderr(Runnable action) {
-        PrintStream originalErr = System.err;
-        ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
-        try {
-            action.run();
-        } finally {
-            System.setErr(originalErr);
-        }
-        return captured.toString(StandardCharsets.UTF_8);
+        return TestOutputCapture.captureStderr(action);
     }
 
     @Test

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -355,6 +355,98 @@ class ScalpelCoreTest {
         }
     }
 
+    @Test
+    void detectChanges_oldPomOverSizeCap_omittedWithWarn() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            // Old POM deliberately larger than the configured cap
+            String oldPom = "<project><!--" + "x".repeat(300) + "--><version>1.0</version></project>";
+            Files.write(tempDir.resolve("pom.xml"), oldPom.getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            String newPom = "<project><version>2.0</version></project>";
+            Files.write(tempDir.resolve("pom.xml"), newPom.getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("bump version").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            sys.setProperty("scalpel.maxResourceFileSize", "200");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            String err = captureStderr(() -> {
+                ChangeDetectionResult result;
+                try {
+                    result = core.detectChanges(tempDir, config, Set.of("pom.xml"));
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                assertNotNull(result);
+                assertTrue(result.getChangedFiles().contains("pom.xml"), "the change itself must still be detected");
+                assertFalse(
+                        result.getOldPomContents().containsKey("pom.xml"),
+                        "old POM blob over scalpel.maxResourceFileSize must be omitted from old POM contents");
+            });
+
+            assertTrue(err.contains("WARN "), "expected a WARN about the oversized blob but stderr was: " + err);
+            assertTrue(err.contains("pom.xml"), "WARN should name the blob path but stderr was: " + err);
+            assertTrue(
+                    err.contains("scalpel.maxResourceFileSize"),
+                    "WARN should name how to raise the cap but stderr was: " + err);
+        }
+    }
+
+    @Test
+    void detectChanges_oldPomUnderSizeCap_stillRead() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            String oldPom = "<project><!--" + "x".repeat(300) + "--><version>1.0</version></project>";
+            Files.write(tempDir.resolve("pom.xml"), oldPom.getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            Files.write(
+                    tempDir.resolve("pom.xml"),
+                    "<project><version>2.0</version></project>".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("bump version").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            // Cap comfortably above the blob size: the read must go through
+            sys.setProperty("scalpel.maxResourceFileSize", "4096");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of("pom.xml"));
+
+            assertNotNull(result);
+            assertTrue(
+                    result.getOldPomContents().containsKey("pom.xml"), "old POM blob under the cap must still be read");
+            assertTrue(
+                    new String(result.getOldPomContents().get("pom.xml"), StandardCharsets.UTF_8).contains("1.0"),
+                    "old POM content must be the base-branch version");
+        }
+    }
+
+    /**
+     * Runs the callable with System.err captured (slf4j-simple writes to stderr)
+     * and returns everything that was written during its execution.
+     */
+    private String captureStderr(Runnable action) {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
     /**
      * Detector whose findMergeBase returns null (simulating graceful degradation
      * when the merge-base is unreachable, e.g. shallow clone).

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -226,15 +226,7 @@ class ScalpelCoreTest {
      * and returns everything that was written during its execution.
      */
     private String captureStderr(Runnable action) {
-        PrintStream originalErr = System.err;
-        ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
-        try {
-            action.run();
-        } finally {
-            System.setErr(originalErr);
-        }
-        return captured.toString(StandardCharsets.UTF_8);
+        return TestOutputCapture.captureStderr(action);
     }
 
     @Test
@@ -427,14 +419,6 @@ class ScalpelCoreTest {
                     new String(result.getOldPomContents().get("pom.xml"), StandardCharsets.UTF_8).contains("1.0"),
                     "old POM content must be the base-branch version");
         }
-    }
-
-    /**
-     * Runs the callable with System.err captured (slf4j-simple writes to stderr)
-     * and returns everything that was written during its execution.
-     */
-    private String captureStderr(Runnable action) {
-        return TestOutputCapture.captureStderr(action);
     }
 
     /**

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -15,8 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -436,15 +434,7 @@ class ScalpelCoreTest {
      * and returns everything that was written during its execution.
      */
     private String captureStderr(Runnable action) {
-        PrintStream originalErr = System.err;
-        ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
-        try {
-            action.run();
-        } finally {
-            System.setErr(originalErr);
-        }
-        return captured.toString(StandardCharsets.UTF_8);
+        return TestOutputCapture.captureStderr(action);
     }
 
     /**

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/TestOutputCapture.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/TestOutputCapture.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Test utility capturing {@code System.err} while an action runs, for asserting on
+ * log output (the test logging backend writes there and resolves the stream per call).
+ */
+final class TestOutputCapture {
+
+    private TestOutputCapture() {}
+
+    /**
+     * Runs the action with {@code System.err} redirected to an in-memory buffer
+     * and returns everything that was written during its execution.
+     */
+    static String captureStderr(Runnable action) {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -418,16 +418,23 @@ class PomChangeAnalyzer {
         // Parent/BOM POM changed: analyze what actually changed
         byte[] oldPomBytes = ctx.oldPomContents.get(changedPomPath);
         if (oldPomBytes == null) {
-            // New POM (didn't exist in base), mark all dependents as affected
+            // No base content: either a genuinely new POM or one skipped for exceeding
+            // scalpel.maxResourceFileSize (the git-side WARN names it); both fail toward affected
             if (logger.isDebugEnabled()) {
-                logger.debug("New parent/BOM POM: {}, marking all dependents as affected", key(project));
+                logger.debug(
+                        "No base content for parent/BOM POM {} (new or oversize-skipped), marking all dependents as affected",
+                        key(project));
             }
             ctx.affected.add(project);
             ctx.affected.addAll(dependents);
             if (ctx.explain) {
-                addEvidence(ctx.evidence, project, "new pom " + changedPomPath);
+                addEvidence(
+                        ctx.evidence, project, "no base content for " + changedPomPath + " (new or oversize-skipped)");
                 for (MavenProject dependent : dependents) {
-                    addEvidence(ctx.evidence, dependent, "new pom " + changedPomPath);
+                    addEvidence(
+                            ctx.evidence,
+                            dependent,
+                            "no base content for " + changedPomPath + " (new or oversize-skipped)");
                 }
             }
             return;

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -347,6 +347,34 @@ class PomChangeAnalyzerTest {
     }
 
     @Test
+    void analyzeChanges_oversizedOldPomOmitted_marksAllDependentsAffected() throws Exception {
+        // The blob-size cap (scalpel.maxResourceFileSize) makes readPomFilesAtCommit omit
+        // an old POM blob that exceeds it from oldPomContents. That omission must land on
+        // the conservative side: the module and all its dependents are marked affected,
+        // never treated as "no effective change" (which would under-build).
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createSimpleReactor(root);
+
+        // Parent entry absent from oldPoms: exactly the map readPomFilesAtCommit returns
+        // when the parent's blob exceeded the size cap
+        Set<String> changedPoms = Set.of("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+
+        Set<MavenProject> affected =
+                analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+
+        assertEquals(
+                3,
+                affected.size(),
+                "Omitted oversized old POM must mark parent + all children as affected, not zero modules");
+        assertTrue(affected.contains(projects.get(0)), "parent must be affected when its old blob is unreadable");
+        assertTrue(
+                affected.contains(projects.get(1)), "module-a must be affected when the parent old blob is unreadable");
+        assertTrue(
+                affected.contains(projects.get(2)), "module-b must be affected when the parent old blob is unreadable");
+    }
+
+    @Test
     void analyzeChanges_returnsChangedProperties() throws Exception {
         Path root = setupReactorRoot();
         List<MavenProject> projects = createReactorWithPropertyUsage(root);


### PR DESCRIPTION
## Problem

As filed in #105: `readPomFilesAtCommit` read whole git blobs into memory with no ceiling (and `readFileAtCommit` the same), with every reactor POM held simultaneously during analysis. The realistic outcome was memory pressure rather than a clean OOM primitive, but a cap is cheap defence. The `scalpel.maxResourceFileSize` property (default 10 MiB) was fully orphaned after the effective-model rework - declared, validated, zero production consumers.

## Change

- Both blob readers in `GitChangeDetector` take the cap, check `ObjectLoader.getSize()` before any copy, and on oversize emit a WARN naming the path, size, cap and the `-Dscalpel.maxResourceFileSize` escape hatch, then skip (`readFileAtCommit` returns null, `readPomFilesAtCommit` omits the entry).
- The omission flows into the existing conservative branch: a changed POM with no base content marks the project and ALL transitive dependents affected (the same branch as a genuinely-new POM). Non-positive caps are rejected up front, mirroring the configuration-layer validation.
- `ScalpelCore` passes `config.getMaxResourceFileSize()`, bringing the property back into service for blob reads.

**Which knob governs which read** (worth stating plainly since the names are close): `scalpel.maxResourceFileSize` (10 MiB, configurable) caps git blob reads for old-POM comparison - this change. The filtered-resource file scan keeps its separate 1 MiB hardcoded limit; PR #129 fixes that side's skip direction. The property's documented meaning changes accordingly (it was dead code before this change).

**Binary-compatibility note**: `readFileAtCommit` is public core API (documented in #149) and its signature gains a parameter - a breaking change for direct users, worth a release-note line.

## Verification

TDD: RED first (the property ignored end-to-end, oversize POM present in old contents), then the fix, then a review pass (the explain evidence no longer misattributes an oversize skip as a "new pom"). Full suites green (core 156, extension3 166). Null-input covered: unset/default 10 MiB, small, non-positive at both config and detector layer. TOCTOU excluded by git's content-addressed immutability (verified against the JGit 7.7.1 jar).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable size limits for files read during change analysis.
  * Added detection and actionable warnings for shallow repositories.

* **Bug Fixes**
  * Oversized files are skipped with a warning and conservatively treated as affected.
  * Oversized previous POM files also affect dependent modules.
  * Unreadable files and failed model analysis now conservatively mark affected modules.
  * Files at or below the configured limit continue to be analyzed normally.

* **Documentation**
  * Clarified the maximum resource file size setting and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->