### PR TITLE
chore: pin comment consistency; document deliberately-empty test resolver overrides

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
 
       - name: Checkout ${{ github.ref_name }}
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -3076,12 +3076,14 @@ class PomChangeAnalyzerTest {
 
         @Override
         public void addRepository(Repository repository) throws InvalidRepositoryException {
-            // deliberately ignores repository declarations: the reactor model resolver only needs parent resolution
+            // deliberately ignores repository declarations: the reactor model resolver resolves parents and BOM imports
+            // from the reactor itself, never remote repositories
         }
 
         @Override
         public void addRepository(Repository repository, boolean replace) throws InvalidRepositoryException {
-            // deliberately ignores repository declarations: the reactor model resolver only needs parent resolution
+            // deliberately ignores repository declarations: the reactor model resolver resolves parents and BOM imports
+            // from the reactor itself, never remote repositories
         }
 
         @Override

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -3075,10 +3075,14 @@ class PomChangeAnalyzerTest {
         }
 
         @Override
-        public void addRepository(Repository repository) throws InvalidRepositoryException {}
+        public void addRepository(Repository repository) throws InvalidRepositoryException {
+            // deliberately ignores repository declarations: the reactor model resolver only needs parent resolution
+        }
 
         @Override
-        public void addRepository(Repository repository, boolean replace) throws InvalidRepositoryException {}
+        public void addRepository(Repository repository, boolean replace) throws InvalidRepositoryException {
+            // deliberately ignores repository declarations: the reactor model resolver only needs parent resolution
+        }
 
         @Override
         public ModelResolver newCopy() {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -4418,7 +4418,9 @@ class ScalpelLifecycleParticipantTest {
         }
 
         @Override
-        public void addRepository(Repository repository) throws InvalidRepositoryException {}
+        public void addRepository(Repository repository) throws InvalidRepositoryException {
+            // deliberately ignores repository declarations: the reactor model resolver only needs parent resolution
+        }
 
         @Override
         public void addRepository(Repository repository, boolean replace) throws InvalidRepositoryException {}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -4419,7 +4419,8 @@ class ScalpelLifecycleParticipantTest {
 
         @Override
         public void addRepository(Repository repository) throws InvalidRepositoryException {
-            // deliberately ignores repository declarations: the reactor model resolver only needs parent resolution
+            // deliberately ignores repository declarations: the reactor model resolver resolves parents and BOM imports
+            // from the reactor itself, never remote repositories
         }
 
         @Override

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -4424,7 +4424,10 @@ class ScalpelLifecycleParticipantTest {
         }
 
         @Override
-        public void addRepository(Repository repository, boolean replace) throws InvalidRepositoryException {}
+        public void addRepository(Repository repository, boolean replace) throws InvalidRepositoryException {
+            // deliberately ignores repository declarations: the reactor model resolver resolves parents and BOM imports
+            // from the reactor itself, never remote repositories
+        }
 
         @Override
         public org.apache.maven.model.resolution.ModelResolver newCopy() {


### PR DESCRIPTION
Two small follow-ups from review threads on merged PRs:

1. **Pin comment consistency** (open thread on #134): the actions/checkout pin `3d3c42e` carried `# v7` but resolves to v7.0.1, while every other pin in that PR uses the specific point version. Comments updated in the three workflows.

2. **Deliberately-empty test resolver overrides** (thread on #145): the `addRepository` overrides in the test `ReactorModelResolver` copies ignore repository declarations by design, but the empty bodies carried no explanation - a SonarCloud "undocumented empty method" gate risk. Each now says why it is empty (the resolver only needs parent resolution).

Test-only and comment-only changes; extension3 suite green (173 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated workflow version annotations to accurately reflect the pinned action release.
  - Clarified test behavior around intentionally ignored repository declarations.

- **Tests**
  - Improved inline documentation in test helpers without changing test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->