### PR TITLE
test: bidirectional schema drift guard (emitted fields vs schema properties)

### DIFF
--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -191,6 +192,34 @@ class ScalpelReportSchemaTest {
     @Test
     void schemaSkippedReasons_matchEmittableConstants() {
         assertEquals(List.of(ScalpelReport.SKIP_REASON_NOT_AFFECTED), skippedModuleReasonsEnum());
+    }
+
+    @Test
+    void schemaTopLevelProperties_matchEmittableFields() {
+        // The validator cannot catch a newly emitted OPTIONAL field (JSON Schema ignores
+        // undeclared instance properties by design), so this guard compares the schema's
+        // declared top-level property set against the field names toJson can emit. A new
+        // field without a matching schema edit fails here instead of drifting silently.
+        Map<String, Object> props = cast(schema.get("properties"), "schema.properties");
+        Set<String> declared = new java.util.TreeSet<>(props.keySet());
+        // Every top-level key ScalpelReport.toJson emits, in emission order:
+        Set<String> emittable = new java.util.TreeSet<>(Set.of(
+                "version",
+                "scalpelVersion",
+                "baseBranch",
+                "fullBuildTriggered",
+                "triggerFile",
+                "changedFiles",
+                "changedProperties",
+                "changedManagedDependencies",
+                "changedManagedPlugins",
+                "unmatchedPomPaths",
+                "excludedUpstreamCount",
+                "affectedModules",
+                "skippedModules",
+                "status",
+                "reason"));
+        assertEquals(emittable, declared, "schema top-level properties must exactly match the fields toJson emits");
     }
 
     // ---------------------------------------------------------------

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -221,27 +221,35 @@ class ScalpelReportSchemaTest {
         // undeclared instance properties by design), so this guard compares the schema's
         // declared top-level property set against the field names toJson can emit. A new
         // field without a matching schema edit fails here instead of drifting silently.
+        //
+        // Rather than hardcoding the emittable set, we derive it from a maximal report
+        // instance that populates every optional field. This way, adding a field to
+        // toJson() without updating the schema (or vice versa) is caught automatically.
+        Timings timings = new Timings();
+        timings.start(Timings.PHASE_DIFF);
+        timings.stop(Timings.PHASE_DIFF);
+        timings.increment(Timings.OP_GIT_BLOBS_READ, 1);
+        ScalpelReport maximalReport = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .status("skipped")
+                .reason("drift guard fixture")
+                .fullBuildTriggered(false)
+                .changedFiles(List.of("A.java"))
+                .changedProperties(List.of("v"))
+                .changedManagedDependencies(List.of("g:a"))
+                .changedManagedPlugins(List.of("g:p"))
+                .unmatchedPomPaths(List.of("x/pom.xml"))
+                .excludedUpstreamCount(1)
+                .timings(timings, 1)
+                .addAffectedModule(
+                        new ScalpelReport.AffectedModule("g", "a", "a", List.of(ScalpelReport.REASON_SOURCE_CHANGE)))
+                .addSkippedModule(
+                        new ScalpelReport.SkippedModule("g", "b", "b", ScalpelReport.SKIP_REASON_NOT_AFFECTED))
+                .build();
+        Map<String, Object> emitted = cast(Json.parse(maximalReport.toJson()), "maximal report");
+        Set<String> emittable = new TreeSet<>(emitted.keySet());
         Map<String, Object> props = cast(schema.get("properties"), "schema.properties");
         Set<String> declared = new TreeSet<>(props.keySet());
-        // Every top-level key ScalpelReport.toJson emits, in emission order:
-        Set<String> emittable = new TreeSet<>(Set.of(
-                "version",
-                "scalpelVersion",
-                "baseBranch",
-                "fullBuildTriggered",
-                "triggerFile",
-                "changedFiles",
-                "changedProperties",
-                "changedManagedDependencies",
-                "changedManagedPlugins",
-                "unmatchedPomPaths",
-                "excludedUpstreamCount",
-                "affectedModules",
-                "skippedModules",
-                "timings",
-                "operations",
-                "status",
-                "reason"));
         assertEquals(emittable, declared, "schema top-level properties must exactly match the fields toJson emits");
     }
 

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -221,9 +222,9 @@ class ScalpelReportSchemaTest {
         // declared top-level property set against the field names toJson can emit. A new
         // field without a matching schema edit fails here instead of drifting silently.
         Map<String, Object> props = cast(schema.get("properties"), "schema.properties");
-        Set<String> declared = new java.util.TreeSet<>(props.keySet());
+        Set<String> declared = new TreeSet<>(props.keySet());
         // Every top-level key ScalpelReport.toJson emits, in emission order:
-        Set<String> emittable = new java.util.TreeSet<>(Set.of(
+        Set<String> emittable = new TreeSet<>(Set.of(
                 "version",
                 "scalpelVersion",
                 "baseBranch",


### PR DESCRIPTION
Follow-up to #147's review: the report schema drift guarantee was one-directional for optional fields - the validator (correctly, per JSON Schema semantics) ignores undeclared instance properties, so a newly emitted optional field without a matching schema edit passed every test silently.

This adds an equality check between the set of top-level properties declared in `scalpel-report-v2.schema.json` and the set of top-level fields `toJson` can emit. A new field now fails the build until the schema is deliberately updated, making the README's drift guarantee bidirectional.

Core suite green (171 tests, including the new guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that the report schema stays aligned with the fields emitted in report output.
  * Added protection against optional fields being emitted without corresponding schema declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->