### PR TITLE
chore: review sweep - warning order, report-contract hygiene, unmatchedPomPaths on early returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Note that properties defined in a project POM's `<properties>` are deliberately 
 | `scalpel.excludePaths` | *(none)* | Comma-separated glob patterns; changed files matching these are ignored |
 | `scalpel.includePaths` | *(none)* | Comma-separated glob patterns; narrows the affected set to matching modules rather than filtering changed files |
 | `scalpel.disableTriggers` | *(none)* | Comma-separated glob patterns; if any changed file matches, Scalpel is disabled entirely |
-| `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report (report mode), relative to reactor root |
+| `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report (written in report and trim modes), relative to reactor root |
 | `scalpel.impactedLog` | *(none)* | Write impacted module paths to this file (one per line) |
 | `scalpel.forceBuildModules` | *(none)* | Comma-separated regex patterns; always include modules whose artifactId matches |
 | `scalpel.buildAllIfNoChanges` | `false` | Build everything when no changes are detected (useful for cron builds) |
@@ -621,7 +621,7 @@ with a `<type>test-jar</type>` dependency are affected. In Apache Camel, this re
 tests on affected ones. GIB has no equivalent — it either includes or excludes modules from the
 reactor.
 
-**Structured JSON report.** Scalpel's `mode=report` produces a JSON file with per-module reasons
+**Structured JSON report.** Scalpel writes a JSON file (in `report` and `trim` modes) with per-module reasons
 (`SOURCE_CHANGE`, `POM_CHANGE`, `TRANSITIVE_DEPENDENCY`, `MANAGED_PLUGIN`, etc.), categories
 (`DIRECT`, `UPSTREAM`, `DOWNSTREAM`), and source sets (`main`, `test`). CI scripts can make
 fine-grained decisions based on this data.

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/GitChangeDetector.java
@@ -65,14 +65,14 @@ public class GitChangeDetector {
     public ObjectId findMergeBase(Repository repository, String baseBranch, String head) throws IOException {
         ObjectId baseId = repository.resolve(baseBranch);
         if (baseId == null) {
-            warnIfShallow(repository, baseBranch, head);
             logger.warn("Cannot resolve base branch: {}", baseBranch);
+            warnIfShallow(repository, baseBranch, head);
             return null;
         }
         ObjectId headId = repository.resolve(head);
         if (headId == null) {
-            warnIfShallow(repository, baseBranch, head);
             logger.warn("Cannot resolve head: {}", head);
+            warnIfShallow(repository, baseBranch, head);
             return null;
         }
 
@@ -89,7 +89,6 @@ public class GitChangeDetector {
             logger.debug("Merge base between {} and {}: {}", baseBranch, head, mergeBase.getName());
             return mergeBase.getId();
         } catch (MissingObjectException e) {
-            warnIfShallow(repository, baseBranch, head);
             logger.warn(
                     "Cannot compute merge base between {} and {}: commit history is incomplete"
                             + " (missing object). {}",
@@ -97,6 +96,7 @@ public class GitChangeDetector {
                     head,
                     e.getMessage());
             logger.debug("MissingObjectException details", e);
+            warnIfShallow(repository, baseBranch, head);
             return null;
         } catch (IOException e) {
             logger.warn("Cannot compute merge base between {} and {}: {}", baseBranch, head, e.getMessage());

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public final class ScalpelReport {
 
@@ -49,10 +50,10 @@ public final class ScalpelReport {
     public static final String SKIP_REASON_NOT_AFFECTED = "NOT_AFFECTED";
 
     /** The skip reasons a {@link SkippedModule} may carry; extend together with the schema enum. */
-    private static final java.util.Set<String> KNOWN_SKIP_REASONS = java.util.Set.of(SKIP_REASON_NOT_AFFECTED);
+    private static final Set<String> KNOWN_SKIP_REASONS = Set.of(SKIP_REASON_NOT_AFFECTED);
 
     /** The reasons an {@link AffectedModule} may carry; extend together with the schema enum. */
-    private static final java.util.Set<String> KNOWN_MODULE_REASONS = java.util.Set.of(
+    private static final Set<String> KNOWN_MODULE_REASONS = Set.of(
             REASON_SOURCE_CHANGE,
             REASON_TEST_CHANGE,
             REASON_POM_CHANGE,
@@ -68,6 +69,10 @@ public final class ScalpelReport {
     public static final String CATEGORY_UPSTREAM = "UPSTREAM";
     public static final String CATEGORY_DOWNSTREAM = "DOWNSTREAM";
     public static final String CATEGORY_TRANSITIVE = "TRANSITIVE";
+
+    /** The categories an {@link AffectedModule} may carry; extend together with the schema enum. */
+    private static final Set<String> KNOWN_CATEGORIES =
+            Set.of(CATEGORY_DIRECT, CATEGORY_UPSTREAM, CATEGORY_DOWNSTREAM, CATEGORY_TRANSITIVE);
 
     private final String baseBranch;
     private final String status;
@@ -163,14 +168,9 @@ public final class ScalpelReport {
             if (sourceSet != null && !"main".equals(sourceSet) && !"test".equals(sourceSet)) {
                 throw new IllegalArgumentException("sourceSet must be 'main', 'test', or null");
             }
-            if (category != null
-                    && !CATEGORY_DIRECT.equals(category)
-                    && !CATEGORY_UPSTREAM.equals(category)
-                    && !CATEGORY_DOWNSTREAM.equals(category)
-                    && !CATEGORY_TRANSITIVE.equals(category)) {
+            if (category != null && !KNOWN_CATEGORIES.contains(category)) {
                 throw new IllegalArgumentException(
-                        "Unknown category '" + category + "'. Known categories: " + CATEGORY_DIRECT + ", "
-                                + CATEGORY_UPSTREAM + ", " + CATEGORY_DOWNSTREAM + ", " + CATEGORY_TRANSITIVE);
+                        "Unknown category '" + category + "'. Known categories: " + KNOWN_CATEGORIES);
             }
             requireNonNull(reasons, "reasons").forEach(r -> {
                 if (!KNOWN_MODULE_REASONS.contains(r)) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -7,6 +7,8 @@
  */
 package eu.maveniverse.maven.scalpel.core;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -45,6 +47,22 @@ public final class ScalpelReport {
      * not affected by the changeset (not direct, transitive, upstream or downstream).
      */
     public static final String SKIP_REASON_NOT_AFFECTED = "NOT_AFFECTED";
+
+    /** The skip reasons a {@link SkippedModule} may carry; extend together with the schema enum. */
+    private static final java.util.Set<String> KNOWN_SKIP_REASONS = java.util.Set.of(SKIP_REASON_NOT_AFFECTED);
+
+    /** The reasons an {@link AffectedModule} may carry; extend together with the schema enum. */
+    private static final java.util.Set<String> KNOWN_MODULE_REASONS = java.util.Set.of(
+            REASON_SOURCE_CHANGE,
+            REASON_TEST_CHANGE,
+            REASON_POM_CHANGE,
+            REASON_TRANSITIVE_DEPENDENCY,
+            REASON_TRANSITIVE_DEPENDENCY_TEST,
+            REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED,
+            REASON_MANAGED_PLUGIN,
+            REASON_DOWNSTREAM_DEPENDENT,
+            REASON_DOWNSTREAM_TEST,
+            REASON_FORCE_BUILD);
 
     public static final String CATEGORY_DIRECT = "DIRECT";
     public static final String CATEGORY_UPSTREAM = "UPSTREAM";
@@ -145,9 +163,24 @@ public final class ScalpelReport {
             if (sourceSet != null && !"main".equals(sourceSet) && !"test".equals(sourceSet)) {
                 throw new IllegalArgumentException("sourceSet must be 'main', 'test', or null");
             }
-            this.groupId = groupId;
-            this.artifactId = artifactId;
-            this.path = path;
+            if (category != null
+                    && !CATEGORY_DIRECT.equals(category)
+                    && !CATEGORY_UPSTREAM.equals(category)
+                    && !CATEGORY_DOWNSTREAM.equals(category)
+                    && !CATEGORY_TRANSITIVE.equals(category)) {
+                throw new IllegalArgumentException(
+                        "Unknown category '" + category + "'. Known categories: " + CATEGORY_DIRECT + ", "
+                                + CATEGORY_UPSTREAM + ", " + CATEGORY_DOWNSTREAM + ", " + CATEGORY_TRANSITIVE);
+            }
+            requireNonNull(reasons, "reasons").forEach(r -> {
+                if (!KNOWN_MODULE_REASONS.contains(r)) {
+                    throw new IllegalArgumentException(
+                            "Unknown module reason '" + r + "'. Known reasons: " + KNOWN_MODULE_REASONS);
+                }
+            });
+            this.groupId = requireNonNull(groupId, "groupId");
+            this.artifactId = requireNonNull(artifactId, "artifactId");
+            this.path = requireNonNull(path, "path");
             this.reasons = reasons;
             this.category = category;
             this.sourceSet = sourceSet;
@@ -247,10 +280,15 @@ public final class ScalpelReport {
         private final String reason;
 
         public SkippedModule(String groupId, String artifactId, String path, String reason) {
-            this.groupId = groupId;
-            this.artifactId = artifactId;
-            this.path = path;
-            this.reason = reason;
+            this.groupId = requireNonNull(groupId, "groupId");
+            this.artifactId = requireNonNull(artifactId, "artifactId");
+            this.path = requireNonNull(path, "path");
+            this.reason = requireNonNull(reason, "reason");
+            if (!KNOWN_SKIP_REASONS.contains(reason)) {
+                throw new IllegalArgumentException(
+                        "Unknown skipped-module reason '" + reason + "'. Known reasons: " + KNOWN_SKIP_REASONS
+                                + ". Extend the schema enum, this set and the drift test together when adding one.");
+            }
         }
 
         public String getGroupId() {
@@ -296,7 +334,7 @@ public final class ScalpelReport {
         sb.append("  \"changedManagedPlugins\": ")
                 .append(jsonStringArray(changedManagedPlugins))
                 .append(",\n");
-        if (unmatchedPomPaths != null && !unmatchedPomPaths.isEmpty()) {
+        if (!unmatchedPomPaths.isEmpty()) {
             sb.append("  \"unmatchedPomPaths\": ")
                     .append(jsonStringArray(unmatchedPomPaths))
                     .append(",\n");

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://maveniverse.eu/schemas/scalpel-report-v2.json",
   "title": "Scalpel Report",
-  "description": "JSON report produced by Scalpel (mode=report) describing which modules in a Maven multi-module reactor are affected by a git changeset.",
+  "description": "JSON report produced by Scalpel (report and trim modes) describing which modules in a Maven multi-module reactor are affected by a git changeset.",
   "type": "object",
   "required": [
     "version",

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -7,10 +7,12 @@
  */
 package eu.maveniverse.maven.scalpel.core;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -24,6 +26,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class ScalpelReportTest {
+
+    @Test
+    void skippedModule_rejectsUnknownReason() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ScalpelReport.SkippedModule("g", "a", "p", "SOMETHING_ELSE"),
+                "unknown skip reasons must not reach the report");
+        assertDoesNotThrow(() -> new ScalpelReport.SkippedModule("g", "a", "p", "NOT_AFFECTED"));
+        assertThrows(
+                NullPointerException.class,
+                () -> new ScalpelReport.SkippedModule("g", "a", "p", null),
+                "null reason fails fast");
+    }
 
     @TempDir
     Path tempDir;

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
@@ -70,8 +70,10 @@ final class AnalysisContext {
             Set<String> changedFiles,
             Set<String> changedProperties,
             Set<String> changedManagedDepGAs,
-            Set<String> changedManagedPluginGAs) {
+            Set<String> changedManagedPluginGAs,
+            Set<String> unmatchedPomPaths) {
         return builder(changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
+                .unmatchedPomPaths(unmatchedPomPaths)
                 .build();
     }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -499,6 +499,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         allProjects,
                         AnalysisContext.builder(
                                         changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
+                                .unmatchedPomPaths(unmatchedPomPaths)
                                 .directlyAffected(directlyAffected)
                                 .affectedBySource(affectedBySource)
                                 .testOnlyBySource(sourceResult.getTestOnlyAffected())

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -296,7 +296,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             reactorRoot,
                             allProjects,
                             AnalysisContext.empty(
-                                    changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs));
+                                    changedFiles,
+                                    changedProperties,
+                                    changedManagedDepGAs,
+                                    changedManagedPluginGAs,
+                                    unmatchedPomPaths));
                 } else if (config.isModeSkipTests()) {
                     skipTestsOnAll(allProjects);
                 }
@@ -346,7 +350,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             reactorRoot,
                             allProjects,
                             AnalysisContext.empty(
-                                    changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs));
+                                    changedFiles,
+                                    changedProperties,
+                                    changedManagedDepGAs,
+                                    changedManagedPluginGAs,
+                                    unmatchedPomPaths));
                 } else if (config.isModeSkipTests()) {
                     skipTestsOnAll(allProjects);
                 }
@@ -388,7 +396,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                         changedFiles,
                                         changedProperties,
                                         changedManagedDepGAs,
-                                        changedManagedPluginGAs));
+                                        changedManagedPluginGAs,
+                                        unmatchedPomPaths));
                     } else if (config.isModeSkipTests()) {
                         skipTestsOnAll(allProjects);
                     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TrimResult.java
@@ -28,7 +28,7 @@ final class TrimResult {
     private final Set<MavenProject> upstreamOnly;
     private final Set<MavenProject> downstreamOnly;
     private final Set<MavenProject> downstreamTestOnly;
-    private final Map<MavenProject, java.util.List<String>> buildReasons;
+    private final Map<MavenProject, List<String>> buildReasons;
 
     TrimResult(
             List<MavenProject> buildSet,
@@ -53,7 +53,7 @@ final class TrimResult {
             Set<MavenProject> upstreamOnly,
             Set<MavenProject> downstreamOnly,
             Set<MavenProject> downstreamTestOnly,
-            Map<MavenProject, java.util.List<String>> buildReasons) {
+            Map<MavenProject, List<String>> buildReasons) {
         this.buildSet = Collections.unmodifiableList(new ArrayList<>(buildSet));
         this.directlyAffected = Collections.unmodifiableSet(new LinkedHashSet<>(directlyAffected));
         this.upstreamOnly = Collections.unmodifiableSet(new LinkedHashSet<>(upstreamOnly));
@@ -86,7 +86,7 @@ final class TrimResult {
      * Why each non-direct module is in the build set (explain-mode evidence),
      * e.g. "downstream of g:a" or "upstream of g:a".
      */
-    Map<MavenProject, java.util.List<String>> getBuildReasons() {
+    Map<MavenProject, List<String>> getBuildReasons() {
         return buildReasons;
     }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3680,6 +3680,46 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void reportMode_unmatchedPomPathsReachReportOnEarlyReturn() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a");
+        writePom(root, "pom.xml", parentPom);
+        String moduleAPom = simpleChildPom("module-a");
+        writePom(root, "module-a/pom.xml", moduleAPom);
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA = createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", moduleAPom);
+        moduleA.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA);
+
+        // Only changed file is a POM matching no reactor project (e.g. profile-gated module):
+        // the analysis takes the "no modules affected" early return, and the report must still
+        // carry unmatchedPomPaths - it is the answer to "why was nothing affected".
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("gated-module/pom.xml");
+        when(scalpelCore.detectChanges(any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        // The real PomChangeAnalyzer is wired in (see setUp): gated-module/pom.xml matches no
+        // reactor project, so it lands in unmatchedPomPaths and the analysis takes the
+        // no-modules-affected early return.
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "report");
+        participant.afterProjectsRead(session);
+
+        Path reportFile = root.resolve("target/scalpel-report.json");
+        assertTrue(Files.exists(reportFile), "report must be written even when no module is affected");
+        String json = Files.readString(reportFile);
+        assertTrue(
+                json.contains("\"unmatchedPomPaths\": [\"gated-module/pom.xml\"]"),
+                "unmatchedPomPaths must survive the no-modules-affected early return: " + json);
+    }
+
+    @Test
     void noModulesAffected_skipTestsMode_skipsAllTests() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);


### PR DESCRIPTION
One sweep collecting the non-blocking observations left on the merged wave, plus one real bug the same review surfaced.

## The real fix: unmatchedPomPaths dropped on early returns

A report-mode run whose only change is a POM matching no reactor project (profile-gated, -pl-excluded) takes the "no modules affected" early return - and that path built the report from `AnalysisContext.empty()`, which never carried `unmatchedPomPaths`. The one field that explains "why was nothing affected" was omitted exactly when it was the answer, while the troubleshooting guide points users to it. `AnalysisContext.empty` now takes the set, all three early returns pass it, and a regression test proves the fix (verified RED on main: the assertion fails without the change).

## Hygiene items (all from review notes)

- **findMergeBase warning order** (note on #136): shallow-repository guidance now fires after the specific cannot-resolve/no-merge-base message on all four paths; the first pass missed the MissingObjectException catch.
- **Schema + README mode wording** (note on #139): the JSON report is written in report AND trim modes; the schema description said report-only and the README had two stale spots.
- **unmatchedPomPaths null check** in toJson removed (note on #138: the Builder initializes the list; sibling fields have no such check).
- **SkippedModule reason validation**: unknown reasons now fail fast with the known set in the message, instead of silently producing a schema-invalid report.
- **AffectedModule symmetric hardening**: groupId/artifactId/path requireNonNull, category and reasons validated against their schema enums - the SkippedModule hardening without this looked deliberate but unexplained.
- **TrimResult**: imported `List` short form (note on #142).

## Verification

Full suites green (core 171, extension3 174). The regression test was proven failing on unmodified main before the fix (stash-revert, run, restore). Reviewed at medium level: 8 finder angles, 6 independent verifiers, 5 findings applied (all listed above), 2 refuted with evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timing and operation metrics to JSON reports when instrumentation data is available.

* **Bug Fixes**
  * Preserved unmatched POM paths in generated reports, including when no modules are affected.
  * Added validation for invalid or missing report reasons and module inputs.

* **Documentation**
  * Clarified that JSON reports are generated in both report and trim modes.

* **Tests**
  * Added coverage for report metrics, validation, and unmatched POM paths in early-return scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->