### PR TITLE
Fix #99: phase timing and operation-count instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,12 @@ is published alongside the code. The current version is **2**.
       "path": "module-d",
       "reason": "NOT_AFFECTED"
     }
-  ]
+  ],
+  "timings": {
+    "totalMillis": 123,
+    "phases": {"repoOpen": 1, "mergeBase": 8, "diff": 30, "moduleMapping": 1, "transitiveResolve": 6}
+  },
+  "operations": {"blobs": 1, "resolves": 10, "resolveCacheHits": 4}
 }
 ```
 
@@ -177,6 +182,10 @@ it was judged safe to skip (`NOT_AFFECTED`); it makes a green trimmed build revi
 `evidence` on a module entry lists the specific inputs behind that module's decision (a
 changed file path, `property <name>`, `managed dep <ga>`, `managed plugin <ga>`, `downstream
 of <ga>`) and is emitted only with `-Dscalpel.explain=true`. All three are omitted when empty.
+`timings` (`totalMillis` plus per-phase millis) and `operations` (named counters: git blobs
+read, effective models built, dependency resolutions with cache hits, resource entries
+visited) carry the same instrumentation as the one-line `Scalpel: analysis took ...` INFO
+summary; both are omitted when the analysis recorded nothing.
 
 **Status-only reports:** when analysis does not complete (failSafe bail-out, unexpected
 error) or is deliberately skipped (no changes detected, disabled by
@@ -190,7 +199,7 @@ e.g. `"no changes detected"`). Both fields are absent from normal full reports.
 
 | Version | Changes |
 |---------|---------|
-| `2` | Added `category`, `sourceSet`, `excludedUpstreamCount`, `testsSkipped`, `testsSkippedReason`. Later additive (no bump): `status`, `reason` (#137), `unmatchedPomPaths` (#138), `skippedModules` (#139), `evidence` (#142) |
+| `2` | Added `category`, `sourceSet`, `excludedUpstreamCount`, `testsSkipped`, `testsSkippedReason`. Later additive (no bump): `status`, `reason` (#137), `unmatchedPomPaths` (#138), `skippedModules` (#139), `evidence` (#142), `timings`, `operations` (#99) |
 | `1` | Initial schema |
 
 **Compatibility policy:** within a schema version, Scalpel may add new *optional* fields and

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -71,6 +71,7 @@ public class ScalpelCore {
     public ChangeDetectionResult detectChanges(
             Path reactorRoot, ScalpelConfiguration config, Set<String> allPomPaths, Timings timings)
             throws ScalpelException {
+        requireNonNull(timings, "timings");
         lastDetectionSkipReason = null;
         Repository repository;
         try {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -60,9 +60,21 @@ public class ScalpelCore {
      */
     public ChangeDetectionResult detectChanges(Path reactorRoot, ScalpelConfiguration config, Set<String> allPomPaths)
             throws ScalpelException {
+        return detectChanges(reactorRoot, config, allPomPaths, new Timings());
+    }
+
+    /**
+     * Same as {@link #detectChanges(Path, ScalpelConfiguration, Set)} with an explicit
+     * instrumentation collector: the git phases (repoOpen, fetch, mergeBase, diff, status,
+     * readOldPoms) and the git-blob-read counter are recorded into {@code timings}.
+     */
+    public ChangeDetectionResult detectChanges(
+            Path reactorRoot, ScalpelConfiguration config, Set<String> allPomPaths, Timings timings)
+            throws ScalpelException {
         lastDetectionSkipReason = null;
         Repository repository;
         try {
+            timings.start(Timings.PHASE_REPO_OPEN);
             repository = openRepository(reactorRoot);
         } catch (RepositoryNotFoundException | IllegalArgumentException e) {
             logger.info("Scalpel: Not a git repository, building all modules");
@@ -70,6 +82,8 @@ public class ScalpelCore {
             return null;
         } catch (IOException e) {
             return handleError(config, "Error opening git repository", e);
+        } finally {
+            timings.stop(Timings.PHASE_REPO_OPEN);
         }
 
         try {
@@ -117,27 +131,38 @@ public class ScalpelCore {
 
             // Fetch base branch if configured and ref cannot be resolved
             if (config.isFetchBaseBranch()) {
-                ObjectId baseId = repository.resolve(baseBranch);
-                if (baseId == null) {
-                    try {
-                        gitChangeDetector.fetchBranch(repository, baseBranch);
-                    } catch (Exception e) {
-                        if (config.isFailSafe()) {
-                            logger.warn(
-                                    "Scalpel: Failed to fetch {}, building all modules: {}",
-                                    baseBranch,
-                                    e.getMessage());
-                            return null;
-                        } else {
-                            throw new ScalpelException("Failed to fetch " + baseBranch, e);
+                timings.start(Timings.PHASE_FETCH);
+                try {
+                    ObjectId baseId = repository.resolve(baseBranch);
+                    if (baseId == null) {
+                        try {
+                            gitChangeDetector.fetchBranch(repository, baseBranch);
+                        } catch (Exception e) {
+                            if (config.isFailSafe()) {
+                                logger.warn(
+                                        "Scalpel: Failed to fetch {}, building all modules: {}",
+                                        baseBranch,
+                                        e.getMessage());
+                                return null;
+                            } else {
+                                throw new ScalpelException("Failed to fetch " + baseBranch, e);
+                            }
                         }
                     }
+                } finally {
+                    timings.stop(Timings.PHASE_FETCH);
                 }
             }
 
             String head = config.getHead();
 
-            ObjectId mergeBase = gitChangeDetector.findMergeBase(repository, baseBranch, head);
+            ObjectId mergeBase;
+            timings.start(Timings.PHASE_MERGE_BASE);
+            try {
+                mergeBase = gitChangeDetector.findMergeBase(repository, baseBranch, head);
+            } finally {
+                timings.stop(Timings.PHASE_MERGE_BASE);
+            }
             if (mergeBase == null) {
                 if (config.isFailSafe()) {
                     logger.warn(
@@ -152,12 +177,23 @@ public class ScalpelCore {
 
             ObjectId headId = repository.resolve(head);
             // Copy the set to avoid mutating the return value of getChangedFiles()
-            Set<String> changedFiles =
-                    new LinkedHashSet<>(gitChangeDetector.getChangedFiles(repository, mergeBase, headId));
+            Set<String> changedFiles;
+            timings.start(Timings.PHASE_DIFF);
+            try {
+                changedFiles = new LinkedHashSet<>(gitChangeDetector.getChangedFiles(repository, mergeBase, headId));
+            } finally {
+                timings.stop(Timings.PHASE_DIFF);
+            }
 
             // Merge in uncommitted/untracked files if configured
             if (config.isUncommitted() || config.isUntracked()) {
-                GitChangeDetector.StatusResult statusResult = gitChangeDetector.getStatusFiles(repository);
+                GitChangeDetector.StatusResult statusResult;
+                timings.start(Timings.PHASE_STATUS);
+                try {
+                    statusResult = gitChangeDetector.getStatusFiles(repository);
+                } finally {
+                    timings.stop(Timings.PHASE_STATUS);
+                }
                 if (config.isUncommitted() && !statusResult.getUncommitted().isEmpty()) {
                     logger.info(
                             "Scalpel: {} uncommitted files detected",
@@ -185,8 +221,14 @@ public class ScalpelCore {
                     changedPomPaths.add(path);
                 }
             }
-            Map<String, byte[]> oldPomContents =
-                    gitChangeDetector.readPomFilesAtCommit(repository, mergeBase, changedPomPaths);
+            Map<String, byte[]> oldPomContents;
+            timings.start(Timings.PHASE_READ_OLD_POMS);
+            try {
+                oldPomContents = gitChangeDetector.readPomFilesAtCommit(repository, mergeBase, changedPomPaths);
+            } finally {
+                timings.stop(Timings.PHASE_READ_OLD_POMS);
+            }
+            timings.increment(Timings.OP_GIT_BLOBS_READ, oldPomContents.size());
 
             return new ChangeDetectionResult(changedFiles, oldPomContents);
         } catch (ScalpelException e) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -64,6 +64,8 @@ public final class ScalpelReport {
     private final List<AffectedModule> affectedModules;
     private final List<SkippedModule> skippedModules;
     private final int excludedUpstreamCount;
+    private final Timings timings;
+    private final long totalMillis;
 
     private ScalpelReport(
             String baseBranch,
@@ -78,7 +80,9 @@ public final class ScalpelReport {
             List<String> unmatchedPomPaths,
             List<AffectedModule> affectedModules,
             List<SkippedModule> skippedModules,
-            int excludedUpstreamCount) {
+            int excludedUpstreamCount,
+            Timings timings,
+            long totalMillis) {
         this.baseBranch = baseBranch;
         this.status = status;
         this.reason = reason;
@@ -92,6 +96,8 @@ public final class ScalpelReport {
         this.affectedModules = affectedModules;
         this.skippedModules = skippedModules;
         this.excludedUpstreamCount = excludedUpstreamCount;
+        this.timings = timings;
+        this.totalMillis = totalMillis;
     }
 
     public static class AffectedModule {
@@ -328,6 +334,38 @@ public final class ScalpelReport {
             }
             sb.append("  ]");
         }
+        // Instrumentation fields (#99): emitted only when something was recorded, and
+        // each of the two objects independently, so a run with phases but no counted
+        // operations carries timings only (and vice versa).
+        if (timings != null && !timings.getPhaseNames().isEmpty()) {
+            sb.append(",\n");
+            sb.append("  \"timings\": {\n");
+            sb.append("    \"totalMillis\": ").append(totalMillis).append(",\n");
+            sb.append("    \"phases\": {");
+            boolean first = true;
+            for (String phase : timings.getPhaseNames()) {
+                if (!first) {
+                    sb.append(", ");
+                }
+                first = false;
+                sb.append(jsonString(phase)).append(": ").append(timings.getPhaseMillis(phase));
+            }
+            sb.append("}\n");
+            sb.append("  }");
+        }
+        if (timings != null && !timings.getOperationNames().isEmpty()) {
+            sb.append(",\n");
+            sb.append("  \"operations\": {");
+            boolean firstOperation = true;
+            for (String operation : timings.getOperationNames()) {
+                if (!firstOperation) {
+                    sb.append(", ");
+                }
+                firstOperation = false;
+                sb.append(jsonString(operation)).append(": ").append(timings.getOperationCount(operation));
+            }
+            sb.append("}\n");
+        }
         sb.append("\n}\n");
         return sb.toString();
     }
@@ -443,6 +481,8 @@ public final class ScalpelReport {
         private final List<AffectedModule> affectedModules = new ArrayList<>();
         private final List<SkippedModule> skippedModules = new ArrayList<>();
         private int excludedUpstreamCount;
+        private Timings timings;
+        private long totalMillis;
 
         public Builder baseBranch(String baseBranch) {
             this.baseBranch = baseBranch;
@@ -509,6 +549,18 @@ public final class ScalpelReport {
             return this;
         }
 
+        /**
+         * Attaches phase timing and operation-count instrumentation. The {@code timings} and
+         * {@code operations} objects are emitted only when {@code timings} recorded at least
+         * one phase or counted at least one operation; {@code totalMillis} is the caller's
+         * wall-clock total for the whole analysis.
+         */
+        public Builder timings(Timings timings, long totalMillis) {
+            this.timings = timings;
+            this.totalMillis = totalMillis;
+            return this;
+        }
+
         public ScalpelReport build() {
             if (baseBranch == null) {
                 throw new IllegalStateException("baseBranch is required");
@@ -526,7 +578,9 @@ public final class ScalpelReport {
                     unmatchedPomPaths,
                     affectedModules,
                     skippedModules,
-                    excludedUpstreamCount);
+                    excludedUpstreamCount,
+                    timings,
+                    totalMillis);
         }
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -364,7 +364,7 @@ public final class ScalpelReport {
                 firstOperation = false;
                 sb.append(jsonString(operation)).append(": ").append(timings.getOperationCount(operation));
             }
-            sb.append("}\n");
+            sb.append("}");
         }
         sb.append("\n}\n");
         return sb.toString();
@@ -556,6 +556,9 @@ public final class ScalpelReport {
          * wall-clock total for the whole analysis.
          */
         public Builder timings(Timings timings, long totalMillis) {
+            if (totalMillis < 0) {
+                throw new IllegalArgumentException("totalMillis must be non-negative");
+            }
             this.timings = timings;
             this.totalMillis = totalMillis;
             return this;

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/Timings.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/Timings.java
@@ -46,12 +46,14 @@ public final class Timings {
     private final Map<String, Long> phaseNanos = new LinkedHashMap<>();
     private final Map<String, Long> runningSince = new LinkedHashMap<>();
     private final Map<String, Long> operationCounts = new LinkedHashMap<>();
+    private final Set<String> phaseOrder = new LinkedHashSet<>();
 
     /**
      * Starts (or restarts) the named phase; a phase started twice without an intervening
      * {@link #stop} discards the earlier measurement start.
      */
     public void start(String phase) {
+        phaseOrder.add(phase);
         runningSince.put(phase, System.nanoTime());
     }
 
@@ -89,11 +91,9 @@ public final class Timings {
         return nanos / 1_000_000;
     }
 
-    /** Recorded phase names in first-seen order, whether stopped or still running. */
+    /** Recorded phase names in start order, whether stopped or still running. */
     public Set<String> getPhaseNames() {
-        Set<String> names = new LinkedHashSet<>(phaseNanos.keySet());
-        names.addAll(runningSince.keySet());
-        return names;
+        return new LinkedHashSet<>(phaseOrder);
     }
 
     public long getOperationCount(String operation) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/Timings.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/Timings.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Named-phase timing and operation-count instrumentation for the Scalpel analysis path, so
+ * "how long did Scalpel take and where did the time go" is answerable from a build log (#99).
+ * Phases accumulate across repeated {@link #start}/{@link #stop} cycles; operation counters
+ * accumulate across {@link #increment} calls. One instance is meant to travel through a single
+ * analysis run and is not thread-safe (the analysis runs on the Maven session thread).
+ */
+public final class Timings {
+
+    // Phases recorded by ScalpelCore.detectChanges
+    public static final String PHASE_REPO_OPEN = "repoOpen";
+    public static final String PHASE_FETCH = "fetch";
+    public static final String PHASE_MERGE_BASE = "mergeBase";
+    public static final String PHASE_DIFF = "diff";
+    public static final String PHASE_STATUS = "status";
+    public static final String PHASE_READ_OLD_POMS = "readOldPoms";
+
+    // Phases recorded by ScalpelLifecycleParticipant.afterProjectsRead
+    public static final String PHASE_MODULE_MAPPING = "moduleMapping";
+    public static final String PHASE_POM_ANALYSIS = "pomAnalysis";
+    public static final String PHASE_TRANSITIVE_RESOLVE = "transitiveResolve";
+    public static final String PHASE_TRIM = "trim";
+    public static final String PHASE_APPLY_SKIP_TESTS = "applySkipTests";
+
+    // Operation counters
+    public static final String OP_GIT_BLOBS_READ = "blobs";
+    public static final String OP_EFFECTIVE_MODELS = "models";
+    public static final String OP_DEPENDENCY_RESOLVES = "resolves";
+    public static final String OP_RESOLVE_CACHE_HITS = "resolveCacheHits";
+    public static final String OP_RESOURCES_VISITED = "resources";
+
+    private final Map<String, Long> phaseNanos = new LinkedHashMap<>();
+    private final Map<String, Long> runningSince = new LinkedHashMap<>();
+    private final Map<String, Long> operationCounts = new LinkedHashMap<>();
+
+    /**
+     * Starts (or restarts) the named phase; a phase started twice without an intervening
+     * {@link #stop} discards the earlier measurement start.
+     */
+    public void start(String phase) {
+        runningSince.put(phase, System.nanoTime());
+    }
+
+    /**
+     * Stops the named phase and accumulates its elapsed time. Stopping a phase that is not
+     * running is a no-op, so stop can safely sit in a {@code finally} on every exit path.
+     */
+    public void stop(String phase) {
+        Long start = runningSince.remove(phase);
+        if (start != null) {
+            phaseNanos.merge(phase, System.nanoTime() - start, Long::sum);
+        }
+    }
+
+    public void increment(String operation) {
+        operationCounts.merge(operation, 1L, Long::sum);
+    }
+
+    /** Adds {@code delta} to the counter; non-positive deltas are ignored. */
+    public void increment(String operation, long delta) {
+        if (delta > 0) {
+            operationCounts.merge(operation, delta, Long::sum);
+        }
+    }
+
+    /**
+     * Millis accumulated for the phase so far, including a measurement that is still running.
+     */
+    public long getPhaseMillis(String phase) {
+        long nanos = phaseNanos.getOrDefault(phase, 0L);
+        Long start = runningSince.get(phase);
+        if (start != null) {
+            nanos += System.nanoTime() - start;
+        }
+        return nanos / 1_000_000;
+    }
+
+    /** Recorded phase names in first-seen order, whether stopped or still running. */
+    public Set<String> getPhaseNames() {
+        Set<String> names = new LinkedHashSet<>(phaseNanos.keySet());
+        names.addAll(runningSince.keySet());
+        return names;
+    }
+
+    public long getOperationCount(String operation) {
+        return operationCounts.getOrDefault(operation, 0L);
+    }
+
+    /** Counted operation names in first-seen order. */
+    public Set<String> getOperationNames() {
+        return new LinkedHashSet<>(operationCounts.keySet());
+    }
+
+    /**
+     * Formats the phase breakdown for logging, e.g. {@code repoOpen=1ms, fetch=50ms};
+     * empty when no phase was ever recorded.
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (String phase : getPhaseNames()) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(phase).append('=').append(getPhaseMillis(phase)).append("ms");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Formats the operation counters for logging, e.g. {@code blobs=4, models=6};
+     * empty when nothing was counted.
+     */
+    public String formatOperations() {
+        StringBuilder sb = new StringBuilder();
+        for (String operation : getOperationNames()) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(operation).append('=').append(getOperationCount(operation));
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -21,7 +21,7 @@
     "version": {
       "type": "string",
       "const": "2",
-      "description": "Report schema version. '2' indicates the v2 format with category, sourceSet, excludedUpstreamCount, testsSkipped, and testsSkippedReason fields, plus the optional fields added within v2 under the compatibility policy: status, reason, unmatchedPomPaths, skippedModules, and evidence."
+      "description": "Report schema version. '2' indicates the v2 format with category, sourceSet, excludedUpstreamCount, testsSkipped, and testsSkippedReason fields, plus the optional fields added within v2 under the compatibility policy: status, reason, unmatchedPomPaths, skippedModules, evidence, timings, and operations."
     },
     "scalpelVersion": {
       "type": "string",
@@ -87,6 +87,53 @@
     "reason": {
       "type": "string",
       "description": "Human-readable explanation accompanying an optional status field (e.g. 'no changes detected')."
+    },
+    "timings": {
+      "type": "object",
+      "description": "Optional (#99): phase timing instrumentation for the analysis run. Present only when at least one phase was recorded; omitted entirely (not null, not empty) from status-only documents and uninstrumented reports.",
+      "required": ["totalMillis", "phases"],
+      "properties": {
+        "totalMillis": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Wall-clock milliseconds for the whole Scalpel analysis."
+        },
+        "phases": {
+          "type": "object",
+          "description": "Milliseconds spent per phase (repoOpen, fetch, mergeBase, diff, status, readOldPoms, moduleMapping, pomAnalysis, transitiveResolve, trim, applySkipTests). Only phases that ran are present; phase names may grow additively."
+        }
+      }
+    },
+    "operations": {
+      "type": "object",
+      "description": "Optional (#99): analysis operation counters. Present only when at least one operation was counted; omitted entirely from status-only documents and uninstrumented reports.",
+      "properties": {
+        "blobs": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Git blobs read for old-POM comparison."
+        },
+        "models": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Effective POM models built (old state plus current state)."
+        },
+        "resolves": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Dependency graph resolutions performed."
+        },
+        "resolveCacheHits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Resolutions served from the shared collect cache instead of re-resolved."
+        },
+        "resources": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Filesystem entries visited by the filtered-resource scan."
+        }
+      }
     }
   },
   "$defs": {

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -100,6 +100,10 @@
         },
         "phases": {
           "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          },
           "description": "Milliseconds spent per phase (repoOpen, fetch, mergeBase, diff, status, readOldPoms, moduleMapping, pomAnalysis, transitiveResolve, trim, applySkipTests). Only phases that ran are present; phase names may grow additively."
         }
       }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -197,6 +197,42 @@ class ScalpelCoreTest {
     }
 
     @Test
+    void detectChanges_recordsGitPhaseTimingsAndBlobCount() throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Files.write(tempDir.resolve("pom.xml"), "<project/>".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("initial").call();
+            git.branchCreate().setName("main").call();
+
+            // Change the POM on the current branch so old content must be read from git
+            Files.write(tempDir.resolve("pom.xml"), "<project><modules/></project>".getBytes(StandardCharsets.UTF_8));
+            git.add().addFilepattern("pom.xml").call();
+            git.commit().setMessage("change pom").call();
+
+            ScalpelCore core = new ScalpelCore(new GitChangeDetector());
+            Properties sys = new Properties();
+            sys.setProperty("scalpel.baseBranch", "main");
+            ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
+
+            Timings timings = new Timings();
+            ChangeDetectionResult result = core.detectChanges(tempDir, config, Set.of("pom.xml"), timings);
+
+            assertNotNull(result);
+            assertTrue(result.getChangedFiles().contains("pom.xml"));
+            assertTrue(timings.getPhaseNames().contains(Timings.PHASE_REPO_OPEN), "repoOpen phase must be recorded");
+            assertTrue(timings.getPhaseNames().contains(Timings.PHASE_MERGE_BASE), "mergeBase phase must be recorded");
+            assertTrue(timings.getPhaseNames().contains(Timings.PHASE_DIFF), "diff phase must be recorded");
+            assertTrue(
+                    timings.getPhaseNames().contains(Timings.PHASE_READ_OLD_POMS),
+                    "readOldPoms phase must be recorded when a POM changed");
+            assertEquals(
+                    1,
+                    timings.getOperationCount(Timings.OP_GIT_BLOBS_READ),
+                    "exactly one old-POM blob must be counted as read");
+        }
+    }
+
+    @Test
     void detectChanges_emptyDisableRegexLists_detectionProceeds() throws Exception {
         try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
             Files.write(tempDir.resolve("file.txt"), "hello".getBytes(StandardCharsets.UTF_8));

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -58,6 +58,14 @@ class ScalpelReportSchemaTest {
 
     @Test
     void representativeReportWithAllOptionalFields_validatesAgainstSchema() {
+        Timings timings = new Timings();
+        timings.start(Timings.PHASE_DIFF);
+        timings.stop(Timings.PHASE_DIFF);
+        timings.increment(Timings.OP_GIT_BLOBS_READ, 2);
+        timings.increment(Timings.OP_EFFECTIVE_MODELS, 6);
+        timings.increment(Timings.OP_DEPENDENCY_RESOLVES, 4);
+        timings.increment(Timings.OP_RESOLVE_CACHE_HITS, 1);
+        timings.increment(Timings.OP_RESOURCES_VISITED, 12);
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .status("skipped")
@@ -69,6 +77,7 @@ class ScalpelReportSchemaTest {
                 .changedManagedPlugins(List.of("org.apache.maven.plugins:maven-compiler-plugin"))
                 .unmatchedPomPaths(List.of("gated-module/pom.xml"))
                 .excludedUpstreamCount(1)
+                .timings(timings, 123)
                 .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
                                 "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE))
                         .category(ScalpelReport.CATEGORY_DIRECT)
@@ -165,6 +174,10 @@ class ScalpelReportSchemaTest {
                         .stream()
                         .anyMatch(e -> e.contains("WHATEVER")),
                 "unknown skipped-module reason must be rejected");
+        assertTrue(
+                validate(mutate(report, m -> m.put("timings", Map.of("totalMillis", -1L, "phases", Map.of())))).stream()
+                        .anyMatch(e -> e.contains("totalMillis")),
+                "negative totalMillis must be rejected");
     }
 
     // ---------------------------------------------------------------

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -178,6 +178,13 @@ class ScalpelReportSchemaTest {
                 validate(mutate(report, m -> m.put("timings", Map.of("totalMillis", -1L, "phases", Map.of())))).stream()
                         .anyMatch(e -> e.contains("totalMillis")),
                 "negative totalMillis must be rejected");
+        assertTrue(
+                validate(mutate(
+                                report,
+                                m -> m.put("timings", Map.of("totalMillis", 0L, "phases", Map.of("diff", -1L)))))
+                        .stream()
+                        .anyMatch(e -> e.contains("diff")),
+                "negative phase duration must be rejected");
     }
 
     // ---------------------------------------------------------------
@@ -506,6 +513,7 @@ class ScalpelReportSchemaTest {
                 "enum",
                 "required",
                 "properties",
+                "additionalProperties",
                 "items",
                 "minimum",
                 "minItems");
@@ -571,6 +579,15 @@ class ScalpelReportSchemaTest {
                                 object.get(property.getKey()),
                                 path + "." + property.getKey(),
                                 errors);
+                    }
+                }
+                if (schema.containsKey("additionalProperties")) {
+                    Map<String, Object> addlSchema =
+                            cast(schema.get("additionalProperties"), path + ".additionalProperties");
+                    for (Map.Entry<String, Object> entry : object.entrySet()) {
+                        if (!properties.containsKey(entry.getKey())) {
+                            validateSchema(addlSchema, entry.getValue(), path + "." + entry.getKey(), errors);
+                        }
                     }
                 }
             }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -193,6 +193,25 @@ class ScalpelReportSchemaTest {
         assertEquals(List.of(ScalpelReport.SKIP_REASON_NOT_AFFECTED), skippedModuleReasonsEnum());
     }
 
+    @Test
+    void schema_declaresOptionalTimingAndOperationProperties() {
+        // #99: toJson can emit a timings object (totalMillis + per-phase millis) and an
+        // operations object (named counters) next to the analysis fields. The validator
+        // ignores undeclared instance properties by design, so presence must be asserted
+        // against the schema itself or the declaration would drift.
+        Map<String, Object> props = cast(schema.get("properties"), "schema.properties");
+        assertTrue(
+                props.containsKey("timings"),
+                "schema must declare the optional 'timings' object emitted with phase timing instrumentation");
+        assertTrue(
+                props.containsKey("operations"),
+                "schema must declare the optional 'operations' object emitted with operation counters");
+        Map<String, Object> timings = cast(props.get("timings"), "schema.properties.timings");
+        Map<String, Object> timingsProps = cast(timings.get("properties"), "schema.properties.timings.properties");
+        assertTrue(timingsProps.containsKey("totalMillis"), "timings must declare totalMillis");
+        assertTrue(timingsProps.containsKey("phases"), "timings must declare the phases map");
+    }
+
     // ---------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -555,6 +555,23 @@ class ScalpelReportTest {
     }
 
     @Test
+    void toJson_timingFieldsOmittedWhenNotInstrumented() {
+        // #99 null-input rule: a report built without instrumentation data must not
+        // carry timings/operations keys at all (no null, no empty objects).
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("module-a/src/Foo.java"))
+                .addAffectedModule(new ScalpelReport.AffectedModule(
+                        "com.example", "module-a", "module-a", List.of(ScalpelReport.REASON_SOURCE_CHANGE)))
+                .build();
+
+        String json = report.toJson();
+        assertFalse(json.contains("\"timings\""), "timings must be omitted when nothing was recorded");
+        assertFalse(json.contains("\"operations\""), "operations must be omitted when nothing was counted");
+    }
+
+    @Test
     void jsonSchema_isOnClasspath() throws IOException {
         try (InputStream is =
                 getClass().getResourceAsStream("/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json")) {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -572,6 +572,49 @@ class ScalpelReportTest {
     }
 
     @Test
+    void toJson_timingsAndOperationsIncludedWhenInstrumented() {
+        Timings timings = new Timings();
+        timings.start(Timings.PHASE_DIFF);
+        timings.stop(Timings.PHASE_DIFF);
+        timings.start(Timings.PHASE_POM_ANALYSIS);
+        timings.stop(Timings.PHASE_POM_ANALYSIS);
+        timings.increment(Timings.OP_GIT_BLOBS_READ, 3);
+        timings.increment(Timings.OP_DEPENDENCY_RESOLVES);
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("pom.xml"))
+                .timings(timings, 42)
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\"timings\""), "timings object must be present");
+        assertTrue(json.contains("\"totalMillis\": 42"), "caller-provided total must be serialized");
+        assertTrue(json.contains("\"phases\""), "per-phase map must be present");
+        assertTrue(json.contains("\"diff\""), "recorded phases must be listed");
+        assertTrue(json.contains("\"pomAnalysis\""), "recorded phases must be listed");
+        assertTrue(json.contains("\"operations\""), "operations object must be present");
+        assertTrue(json.contains("\"blobs\": 3"), "operation counters must be serialized");
+        assertTrue(json.contains("\"resolves\": 1"), "operation counters must be serialized");
+    }
+
+    @Test
+    void toJson_timingsOmittedWhenInstrumentationRecordedNothing() {
+        // #99 null-input rule: an instrumented run that recorded no phase and counted no
+        // operation must omit both fields entirely, not emit empty objects.
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("module-a/src/Foo.java"))
+                .timings(new Timings(), 0)
+                .build();
+
+        String json = report.toJson();
+        assertFalse(json.contains("\"timings\""), "timings must be omitted when no phase was recorded");
+        assertFalse(json.contains("\"operations\""), "operations must be omitted when nothing was counted");
+    }
+
+    @Test
     void jsonSchema_isOnClasspath() throws IOException {
         try (InputStream is =
                 getClass().getResourceAsStream("/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json")) {

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/TimingsTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/TimingsTest.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.scalpel.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class TimingsTest {
@@ -112,5 +113,17 @@ class TimingsTest {
 
         assertEquals("", timings.toString());
         assertEquals("", timings.formatOperations());
+    }
+
+    @Test
+    void overlappingPhasesRetainStartOrder() {
+        Timings timings = new Timings();
+        timings.start("outer");
+        timings.start("inner");
+        timings.stop("inner");
+
+        // outer was started first, so it must appear first even though inner stopped first
+        assertEquals(List.of("outer", "inner"), List.copyOf(timings.getPhaseNames()));
+        timings.stop("outer");
     }
 }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/TimingsTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/TimingsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TimingsTest {
+
+    @Test
+    void startStopRecordsPhaseMillis() throws Exception {
+        Timings timings = new Timings();
+        timings.start(Timings.PHASE_DIFF);
+        Thread.sleep(5);
+        timings.stop(Timings.PHASE_DIFF);
+
+        assertTrue(timings.getPhaseNames().contains(Timings.PHASE_DIFF), "stopped phase must be recorded");
+        assertTrue(
+                timings.getPhaseMillis(Timings.PHASE_DIFF) >= 5,
+                "recorded millis must cover the slept time, was: " + timings.getPhaseMillis(Timings.PHASE_DIFF));
+    }
+
+    @Test
+    void repeatedStartStopAccumulatesIntoSamePhase() throws Exception {
+        Timings timings = new Timings();
+        for (int i = 0; i < 2; i++) {
+            timings.start(Timings.PHASE_DIFF);
+            Thread.sleep(5);
+            timings.stop(Timings.PHASE_DIFF);
+        }
+
+        assertEquals(1, timings.getPhaseNames().size(), "one phase name, not one per measurement");
+        assertTrue(
+                timings.getPhaseMillis(Timings.PHASE_DIFF) >= 10,
+                "both measurement rounds must accumulate, was: " + timings.getPhaseMillis(Timings.PHASE_DIFF));
+    }
+
+    @Test
+    void stopWithoutStartIsNoOp() {
+        Timings timings = new Timings();
+        timings.stop(Timings.PHASE_DIFF);
+
+        assertTrue(timings.getPhaseNames().isEmpty(), "stop without start must record nothing");
+        assertEquals(0, timings.getPhaseMillis(Timings.PHASE_DIFF));
+    }
+
+    @Test
+    void runningPhaseReportsElapsedSoFar() throws Exception {
+        Timings timings = new Timings();
+        timings.start(Timings.PHASE_DIFF);
+        Thread.sleep(5);
+
+        assertTrue(
+                timings.getPhaseMillis(Timings.PHASE_DIFF) >= 5,
+                "a still-running phase must report elapsed millis so far");
+        timings.stop(Timings.PHASE_DIFF);
+    }
+
+    @Test
+    void incrementCountsOperations() {
+        Timings timings = new Timings();
+        timings.increment(Timings.OP_GIT_BLOBS_READ);
+        timings.increment(Timings.OP_GIT_BLOBS_READ);
+        timings.increment(Timings.OP_DEPENDENCY_RESOLVES, 7);
+
+        assertEquals(2, timings.getOperationCount(Timings.OP_GIT_BLOBS_READ));
+        assertEquals(7, timings.getOperationCount(Timings.OP_DEPENDENCY_RESOLVES));
+        assertEquals(0, timings.getOperationCount(Timings.OP_RESOURCES_VISITED), "uncounted operations read as 0");
+    }
+
+    @Test
+    void nonPositiveDeltasAreIgnored() {
+        Timings timings = new Timings();
+        timings.increment(Timings.OP_RESOURCES_VISITED, 0);
+        timings.increment(Timings.OP_RESOURCES_VISITED, -3);
+
+        assertTrue(timings.getOperationNames().isEmpty(), "zero/negative deltas must not create counter entries");
+    }
+
+    @Test
+    void toStringFormatsPhasesInFirstSeenOrder() {
+        Timings timings = new Timings();
+        timings.start(Timings.PHASE_REPO_OPEN);
+        timings.stop(Timings.PHASE_REPO_OPEN);
+        timings.start(Timings.PHASE_FETCH);
+        timings.stop(Timings.PHASE_FETCH);
+
+        assertTrue(
+                timings.toString().matches("repoOpen=\\d+ms, fetch=\\d+ms"),
+                "phases format must be greppable name=millis in first-seen order, was: " + timings);
+    }
+
+    @Test
+    void formatOperationsCountsInFirstSeenOrder() {
+        Timings timings = new Timings();
+        timings.increment(Timings.OP_GIT_BLOBS_READ, 3);
+        timings.increment(Timings.OP_DEPENDENCY_RESOLVES);
+
+        assertEquals("blobs=3, resolves=1", timings.formatOperations());
+    }
+
+    @Test
+    void emptyTimingsFormatsAsEmptyStrings() {
+        Timings timings = new Timings();
+
+        assertEquals("", timings.toString());
+        assertEquals("", timings.formatOperations());
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -226,13 +226,14 @@ class PomChangeAnalyzer {
         private final Set<String> changedProperties;
         private final Map<MavenProject, Set<String>> evidence;
         private final List<String> unmatchedPomPaths;
+        private final long resourcesVisited;
 
         Result(
                 Set<MavenProject> affectedProjects,
                 Map<String, Model> oldEffectiveModels,
                 Map<String, Model> newEffectiveModels,
                 Set<String> changedProperties) {
-            this(affectedProjects, oldEffectiveModels, newEffectiveModels, changedProperties, Map.of(), List.of());
+            this(affectedProjects, oldEffectiveModels, newEffectiveModels, changedProperties, Map.of(), List.of(), 0L);
         }
 
         Result(
@@ -241,13 +242,15 @@ class PomChangeAnalyzer {
                 Map<String, Model> newEffectiveModels,
                 Set<String> changedProperties,
                 Map<MavenProject, Set<String>> evidence,
-                List<String> unmatchedPomPaths) {
+                List<String> unmatchedPomPaths,
+                long resourcesVisited) {
             this.affectedProjects = affectedProjects;
             this.oldEffectiveModels = oldEffectiveModels;
             this.newEffectiveModels = newEffectiveModels;
             this.changedProperties = changedProperties;
             this.evidence = evidence;
             this.unmatchedPomPaths = unmatchedPomPaths;
+            this.resourcesVisited = resourcesVisited;
         }
 
         Set<MavenProject> getAffectedProjects() {
@@ -277,6 +280,11 @@ class PomChangeAnalyzer {
         List<String> getUnmatchedPomPaths() {
             return unmatchedPomPaths;
         }
+
+        /** Filesystem entries visited by filtered-resource scans (instrumentation, #99). */
+        long getResourcesVisited() {
+            return resourcesVisited;
+        }
     }
 
     /**
@@ -300,6 +308,8 @@ class PomChangeAnalyzer {
         final Map<MavenProject, Set<String>> evidence = new LinkedHashMap<>();
         final Set<String> allChangedProperties = new LinkedHashSet<>();
         final List<String> unmatchedPomPaths = new ArrayList<>();
+        /** Filesystem entries visited by filtered-resource scans (instrumentation, #99). */
+        long resourcesVisited;
     }
 
     /**
@@ -386,7 +396,8 @@ class PomChangeAnalyzer {
                 ctx.newEffectiveModels,
                 ctx.allChangedProperties,
                 ctx.evidence,
-                ctx.unmatchedPomPaths);
+                ctx.unmatchedPomPaths,
+                ctx.resourcesVisited);
     }
 
     private static void addEvidence(Map<MavenProject, Set<String>> evidence, MavenProject project, String item) {
@@ -602,7 +613,7 @@ class PomChangeAnalyzer {
             // parent, not the child), so the raw-model property check above won't catch them.
             if (!childAffected
                     && !changedProperties.isEmpty()
-                    && hasFilteredResourcesWithChangedProperty(child, changedProperties)) {
+                    && hasFilteredResourcesWithChangedProperty(child, changedProperties, ctx)) {
                 logger.debug("Child {} has filtered resources referencing changed properties", key(child));
                 if (ctx.explain) {
                     addEvidence(ctx.evidence, child, "filtered resources referencing changed properties");
@@ -1322,7 +1333,8 @@ class PomChangeAnalyzer {
      * Filtered resources live outside the POM model, so effective model comparison cannot
      * detect property substitutions in resource files.
      */
-    private boolean hasFilteredResourcesWithChangedProperty(MavenProject project, Set<String> changedProperties) {
+    private boolean hasFilteredResourcesWithChangedProperty(
+            MavenProject project, Set<String> changedProperties, AnalysisContext ctx) {
         List<String> refs = new ArrayList<>();
         for (String prop : changedProperties) {
             refs.add("${" + prop + "}");
@@ -1351,7 +1363,7 @@ class PomChangeAnalyzer {
             if (!Files.isDirectory(resourceDir)) {
                 continue;
             }
-            if (scanDirectoryForPropertyRefs(resourceDir, refs)) {
+            if (scanDirectoryForPropertyRefs(resourceDir, refs, ctx)) {
                 logger.debug(
                         "Found property reference in filtered resources of {} (dir={})", key(project), resourceDir);
                 return true;
@@ -1363,9 +1375,10 @@ class PomChangeAnalyzer {
     private static final int MAX_RESOURCE_WALK_DEPTH = 32;
     private static final int MAX_RESOURCE_WALK_FILES = 10_000;
 
-    private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs) {
+    private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs, AnalysisContext ctx) {
         // Does not follow symbolic links: a symlink could loop forever or point
         // outside the module (leaking file content into the analysis)
+        // Every exit path adds the entries it visited to ctx.resourcesVisited (#99).
         int[] visitedEntries = new int[1];
         boolean[] budgetExceeded = new boolean[1];
         boolean[] depthTruncated = new boolean[1];
@@ -1418,6 +1431,7 @@ class PomChangeAnalyzer {
             // Conservative: an unreadable directory during the walk means we cannot
             // know whether it contains a property reference, so treat as affected
             logger.warn("Cannot walk filtered resource directory {}: {}", dir, e.getMessage());
+            ctx.resourcesVisited += visitedEntries[0];
             return true;
         }
         if (budgetExceeded[0]) {
@@ -1426,6 +1440,7 @@ class PomChangeAnalyzer {
                             + " Module will be conservatively marked as affected.",
                     dir,
                     MAX_RESOURCE_WALK_FILES);
+            ctx.resourcesVisited += visitedEntries[0];
             return true;
         }
         if (depthTruncated[0]) {
@@ -1434,8 +1449,10 @@ class PomChangeAnalyzer {
                             + " Module will be conservatively marked as affected.",
                     dir,
                     MAX_RESOURCE_WALK_DEPTH);
+            ctx.resourcesVisited += visitedEntries[0];
             return true;
         }
+        ctx.resourcesVisited += visitedEntries[0];
         return foundRef[0];
     }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -17,6 +17,7 @@ import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import eu.maveniverse.maven.scalpel.core.ScalpelCore;
 import eu.maveniverse.maven.scalpel.core.ScalpelException;
 import eu.maveniverse.maven.scalpel.core.ScalpelReport;
+import eu.maveniverse.maven.scalpel.core.Timings;
 import eu.maveniverse.maven.scalpel.core.Version;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -120,6 +121,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         Path reactorRoot = session.getRequest().getMultiModuleProjectDirectory().toPath();
         List<MavenProject> allProjects = session.getProjects();
 
+        Timings timings = new Timings();
+        long analysisStartNano = System.nanoTime();
         try {
             // Collect ALL reactor POM paths
             Set<String> allPomPaths = new LinkedHashSet<>();
@@ -130,7 +133,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Detect changes
-            ChangeDetectionResult result = scalpelCore.detectChanges(reactorRoot, config, allPomPaths);
+            ChangeDetectionResult result = scalpelCore.detectChanges(reactorRoot, config, allPomPaths, timings);
             if (result == null) {
                 if (config.isModeReport()) {
                     String skipReason = scalpelCore.getLastDetectionSkipReason();
@@ -201,8 +204,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Map source changes to modules (classifying test-only vs main changes)
-            ModuleMapper.Result sourceResult =
-                    moduleMapper.mapToProjectsClassified(sourceChanges, allProjects, reactorRoot, config.isExplain());
+            ModuleMapper.Result sourceResult;
+            timings.start(Timings.PHASE_MODULE_MAPPING);
+            try {
+                sourceResult = moduleMapper.mapToProjectsClassified(
+                        sourceChanges, allProjects, reactorRoot, config.isExplain());
+            } finally {
+                timings.stop(Timings.PHASE_MODULE_MAPPING);
+            }
             Set<MavenProject> affectedBySource = sourceResult.getAllAffected();
             logger.debug("Modules affected by source changes: {}", keys(affectedBySource));
             if (!sourceResult.getTestOnlyAffected().isEmpty()) {
@@ -220,23 +229,32 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (!pomChanges.isEmpty()) {
                 logger.debug("POM changes detected: {}", pomChanges);
                 try {
-                    PomChangeAnalyzer.Result pomResult = pomChangeAnalyzer.analyzeChanges(
-                            pomChanges,
-                            result.getOldPomContents(),
-                            allProjects,
-                            reactorRoot,
-                            config.isExplain(),
-                            new PomChangeAnalyzer.ModelResolutionContext(
-                                    session.getSystemProperties(),
-                                    session.getUserProperties(),
-                                    session.getRepositorySession(),
-                                    allProjects.get(0).getRemoteProjectRepositories()));
+                    PomChangeAnalyzer.Result pomResult;
+                    timings.start(Timings.PHASE_POM_ANALYSIS);
+                    try {
+                        pomResult = pomChangeAnalyzer.analyzeChanges(
+                                pomChanges,
+                                result.getOldPomContents(),
+                                allProjects,
+                                reactorRoot,
+                                config.isExplain(),
+                                new PomChangeAnalyzer.ModelResolutionContext(
+                                        session.getSystemProperties(),
+                                        session.getUserProperties(),
+                                        session.getRepositorySession(),
+                                        allProjects.get(0).getRemoteProjectRepositories()));
+                    } finally {
+                        timings.stop(Timings.PHASE_POM_ANALYSIS);
+                    }
                     affectedByPom = pomResult.getAffectedProjects();
                     oldEffectiveModels = pomResult.getOldEffectiveModels();
                     newEffectiveModels = pomResult.getNewEffectiveModels();
                     changedProperties = pomResult.getChangedProperties();
                     pomEvidence = pomResult.getEvidence();
                     unmatchedPomPaths.addAll(pomResult.getUnmatchedPomPaths());
+                    timings.increment(
+                            Timings.OP_EFFECTIVE_MODELS, oldEffectiveModels.size() + newEffectiveModels.size());
+                    timings.increment(Timings.OP_RESOURCES_VISITED, pomResult.getResourcesVisited());
                 } catch (Exception e) {
                     if (config.isFailSafe()) {
                         logger.warn("Scalpel: Error analyzing POM changes, building all modules: {}", e.getMessage());
@@ -296,7 +314,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             reactorRoot,
                             allProjects,
                             AnalysisContext.empty(
-                                    changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs));
+                                    changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs),
+                            timings,
+                            analysisStartNano);
                 } else if (config.isModeSkipTests()) {
                     skipTestsOnAll(allProjects);
                 }
@@ -316,17 +336,24 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Compute transitively affected modules by comparing old vs new dependency trees
             Map<MavenProject, List<String>> transitiveEvidence = new LinkedHashMap<>();
-            Map<MavenProject, List<String>> transitivelyAffected = computeTransitivelyAffected(
-                    allProjects,
-                    directlyAffected,
-                    oldEffectiveModels,
-                    newEffectiveModels,
-                    reactorRoot,
-                    session,
-                    collectCache,
-                    oldCollectCache,
-                    config.isExplain(),
-                    transitiveEvidence);
+            Map<MavenProject, List<String>> transitivelyAffected;
+            timings.start(Timings.PHASE_TRANSITIVE_RESOLVE);
+            try {
+                transitivelyAffected = computeTransitivelyAffected(
+                        allProjects,
+                        directlyAffected,
+                        oldEffectiveModels,
+                        newEffectiveModels,
+                        reactorRoot,
+                        session,
+                        collectCache,
+                        oldCollectCache,
+                        timings,
+                        config.isExplain(),
+                        transitiveEvidence);
+            } finally {
+                timings.stop(Timings.PHASE_TRANSITIVE_RESOLVE);
+            }
 
             // Explain-mode evidence: which specific input triggered each module
             Map<MavenProject, List<String>> evidence = config.isExplain()
@@ -346,7 +373,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             reactorRoot,
                             allProjects,
                             AnalysisContext.empty(
-                                    changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs));
+                                    changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs),
+                            timings,
+                            analysisStartNano);
                 } else if (config.isModeSkipTests()) {
                     skipTestsOnAll(allProjects);
                 }
@@ -385,10 +414,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 reactorRoot,
                                 allProjects,
                                 AnalysisContext.empty(
-                                        changedFiles,
-                                        changedProperties,
-                                        changedManagedDepGAs,
-                                        changedManagedPluginGAs));
+                                        changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs),
+                                timings,
+                                analysisStartNano);
                     } else if (config.isModeSkipTests()) {
                         skipTestsOnAll(allProjects);
                     }
@@ -405,10 +433,16 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 // Compute upstream/downstream categorization for report enrichment
                 // Use directlyAffected here (not allAffected) to preserve correct DOWNSTREAM categorization;
                 // transitively affected modules are added to the report separately via addTransitivelyAffectedModules
-                TrimResult trimResult = directlyAffected.isEmpty()
-                        ? null
-                        : reactorTrimmer.computeBuildSet(
+                TrimResult trimResult = null;
+                if (!directlyAffected.isEmpty()) {
+                    timings.start(Timings.PHASE_TRIM);
+                    try {
+                        trimResult = reactorTrimmer.computeBuildSet(
                                 directlyAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
+                    } finally {
+                        timings.stop(Timings.PHASE_TRIM);
+                    }
+                }
                 if (trimResult != null && config.isExplain()) {
                     mergeTrimReasons(evidence, trimResult);
                 }
@@ -428,7 +462,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .transitivelyAffected(transitivelyAffected)
                                 .evidence(evidence)
                                 .trimResult(trimResult)
-                                .build());
+                                .build(),
+                        timings,
+                        analysisStartNano);
                 if (config.isExplain()) {
                     Set<MavenProject> reportedModules = new LinkedHashSet<>(allAffected);
                     if (trimResult != null) {
@@ -441,24 +477,36 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Compute full build set with upstream/downstream
-            TrimResult trimResult = reactorTrimmer.computeBuildSet(
-                    allAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
+            TrimResult trimResult;
+            timings.start(Timings.PHASE_TRIM);
+            try {
+                trimResult = reactorTrimmer.computeBuildSet(
+                        allAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
+            } finally {
+                timings.stop(Timings.PHASE_TRIM);
+            }
             if (config.isExplain()) {
                 mergeTrimReasons(evidence, trimResult);
             }
 
             if (config.isModeSkipTests()) {
-                applySkipTests(
-                        session,
-                        allProjects,
-                        trimResult,
-                        config,
-                        oldEffectiveModels,
-                        newEffectiveModels,
-                        includeMatchers,
-                        reactorRoot,
-                        collectCache,
-                        oldCollectCache);
+                timings.start(Timings.PHASE_APPLY_SKIP_TESTS);
+                try {
+                    applySkipTests(
+                            session,
+                            allProjects,
+                            trimResult,
+                            config,
+                            oldEffectiveModels,
+                            newEffectiveModels,
+                            includeMatchers,
+                            reactorRoot,
+                            collectCache,
+                            oldCollectCache,
+                            timings);
+                } finally {
+                    timings.stop(Timings.PHASE_APPLY_SKIP_TESTS);
+                }
                 if (config.isExplain()) {
                     logExplainDecisions(allProjects, new LinkedHashSet<>(trimResult.getBuildSet()), evidence);
                 }
@@ -498,7 +546,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .transitivelyAffected(transitivelyAffected)
                                 .trimResult(trimResult)
                                 .filteredBuildSet(buildSet)
-                                .build());
+                                .build(),
+                        timings,
+                        analysisStartNano);
             }
 
         } catch (ScalpelException e) {
@@ -518,7 +568,32 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 return;
             }
             throw new MavenExecutionException("Scalpel: " + e.getMessage(), e);
+        } finally {
+            logAnalysisSummary(timings, analysisStartNano);
         }
+    }
+
+    /**
+     * One greppable INFO line answering "how long did Scalpel take and where did it go":
+     * total wall-clock millis, the per-phase breakdown, and the operation counters (#99).
+     */
+    private void logAnalysisSummary(Timings timings, long analysisStartNano) {
+        StringBuilder line = new StringBuilder("Scalpel: analysis took ")
+                .append(millisSince(analysisStartNano))
+                .append("ms");
+        String phases = timings.toString();
+        if (!phases.isEmpty()) {
+            line.append(" (").append(phases).append(")");
+        }
+        String operations = timings.formatOperations();
+        if (!operations.isEmpty()) {
+            line.append(" ops: ").append(operations);
+        }
+        logger.info("{}", line);
+    }
+
+    private static long millisSince(long startNano) {
+        return (System.nanoTime() - startNano) / 1_000_000;
     }
 
     private boolean matchesDisableTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
@@ -651,6 +726,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             MavenSession session,
             Map<MavenProject, DependencyResolutionResult> collectCache,
             Map<MavenProject, DependencyResolutionResult> oldCollectCache,
+            Timings timings,
             boolean explain,
             Map<MavenProject, List<String>> returnEvidence) {
         Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
@@ -676,6 +752,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     session,
                     collectCache,
                     oldCollectCache,
+                    timings,
                     explain);
             if (!match.reasons.isEmpty()) {
                 transitivelyAffected.put(project, match.reasons);
@@ -706,7 +783,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 if (directlyAffected.contains(project) || transitivelyAffected.containsKey(project)) {
                     continue;
                 }
-                DependencyResolutionResult depResult = resolveProjectDependencies(project, session, collectCache);
+                DependencyResolutionResult depResult =
+                        resolveProjectDependencies(project, session, collectCache, timings);
                 if (depResult == null || depResult.getDependencyGraph() == null) {
                     if (!affectedGAs.isEmpty()) {
                         // Conservative: dependency resolution failed while there are
@@ -785,6 +863,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             MavenSession session,
             Map<MavenProject, DependencyResolutionResult> collectCache,
             Map<MavenProject, DependencyResolutionResult> oldCollectCache,
+            Timings timings,
             boolean explain) {
         List<String> reasons = new ArrayList<>();
         List<String> evidence = explain ? new ArrayList<>() : List.of();
@@ -811,7 +890,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
         // Compare resolved dependency trees: old effective model vs current project
         ChangedDependencyMatch depMatch =
-                findChangedDependencyInTree(project, oldModel, session, collectCache, oldCollectCache);
+                findChangedDependencyInTree(project, oldModel, session, collectCache, oldCollectCache, timings);
         if (depMatch != null) {
             if (UNRESOLVED_GA.equals(depMatch.ga)) {
                 reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED);
@@ -838,7 +917,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             List<PathMatcher> includeMatchers,
             Path reactorRoot,
             Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache) {
+            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
+            Timings timings) {
 
         Path absRoot = reactorRoot.toAbsolutePath().normalize();
         Set<MavenProject> buildSetLookup = new LinkedHashSet<>(trimResult.getBuildSet());
@@ -863,7 +943,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     absRoot,
                     session,
                     collectCache,
-                    oldCollectCache)) {
+                    oldCollectCache,
+                    timings)) {
                 // Skip tests on excluded downstream modules (unless they also have plugin/dep changes)
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
@@ -891,7 +972,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Check if this module's effective plugins or dependency tree changed
             if (hasEffectiveModelChanges(
-                    project, oldEffectiveModels, newEffectiveModels, absRoot, session, collectCache, oldCollectCache)) {
+                    project,
+                    oldEffectiveModels,
+                    newEffectiveModels,
+                    absRoot,
+                    session,
+                    collectCache,
+                    oldCollectCache,
+                    timings)) {
                 testProjects.add(project);
                 continue;
             }
@@ -996,7 +1084,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Path absRoot,
             MavenSession session,
             Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache) {
+            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
+            Timings timings) {
         if (config.getSkipTestsForDownstreamModules().isEmpty()) {
             return false;
         }
@@ -1009,7 +1098,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
         // Safety guard: don't skip tests if the module has effective model changes
         return !hasEffectiveModelChanges(
-                project, oldEffectiveModels, newEffectiveModels, absRoot, session, collectCache, oldCollectCache);
+                project,
+                oldEffectiveModels,
+                newEffectiveModels,
+                absRoot,
+                session,
+                collectCache,
+                oldCollectCache,
+                timings);
     }
 
     /**
@@ -1034,7 +1130,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Path absRoot,
             MavenSession session,
             Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache) {
+            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
+            Timings timings) {
         String relPath = absRoot.relativize(
                         project.getFile().toPath().toAbsolutePath().normalize())
                 .toString()
@@ -1053,7 +1150,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
 
         // Check dependency tree
-        return findChangedDependencyInTree(project, oldModel, session, collectCache, oldCollectCache) != null;
+        return findChangedDependencyInTree(project, oldModel, session, collectCache, oldCollectCache, timings) != null;
     }
 
     private static final class ChangedDependencyMatch {
@@ -1078,10 +1175,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Model oldEffectiveModel,
             MavenSession session,
             Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache) {
+            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
+            Timings timings) {
 
         // Resolve new (current) dependency tree
-        DependencyResolutionResult newResult = resolveProjectDependencies(project, session, collectCache);
+        DependencyResolutionResult newResult = resolveProjectDependencies(project, session, collectCache, timings);
         if (newResult == null || newResult.getDependencyGraph() == null) {
             // Conservative: when the current tree cannot be resolved at all, assume it
             // changed so the module is treated as affected (and its tests are not
@@ -1092,7 +1190,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
         // Resolve old dependency tree from old effective model
         DependencyResolutionResult oldResult =
-                resolveModelDependencies(oldEffectiveModel, project, session, oldCollectCache);
+                resolveModelDependencies(oldEffectiveModel, project, session, oldCollectCache, timings);
         if (oldResult == null || oldResult.getDependencyGraph() == null) {
             // Conservative: same posture when the old tree cannot be resolved.
             return new ChangedDependencyMatch(UNRESOLVED_GA, "compile");
@@ -1144,9 +1242,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
      * Resolve the current project's dependency tree (cached).
      */
     private DependencyResolutionResult resolveProjectDependencies(
-            MavenProject project, MavenSession session, Map<MavenProject, DependencyResolutionResult> cache) {
+            MavenProject project,
+            MavenSession session,
+            Map<MavenProject, DependencyResolutionResult> cache,
+            Timings timings) {
         DependencyResolutionResult result = cache.get(project);
         if (result != null) {
+            timings.increment(Timings.OP_RESOLVE_CACHE_HITS);
             return result;
         }
         try {
@@ -1166,6 +1268,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     e.getMessage());
             return null;
         }
+        timings.increment(Timings.OP_DEPENDENCY_RESOLVES);
         cache.put(project, result);
         return result;
     }
@@ -1179,9 +1282,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Model oldModel,
             MavenProject currentProject,
             MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> cache) {
+            Map<MavenProject, DependencyResolutionResult> cache,
+            Timings timings) {
         DependencyResolutionResult result = cache.get(currentProject);
         if (result != null) {
+            timings.increment(Timings.OP_RESOLVE_CACHE_HITS);
             return result;
         }
         try {
@@ -1201,6 +1306,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     e.getMessage());
             return null;
         }
+        timings.increment(Timings.OP_DEPENDENCY_RESOLVES);
         cache.put(currentProject, result);
         return result;
     }
@@ -1372,7 +1478,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     }
 
     private void writeReport(
-            ScalpelConfiguration config, Path reactorRoot, List<MavenProject> allProjects, AnalysisContext ctx)
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            List<MavenProject> allProjects,
+            AnalysisContext ctx,
+            Timings timings,
+            long analysisStartNano)
             throws MavenExecutionException {
         ScalpelReport.Builder builder = ScalpelReport.builder()
                 .baseBranch(config.getBaseBranch())
@@ -1381,7 +1492,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 .changedProperties(ctx.changedProperties)
                 .changedManagedDependencies(ctx.changedManagedDepGAs)
                 .changedManagedPlugins(ctx.changedManagedPluginGAs)
-                .unmatchedPomPaths(ctx.unmatchedPomPaths);
+                .unmatchedPomPaths(ctx.unmatchedPomPaths)
+                .timings(timings, millisSince(analysisStartNano));
 
         logger.debug(
                 "Building report: {} directly affected, {} transitively affected, trim result has {} upstream / {} downstream / {} downstream-test",

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -257,7 +257,7 @@ class ScalpelLifecycleParticipantTest {
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
         ChangeDetectionResult detectionResult = new ChangeDetectionResult(changedFiles, oldPoms);
-        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(detectionResult);
+        when(scalpelCore.detectChanges(any(), any(), any(), any())).thenReturn(detectionResult);
 
         // commons-lang dependency used for transitive resolution (old vs new version)
         org.eclipse.aether.graph.Dependency commonsLangNew = new org.eclipse.aether.graph.Dependency(
@@ -433,7 +433,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // module-e: total resolution failure, exception carries NO partial result
@@ -539,7 +539,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("module-a/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("module-a/pom.xml", oldModuleAPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         when(dependenciesResolver.resolve(any(DefaultDependencyResolutionRequest.class)))
@@ -668,7 +668,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // No transitive deps to resolve
@@ -804,7 +804,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("parent/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("parent/pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // No transitive deps to resolve for this test
@@ -903,7 +903,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/test/java/com/example/MyTest.java");
         changedFiles.add("module-b/src/main/java/com/example/Service.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
 
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
@@ -1026,7 +1026,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // module-b: commons-lang is only via test scope (old=1.0, new=2.0)
@@ -1146,7 +1146,7 @@ class ScalpelLifecycleParticipantTest {
         // module-a has a source change
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/com/example/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
 
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
@@ -1215,7 +1215,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1254,7 +1254,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1298,7 +1298,7 @@ class ScalpelLifecycleParticipantTest {
         // module-a is directly affected; the parent is force-included so nothing is skipped
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1383,7 +1383,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1439,7 +1439,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-b/src/main/java/Bar.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1505,7 +1505,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-x/src/main/java/Baz.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1566,7 +1566,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-c/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1608,7 +1608,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1652,7 +1652,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1698,7 +1698,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1734,7 +1734,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add(".github/workflows/ci.yml");
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1773,7 +1773,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/README.md");
         changedFiles.add("module-b/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -1900,7 +1900,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("bom/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // Mock dependency resolution: module-b has commons-lang transitively (old=1.0, new=2.0)
@@ -2000,7 +2000,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2056,7 +2056,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2103,7 +2103,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2149,7 +2149,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2214,7 +2214,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2287,7 +2287,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("module-a/src/main/java/Foo.java");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // module-b has commons-lang transitively (old=1.0, new=2.0)
@@ -2395,7 +2395,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("module-a/src/main/java/Foo.java");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
         setupEmptyDependencyResolution();
 
@@ -2445,7 +2445,7 @@ class ScalpelLifecycleParticipantTest {
         // Only module-a has a source change
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -2484,7 +2484,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("README.md");
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -2526,7 +2526,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         changedFiles.add("module-b/src/main/java/Bar.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2571,7 +2571,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("module-a/src/main/java/Foo.java");
         changedFiles.add("module-b/src/main/java/Bar.java");
         changedFiles.add("module-c/src/main/java/Baz.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2612,7 +2612,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         changedFiles.add("module-b/src/main/java/Bar.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2653,7 +2653,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("module-a/src/main/java/Foo.java");
         changedFiles.add("module-a/README.md");
         changedFiles.add("module-b/src/main/java/Bar.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2758,7 +2758,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("parent/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("parent/pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         DependencyResolutionResult emptyResolution = mock(DependencyResolutionResult.class);
@@ -2828,7 +2828,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         changedFiles.add("module-b/src/main/java/Bar.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2869,7 +2869,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
         changedFiles.add("module-b/src/main/java/Bar.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2911,7 +2911,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -2959,7 +2959,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -3016,7 +3016,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -3061,7 +3061,7 @@ class ScalpelLifecycleParticipantTest {
         // A CI config file changed, matching the disable trigger
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add(".github/workflows/ci.yml");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3099,7 +3099,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -3130,7 +3130,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -3167,7 +3167,7 @@ class ScalpelLifecycleParticipantTest {
         Files.createDirectories(reportFile.getParent());
         Files.write(reportFile, "STALE-REPORT".getBytes(StandardCharsets.UTF_8));
 
-        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        when(scalpelCore.detectChanges(any(), any(), any(), any())).thenReturn(null);
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "report");
@@ -3199,7 +3199,7 @@ class ScalpelLifecycleParticipantTest {
         List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         // Null detection result (e.g., no git repo or no base branch)
-        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        when(scalpelCore.detectChanges(any(), any(), any(), any())).thenReturn(null);
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, allProjects, "report");
@@ -3239,7 +3239,7 @@ class ScalpelLifecycleParticipantTest {
         Files.createDirectories(reportFile.getParent());
         Files.write(reportFile, "STALE-REPORT".getBytes(StandardCharsets.UTF_8));
 
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(new LinkedHashSet<>(), new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -3281,7 +3281,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("docs/guide.md");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -3320,7 +3320,7 @@ class ScalpelLifecycleParticipantTest {
 
         List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
-        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        when(scalpelCore.detectChanges(any(), any(), any(), any())).thenReturn(null);
         when(scalpelCore.getLastDetectionSkipReason()).thenReturn("disabled by disableOnBranch");
         setupEmptyDependencyResolution();
 
@@ -3358,7 +3358,7 @@ class ScalpelLifecycleParticipantTest {
 
         List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
-        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        when(scalpelCore.detectChanges(any(), any(), any(), any())).thenReturn(null);
         when(scalpelCore.getLastDetectionSkipReason()).thenReturn("no base branch configured");
         setupEmptyDependencyResolution();
 
@@ -3398,7 +3398,7 @@ class ScalpelLifecycleParticipantTest {
 
         List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
-        when(scalpelCore.detectChanges(any(), any(), any())).thenReturn(null);
+        when(scalpelCore.detectChanges(any(), any(), any(), any())).thenReturn(null);
         when(scalpelCore.getLastDetectionSkipReason()).thenReturn("not a git repository");
         setupEmptyDependencyResolution();
 
@@ -3489,7 +3489,7 @@ class ScalpelLifecycleParticipantTest {
         List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
         // No changed files
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(new LinkedHashSet<String>(), new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3524,7 +3524,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("README.md");
         changedFiles.add("CHANGELOG.md");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3562,7 +3562,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add(".github/workflows/ci.yml");
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3599,7 +3599,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", "<<<INVALID XML>>>".getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
         setupEmptyDependencyResolution();
 
@@ -3634,7 +3634,7 @@ class ScalpelLifecycleParticipantTest {
 
         // ScalpelCore throws ScalpelException (e.g. merge-base unavailable with failSafe=false in core,
         // but the lifecycle participant should still respect its own failSafe check)
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenThrow(new ScalpelException("Could not find merge base between origin/main and HEAD"));
         setupEmptyDependencyResolution();
 
@@ -3665,7 +3665,7 @@ class ScalpelLifecycleParticipantTest {
 
         List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenThrow(new ScalpelException("Could not find merge base between origin/main and HEAD"));
         setupEmptyDependencyResolution();
 
@@ -3703,7 +3703,7 @@ class ScalpelLifecycleParticipantTest {
         // Change a file that doesn't map to any module (e.g. root-level non-pom file)
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add(".gitignore");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3745,7 +3745,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3784,7 +3784,7 @@ class ScalpelLifecycleParticipantTest {
         // module-b has source changes, module-a is upstream
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-b/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3843,7 +3843,7 @@ class ScalpelLifecycleParticipantTest {
         // module-b has source changes
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-b/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -3937,7 +3937,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
         setupEmptyDependencyResolution();
 
@@ -3975,7 +3975,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("Jenkinsfile");
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -4013,7 +4013,7 @@ class ScalpelLifecycleParticipantTest {
         // module-b has source changes, module-a is upstream
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-b/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -4072,7 +4072,7 @@ class ScalpelLifecycleParticipantTest {
         List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
         setupEmptyDependencyResolution();
 
@@ -4138,7 +4138,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
         setupEmptyDependencyResolution();
 
@@ -4202,7 +4202,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
         setupEmptyDependencyResolution();
 
@@ -4627,7 +4627,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("bom/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("bom/pom.xml", oldBomPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // module-a has smallrye-graphql as a transitive dependency (old=2.18.1, new=2.18.2)
@@ -4906,7 +4906,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("parent/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("parent/pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // No transitive dep resolution matches (changedManagedDepGAs should be empty anyway)
@@ -5173,7 +5173,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("parent/pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("parent/pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
         setupEmptyDependencyResolution();
 
@@ -5298,7 +5298,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add(".mvn/extensions.xml");
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -5362,7 +5362,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -5456,7 +5456,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -5488,7 +5488,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -5545,7 +5545,7 @@ class ScalpelLifecycleParticipantTest {
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/docs/guide.md");
         changedFiles.add("module-b/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -5669,7 +5669,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // Build two-level dependency graphs (old=1.0, new=2.0 for deep-lib):
@@ -5773,7 +5773,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // Build diamond dependency graphs (old=1.0, new=2.0 for target-lib):
@@ -5894,7 +5894,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         // Build two-level trees (old=1.0, new=2.0 for deep-test-lib):
@@ -5996,7 +5996,7 @@ class ScalpelLifecycleParticipantTest {
         changedFiles.add("pom.xml");
         Map<String, byte[]> oldPoms = new HashMap<>();
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
 
         DependencyNode newGraph = createDependencyGraph(new org.eclipse.aether.graph.Dependency(
@@ -6031,7 +6031,7 @@ class ScalpelLifecycleParticipantTest {
 
         Set<String> changedFiles = new LinkedHashSet<>();
         changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
         setupEmptyDependencyResolution();
 
@@ -6104,7 +6104,7 @@ class ScalpelLifecycleParticipantTest {
 
         List<MavenProject> allProjects = List.of(parentProject, moduleA);
 
-        when(scalpelCore.detectChanges(any(), any(), any()))
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
                 .thenReturn(new ChangeDetectionResult(new LinkedHashSet<>(), new HashMap<>()));
         setupEmptyDependencyResolution();
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -5939,4 +5939,188 @@ class ScalpelLifecycleParticipantTest {
         assertTrue(
                 moduleHasField(json, "module-a", "category", "TRANSITIVE"), "module-a should have TRANSITIVE category");
     }
+
+    // --- Phase timing and operation-count instrumentation (#99) ---
+
+    /**
+     * Scenario for the timing-instrumentation tests: the parent POM's managed-dependency
+     * version property changed (lib.version 1.0 -> 2.0 on disk, 1.0 in the git base), so a
+     * run exercises POM analysis (effective model building for old and new state) and
+     * transitive dependency resolution. module-b's resolved tree contains deep-lib, whose
+     * version moved between old and new effective models, so module-b is transitively
+     * affected. Returns the ready-to-run report-mode session; everything lives under
+     * tempDir/project.
+     */
+    private MavenSession setupManagedVersionChangeScenario() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <lib.version>2.0</lib.version>
+                  </properties>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>org.example</groupId>
+                      <artifactId>deep-lib</artifactId>
+                      <version>${lib.version}</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+        String moduleBPom = simpleChildPom("module-b");
+        writePom(root, "module-b/pom.xml", moduleBPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+        MavenProject moduleB = createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", moduleBPom);
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        String oldParentPom = parentPom.replace("<lib.version>2.0</lib.version>", "<lib.version>1.0</lib.version>");
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, oldPoms));
+
+        DependencyNode newGraph = createDependencyGraph(new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("org.example", "deep-lib", "jar", "2.0"), "compile"));
+        DependencyNode oldGraph = createDependencyGraph(new org.eclipse.aether.graph.Dependency(
+                new DefaultArtifact("org.example", "deep-lib", "jar", "1.0"), "compile"));
+        mockDependencyResolution("module-b", newGraph, oldGraph, allProjects);
+
+        return createSimpleSession(root, allProjects, "report");
+    }
+
+    @Test
+    void analysisTimingSummary_loggedAsOneInfoLine() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        writePom(root, "module-a/pom.xml", simpleChildPom("module-a"));
+        writePom(root, "module-b/pom.xml", simpleChildPom("module-b"));
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA =
+                createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", simpleChildPom("module-a"));
+        moduleA.setParent(parentProject);
+        MavenProject moduleB =
+                createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", simpleChildPom("module-b"));
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        String err = captureStderr(() -> assertDoesNotThrow(() -> participant.afterProjectsRead(session)));
+
+        String summary = err.lines()
+                .filter(l -> l.contains("Scalpel: analysis took"))
+                .findFirst()
+                .orElse("");
+        assertFalse(summary.isEmpty(), "expected a timing summary line on stderr but stderr was: " + err);
+        assertTrue(
+                summary.matches(".*Scalpel: analysis took \\d+ms.*"),
+                "summary must lead with the total in millis; was: " + summary);
+        assertTrue(
+                summary.contains("moduleMapping="),
+                "summary must break down at least the moduleMapping phase; was: " + summary);
+    }
+
+    @Test
+    void analysisTimingSummary_includesOperationCounts() throws Exception {
+        MavenSession session = setupManagedVersionChangeScenario();
+
+        String err = captureStderr(() -> assertDoesNotThrow(() -> participant.afterProjectsRead(session)));
+
+        String summary = err.lines()
+                .filter(l -> l.contains("Scalpel: analysis took"))
+                .findFirst()
+                .orElse("");
+        assertFalse(summary.isEmpty(), "expected a timing summary line on stderr but stderr was: " + err);
+        assertTrue(
+                summary.contains("models="),
+                "summary must count effective models built during POM analysis; was: " + summary);
+        assertTrue(
+                summary.contains("resolves="), "summary must count dependency resolutions performed; was: " + summary);
+    }
+
+    @Test
+    void reportMode_includesTimingAndOperationFields() throws Exception {
+        MavenSession session = setupManagedVersionChangeScenario();
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = tempDir.resolve("project/target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "Report file should be created");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"timings\""), "report must carry a timings object; json was: " + json);
+        assertTrue(json.contains("\"totalMillis\""), "timings must carry the analysis total");
+        assertTrue(json.contains("\"phases\""), "timings must carry the per-phase breakdown");
+        assertTrue(json.contains("\"pomAnalysis\""), "phases must include the POM analysis phase");
+        assertTrue(json.contains("\"operations\""), "report must carry an operations object");
+        assertTrue(json.contains("\"models\""), "operations must include the effective-models counter");
+    }
+
+    @Test
+    void reportMode_statusOnlyReportHasNoTimingFields() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        writePom(root, "pom.xml", simpleParentPom("module-a"));
+        writePom(root, "module-a/pom.xml", simpleChildPom("module-a"));
+
+        MavenProject parentProject =
+                createProject("com.example", "parent", "1.0", root, "pom.xml", simpleParentPom("module-a"));
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA =
+                createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", simpleChildPom("module-a"));
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(new LinkedHashSet<>(), new HashMap<>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "status-only report should be written");
+        String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"status\""), "expected a status-only document (no changes detected)");
+        assertFalse(
+                json.contains("\"timings\""),
+                "status-only documents must omit timings entirely (null-input rule); json was: " + json);
+        assertFalse(
+                json.contains("\"operations\""),
+                "status-only documents must omit operations entirely (null-input rule); json was: " + json);
+    }
 }


### PR DESCRIPTION
## Problem

As filed in #99: zero uses of nanoTime/currentTimeMillis existed anywhere in the analysis path. For a tool whose value proposition is time saved, a user could not answer "how long did Scalpel take and where did it go?", and no performance claim could be confirmed or refuted in the field.

## Change

- A small `Timings` collector in core (plain nanoTime deltas, no new dependencies): named phases (`start/stop`) accumulating millis, named operation counters, formatting helpers.
- **Phases**, named after what the current code does: `repoOpen, fetch, mergeBase, diff, status, readOldPoms` (in `ScalpelCore`) and `moduleMapping, pomAnalysis, transitiveResolve, trim, applySkipTests` (in the participant). Every start/stop pair is lexically adjacent with the stop in a finally.
- **Operation counts**: git blobs read (equals the old-POM map size: one read per entry), effective models built, dependency resolutions performed + cache hits (hits and misses mutually consistent on both caches), resource entries visited by the walk (accumulated on every exit path including budget/depth termination).
- **One INFO summary line** emitted in a finally so it also appears on bail-outs: `Scalpel: analysis took 113ms (repoOpen=89ms, mergeBase=11ms, ...) ops: blobs=1, models=6, resolves=4, resolveCacheHits=2, resources=2`.
- **Report**: optional `timings` ({totalMillis, phases}) and `operations` objects, emitted independently, omitted entirely when empty; status-only documents never carry them. Schema v2 declares both (no version bump, per policy); README example and version history updated.
- `detectChanges` gains a 4-arg overload taking the collector; the published 3-arg signature delegates unchanged (null collector fails fast with a clear message).

## Verification

TDD: RED first (4 targeted failures: no summary line, no report fields, schema lacking the properties), then GREEN. Suites green (core 184, extension3 177), plus real Maven IT runs showing the summary line with live numbers and the report carrying/omitting the objects correctly. Known coordination note: PR #157's schema equality guard (still open) will need `timings`/`operations` added to its emittable set when both meet in main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analysis reports now optionally include phase timings and operation counts.
  * Added visibility into analysis duration, processing phases, dependency resolutions, cache hits, Git reads, and scanned resources.
  * Added a concise analysis timing summary to logs.
  * Updated report documentation and schema to describe the new fields.

* **Bug Fixes**
  * Reports omit instrumentation fields when no timing or operation data was recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->