### PR TITLE
Fix #97: contain the report and impacted-log output paths inside the reactor root

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ mvn validate -Dscalpel.mode=report -Dscalpel.baseBranch=origin/main
 
 The report is written to `target/scalpel-report.json` by default. See [Report Format](docs/REPORT-FORMAT.md) for the schema and all fields.
 
-Note that report mode is not a sandbox: `mvn validate` on untrusted PR content still executes PR-controlled Maven configuration and plugins; report mode only guarantees that Scalpel itself leaves the reactor untouched. Both Scalpel output paths (`scalpel.reportFile`, `scalpel.impactedLog`) are confined to the project directory: absolute paths and parent-directory traversal are rejected. The confinement is lexical: a symlink inside the project that already points elsewhere is not resolved.
+Note that report mode is not a sandbox: `mvn validate` on untrusted PR content still executes PR-controlled Maven configuration and plugins; report mode only guarantees that Scalpel itself leaves the reactor untouched. Both Scalpel output paths (`scalpel.reportFile`, `scalpel.impactedLog`) are confined to the project directory: absolute paths are rejected, as is any path that normalizes outside the project (`..` segments that stay inside are fine). The confinement is lexical: a symlink inside the project that already points elsewhere is not resolved.
 
 ### `shadow`
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ mvn validate -Dscalpel.mode=report -Dscalpel.baseBranch=origin/main
 
 The report is written to `target/scalpel-report.json` by default. See [Report Format](docs/REPORT-FORMAT.md) for the schema and all fields.
 
+Note that report mode is not a sandbox: `mvn validate` on untrusted PR content still executes PR-controlled Maven configuration and plugins; report mode only guarantees that Scalpel itself leaves the reactor untouched. Both Scalpel output paths (`scalpel.reportFile`, `scalpel.impactedLog`) are confined to the project directory: absolute paths and parent-directory traversal are rejected.
+
 ### `shadow`
 
 Behaves exactly like `report` and additionally measures the full build: it records the trim decision it would have made, per-module durations, `estimatedSecondsSaved`, and `wouldHaveSkippedButFailed` (the false-negative counter) to `target/scalpel-shadow.json`, appending one line per run to `target/scalpel-shadow-history.jsonl`. This is the recommended first step of the adoption path: one full build tells you what Scalpel would save on your topology.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ mvn validate -Dscalpel.mode=report -Dscalpel.baseBranch=origin/main
 
 The report is written to `target/scalpel-report.json` by default. See [Report Format](docs/REPORT-FORMAT.md) for the schema and all fields.
 
-Note that report mode is not a sandbox: `mvn validate` on untrusted PR content still executes PR-controlled Maven configuration and plugins; report mode only guarantees that Scalpel itself leaves the reactor untouched. Both Scalpel output paths (`scalpel.reportFile`, `scalpel.impactedLog`) are confined to the project directory: absolute paths and parent-directory traversal are rejected.
+Note that report mode is not a sandbox: `mvn validate` on untrusted PR content still executes PR-controlled Maven configuration and plugins; report mode only guarantees that Scalpel itself leaves the reactor untouched. Both Scalpel output paths (`scalpel.reportFile`, `scalpel.impactedLog`) are confined to the project directory: absolute paths and parent-directory traversal are rejected. The confinement is lexical: a symlink inside the project that already points elsewhere is not resolved.
 
 ### `shadow`
 

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -12,6 +12,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -446,9 +447,38 @@ public final class ScalpelReport {
     }
 
     public void writeToFile(Path reactorRoot, String reportFile) throws IOException {
-        Path path = reactorRoot.resolve(reportFile);
+        Path path = resolveContained(reactorRoot, reportFile, "scalpel.reportFile");
         Files.createDirectories(path.getParent());
         Files.write(path, toJson().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Resolves {@code configuredPath} against {@code reactorRoot} and returns the normalized
+     * target, refusing any path that escapes the reactor root. Absolute paths are rejected
+     * outright, as are parent-directory traversals, with an {@link IOException} naming
+     * {@code propertyName}: output paths are PR-controllable through {@code .mvn/maven.config},
+     * so neither write may land outside the project (#97). The check is lexical (a
+     * pre-existing symlink inside the root pointing elsewhere is not followed).
+     */
+    public static Path resolveContained(Path reactorRoot, String configuredPath, String propertyName)
+            throws IOException {
+        if (configuredPath == null || configuredPath.trim().isEmpty()) {
+            throw new IOException(propertyName + " must not be empty");
+        }
+        String trimmed = configuredPath.trim();
+        Path root = reactorRoot.toAbsolutePath().normalize();
+        Path resolved;
+        try {
+            resolved = root.resolve(trimmed).normalize();
+        } catch (InvalidPathException e) {
+            throw new IOException(propertyName + " '" + configuredPath + "' is not a valid path", e);
+        }
+        if (root.getFileSystem().getPath(trimmed).isAbsolute() || !resolved.startsWith(root)) {
+            throw new IOException(propertyName + " '" + configuredPath
+                    + "' resolves outside the reactor root; absolute paths and parent-directory"
+                    + " traversal are not allowed");
+        }
+        return resolved;
     }
 
     private static String jsonString(String value) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -462,10 +462,10 @@ public final class ScalpelReport {
      */
     public static Path resolveContained(Path reactorRoot, String configuredPath, String propertyName)
             throws IOException {
-        if (configuredPath == null || configuredPath.trim().isEmpty()) {
+        String trimmed = configuredPath == null ? "" : configuredPath.trim();
+        if (trimmed.isEmpty()) {
             throw new IOException(propertyName + " must not be empty");
         }
-        String trimmed = configuredPath.trim();
         Path root = reactorRoot.toAbsolutePath().normalize();
         Path resolved;
         try {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -447,7 +447,7 @@ public final class ScalpelReport {
     }
 
     public void writeToFile(Path reactorRoot, String reportFile) throws IOException {
-        Path path = resolveContained(reactorRoot, reportFile, "scalpel.reportFile");
+        Path path = resolveContained(reactorRoot, reportFile, ScalpelConfiguration.REPORT_FILE);
         Files.createDirectories(path.getParent());
         Files.write(path, toJson().getBytes(StandardCharsets.UTF_8));
     }

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -197,14 +197,20 @@ class ScalpelReportTest {
     @Test
     void writeToFile_rejectsAbsoluteReportFile() throws IOException {
         ScalpelReport report = minimalReport();
-        Path outside = Files.createTempDirectory("scalpel-outside").resolve("pwned.json");
+        // Created outside JUnit's @TempDir lifecycle, so cleaned up explicitly.
+        Path outsideDir = Files.createTempDirectory("scalpel-outside");
+        try {
+            Path outside = outsideDir.resolve("pwned.json");
 
-        IOException e = assertThrows(IOException.class, () -> report.writeToFile(tempDir, outside.toString()));
+            IOException e = assertThrows(IOException.class, () -> report.writeToFile(tempDir, outside.toString()));
 
-        assertTrue(
-                e.getMessage().contains("scalpel.reportFile"),
-                "The rejection must name the property, got: " + e.getMessage());
-        assertFalse(Files.exists(outside), "Nothing may be written outside the reactor root");
+            assertTrue(
+                    e.getMessage().contains("scalpel.reportFile"),
+                    "The rejection must name the property, got: " + e.getMessage());
+            assertFalse(Files.exists(outside), "Nothing may be written outside the reactor root");
+        } finally {
+            Files.deleteIfExists(outsideDir);
+        }
     }
 
     @Test

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -195,6 +195,40 @@ class ScalpelReportTest {
     }
 
     @Test
+    void writeToFile_rejectsAbsoluteReportFile() throws IOException {
+        ScalpelReport report = minimalReport();
+        Path outside = Files.createTempDirectory("scalpel-outside").resolve("pwned.json");
+
+        IOException e = assertThrows(IOException.class, () -> report.writeToFile(tempDir, outside.toString()));
+
+        assertTrue(
+                e.getMessage().contains("scalpel.reportFile"),
+                "The rejection must name the property, got: " + e.getMessage());
+        assertFalse(Files.exists(outside), "Nothing may be written outside the reactor root");
+    }
+
+    @Test
+    void writeToFile_rejectsParentTraversalReportFile() throws IOException {
+        ScalpelReport report = minimalReport();
+
+        IOException e = assertThrows(IOException.class, () -> report.writeToFile(tempDir, "../pwned.json"));
+
+        assertTrue(
+                e.getMessage().contains("scalpel.reportFile"),
+                "The rejection must name the property, got: " + e.getMessage());
+        assertFalse(
+                Files.exists(tempDir.getParent().resolve("pwned.json")),
+                "Nothing may be written outside the reactor root");
+    }
+
+    private static ScalpelReport minimalReport() {
+        return ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .build();
+    }
+
+    @Test
     void toJson_sourceSetIncludedWhenPresent() {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -227,6 +227,18 @@ class ScalpelReportTest {
                 "Nothing may be written outside the reactor root (probe: " + traversalTarget + ")");
     }
 
+    @Test
+    void writeToFile_rejectsEmptyAndBlankReportFile() {
+        ScalpelReport report = minimalReport();
+
+        for (String empty : new String[] {"", "   "}) {
+            IOException e = assertThrows(IOException.class, () -> report.writeToFile(tempDir, empty));
+            assertTrue(
+                    e.getMessage().contains("scalpel.reportFile"),
+                    "The rejection must name the property, got: " + e.getMessage());
+        }
+    }
+
     private static ScalpelReport minimalReport() {
         return ScalpelReport.builder()
                 .baseBranch("origin/main")

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -210,15 +210,21 @@ class ScalpelReportTest {
     @Test
     void writeToFile_rejectsParentTraversalReportFile() throws IOException {
         ScalpelReport report = minimalReport();
+        // Unique probe name plus an explicit pre-clean: the tempdir layout places sibling
+        // test methods under a shared parent, and a leftover from a previous run must not
+        // be mistaken for this run's write.
+        Path traversalTarget = tempDir.getParent().resolve("scalpel-containment-probe.json");
+        Files.deleteIfExists(traversalTarget);
 
-        IOException e = assertThrows(IOException.class, () -> report.writeToFile(tempDir, "../pwned.json"));
+        IOException e =
+                assertThrows(IOException.class, () -> report.writeToFile(tempDir, "../scalpel-containment-probe.json"));
 
         assertTrue(
                 e.getMessage().contains("scalpel.reportFile"),
                 "The rejection must name the property, got: " + e.getMessage());
         assertFalse(
-                Files.exists(tempDir.getParent().resolve("pwned.json")),
-                "Nothing may be written outside the reactor root");
+                Files.exists(traversalTarget),
+                "Nothing may be written outside the reactor root (probe: " + traversalTarget + ")");
     }
 
     private static ScalpelReport minimalReport() {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,8 +22,8 @@ Properties defined in a project POM are deliberately not read. Scalpel is config
 | `scalpel.excludePaths` | none | Comma-separated glob patterns. Changed files matching these are ignored |
 | `scalpel.includePaths` | none | Comma-separated glob patterns. Narrows the affected set to matching modules |
 | `scalpel.disableTriggers` | none | Comma-separated glob patterns. If any changed file matches, Scalpel is disabled |
-| `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report, relative to reactor root (written in all modes; must resolve inside the reactor, absolute paths and `..` traversal are rejected) |
-| `scalpel.impactedLog` | none | Write impacted module paths to this file (one per line; must resolve inside the reactor, and module paths outside the safe character set are skipped with a WARN) |
+| `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report, relative to reactor root (written in all modes; absolute paths are rejected, and so is any path whose normalization escapes the reactor; `..` segments that stay inside the project are fine) |
+| `scalpel.impactedLog` | none | Write impacted module paths to this file (one per line; absolute paths and paths escaping the reactor on normalization are rejected, and module paths outside the safe character set are skipped with a WARN) |
 | `scalpel.forceBuildModules` | none | Comma-separated regex patterns. Always include modules whose artifactId matches |
 | `scalpel.buildAllIfNoChanges` | `false` | Build everything when no changes are detected (useful for cron builds) |
 | `scalpel.disableOnBranch` | none | Comma-separated regex patterns. Disable if current branch matches |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,8 +22,8 @@ Properties defined in a project POM are deliberately not read. Scalpel is config
 | `scalpel.excludePaths` | none | Comma-separated glob patterns. Changed files matching these are ignored |
 | `scalpel.includePaths` | none | Comma-separated glob patterns. Narrows the affected set to matching modules |
 | `scalpel.disableTriggers` | none | Comma-separated glob patterns. If any changed file matches, Scalpel is disabled |
-| `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report, relative to reactor root (written in all modes) |
-| `scalpel.impactedLog` | none | Write impacted module paths to this file (one per line; paths outside the safe character set are skipped with a WARN) |
+| `scalpel.reportFile` | `target/scalpel-report.json` | Path for the JSON report, relative to reactor root (written in all modes; must resolve inside the reactor, absolute paths and `..` traversal are rejected) |
+| `scalpel.impactedLog` | none | Write impacted module paths to this file (one per line; must resolve inside the reactor, and module paths outside the safe character set are skipped with a WARN) |
 | `scalpel.forceBuildModules` | none | Comma-separated regex patterns. Always include modules whose artifactId matches |
 | `scalpel.buildAllIfNoChanges` | `false` | Build everything when no changes are detected (useful for cron builds) |
 | `scalpel.disableOnBranch` | none | Comma-separated regex patterns. Disable if current branch matches |

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -1501,7 +1501,15 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         if (impactedLog == null || impactedLog.trim().isEmpty()) {
             return;
         }
-        Path logPath = reactorRoot.resolve(impactedLog);
+        Path logPath;
+        try {
+            // The path is PR-controllable through .mvn/maven.config; neither write may
+            // land outside the reactor root (#97).
+            logPath = ScalpelReport.resolveContained(reactorRoot, impactedLog, "scalpel.impactedLog");
+        } catch (IOException e) {
+            handleWriteFailure(config, "Rejected impacted log path", e);
+            return;
+        }
         try {
             Files.createDirectories(logPath.getParent());
             List<String> lines = new ArrayList<>();

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -1505,7 +1505,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         try {
             // The path is PR-controllable through .mvn/maven.config; neither write may
             // land outside the reactor root (#97).
-            logPath = ScalpelReport.resolveContained(reactorRoot, impactedLog, "scalpel.impactedLog");
+            logPath = ScalpelReport.resolveContained(reactorRoot, impactedLog, ScalpelConfiguration.IMPACTED_LOG);
         } catch (IOException e) {
             handleWriteFailure(config, "Rejected impacted log path", e);
             return;

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3802,28 +3802,9 @@ class ScalpelLifecycleParticipantTest {
 
     @Test
     void impactedLog_absolutePathIsRejectedNotWritten() throws Exception {
-        Path root = tempDir.resolve("project");
-        Files.createDirectories(root);
-        writePom(root, "pom.xml", simpleParentPom("module-a"));
-        writePom(root, "module-a/pom.xml", simpleChildPom("module-a"));
-        MavenProject parentProject =
-                createProject("com.example", "parent", "1.0", root, "pom.xml", simpleParentPom("module-a"));
-        parentProject.getModel().setPackaging("pom");
-        MavenProject moduleA =
-                createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", simpleChildPom("module-a"));
-        moduleA.setParent(parentProject);
-
-        Set<String> changedFiles = new LinkedHashSet<>();
-        changedFiles.add("module-a/src/main/java/Foo.java");
-        when(scalpelCore.detectChanges(any(), any(), any(), any()))
-                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
-        setupEmptyDependencyResolution();
-
-        MavenSession session = createSimpleSession(root, List.of(parentProject, moduleA), "report");
         Path outside = Files.createTempDirectory("scalpel-outside").resolve("evil-impacted.log");
-        session.getSystemProperties().setProperty("scalpel.impactedLog", outside.toString());
 
-        String stderr = captureStderr(() -> assertDoesNotThrow(() -> participant.afterProjectsRead(session)));
+        String stderr = runImpactedLogScenario(outside.toString());
 
         assertFalse(Files.exists(outside), "An absolute impactedLog path must not be written");
         assertTrue(stderr.contains("scalpel.impactedLog"), "The rejection must name the property, got: " + stderr);
@@ -3831,6 +3812,21 @@ class ScalpelLifecycleParticipantTest {
 
     @Test
     void impactedLog_parentTraversalIsRejectedNotWritten() throws Exception {
+        String stderr = runImpactedLogScenario("../evil-impacted.log");
+
+        assertFalse(
+                Files.exists(tempDir.resolve("evil-impacted.log")),
+                "A parent-directory traversal must not escape the reactor root");
+        assertTrue(stderr.contains("scalpel.impactedLog"), "The rejection must name the property, got: " + stderr);
+    }
+
+    /**
+     * One-module report-mode fixture with a change in module-a and the given
+     * {@code scalpel.impactedLog} value; runs {@code afterProjectsRead} and returns the
+     * captured stderr. The reactor root is {@code tempDir/project}, so a parent traversal
+     * lands at {@code tempDir/}.
+     */
+    private String runImpactedLogScenario(String impactedLogValue) throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
         writePom(root, "pom.xml", simpleParentPom("module-a"));
@@ -3849,14 +3845,8 @@ class ScalpelLifecycleParticipantTest {
         setupEmptyDependencyResolution();
 
         MavenSession session = createSimpleSession(root, List.of(parentProject, moduleA), "report");
-        session.getSystemProperties().setProperty("scalpel.impactedLog", "../evil-impacted.log");
-
-        String stderr = captureStderr(() -> assertDoesNotThrow(() -> participant.afterProjectsRead(session)));
-
-        assertFalse(
-                Files.exists(root.getParent().resolve("evil-impacted.log")),
-                "A parent-directory traversal must not escape the reactor root");
-        assertTrue(stderr.contains("scalpel.impactedLog"), "The rejection must name the property, got: " + stderr);
+        session.getSystemProperties().setProperty("scalpel.impactedLog", impactedLogValue);
+        return runCapturingStdErr(() -> participant.afterProjectsRead(session));
     }
 
     @Test

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3801,6 +3801,65 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void impactedLog_absolutePathIsRejectedNotWritten() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+        writePom(root, "pom.xml", simpleParentPom("module-a"));
+        writePom(root, "module-a/pom.xml", simpleChildPom("module-a"));
+        MavenProject parentProject =
+                createProject("com.example", "parent", "1.0", root, "pom.xml", simpleParentPom("module-a"));
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA =
+                createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", simpleChildPom("module-a"));
+        moduleA.setParent(parentProject);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, List.of(parentProject, moduleA), "report");
+        Path outside = Files.createTempDirectory("scalpel-outside").resolve("evil-impacted.log");
+        session.getSystemProperties().setProperty("scalpel.impactedLog", outside.toString());
+
+        String stderr = captureStderr(() -> assertDoesNotThrow(() -> participant.afterProjectsRead(session)));
+
+        assertFalse(Files.exists(outside), "An absolute impactedLog path must not be written");
+        assertTrue(stderr.contains("scalpel.impactedLog"), "The rejection must name the property, got: " + stderr);
+    }
+
+    @Test
+    void impactedLog_parentTraversalIsRejectedNotWritten() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+        writePom(root, "pom.xml", simpleParentPom("module-a"));
+        writePom(root, "module-a/pom.xml", simpleChildPom("module-a"));
+        MavenProject parentProject =
+                createProject("com.example", "parent", "1.0", root, "pom.xml", simpleParentPom("module-a"));
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA =
+                createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", simpleChildPom("module-a"));
+        moduleA.setParent(parentProject);
+
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, List.of(parentProject, moduleA), "report");
+        session.getSystemProperties().setProperty("scalpel.impactedLog", "../evil-impacted.log");
+
+        String stderr = captureStderr(() -> assertDoesNotThrow(() -> participant.afterProjectsRead(session)));
+
+        assertFalse(
+                Files.exists(root.getParent().resolve("evil-impacted.log")),
+                "A parent-directory traversal must not escape the reactor root");
+        assertTrue(stderr.contains("scalpel.impactedLog"), "The rejection must name the property, got: " + stderr);
+    }
+
+    @Test
     void impactedLog_skipsModulePathsWithShellMetacharacters() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3802,12 +3802,18 @@ class ScalpelLifecycleParticipantTest {
 
     @Test
     void impactedLog_absolutePathIsRejectedNotWritten() throws Exception {
-        Path outside = Files.createTempDirectory("scalpel-outside").resolve("evil-impacted.log");
+        // Created outside JUnit's @TempDir lifecycle, so cleaned up explicitly.
+        Path outsideDir = Files.createTempDirectory("scalpel-outside");
+        try {
+            Path outside = outsideDir.resolve("evil-impacted.log");
 
-        String stderr = runImpactedLogScenario(outside.toString());
+            String stderr = runImpactedLogScenario(outside.toString());
 
-        assertFalse(Files.exists(outside), "An absolute impactedLog path must not be written");
-        assertTrue(stderr.contains("scalpel.impactedLog"), "The rejection must name the property, got: " + stderr);
+            assertFalse(Files.exists(outside), "An absolute impactedLog path must not be written");
+            assertTrue(stderr.contains("scalpel.impactedLog"), "The rejection must name the property, got: " + stderr);
+        } finally {
+            Files.deleteIfExists(outsideDir);
+        }
     }
 
     @Test


### PR DESCRIPTION
Both output paths were resolved with a bare `reactorRoot.resolve(userPath)`: `Path.resolve` returns absolute arguments unchanged and does not normalize parent traversal, so a PR could aim the report write and the fully attacker-controlled impacted-log write outside the project through `.mvn/maven.config` (the issue's verified repro). The write happens in `afterProjectsRead`, before any plugin from the PR runs, which is exactly the report-only pre-flight scenario the issue describes.

`ScalpelReport` gains a public `resolveContained(reactorRoot, configuredPath, propertyName)`: empty, absolute and escaping paths are rejected with an `IOException` naming the property. `writeToFile` routes every report write through it (status and full-build reports included), and the impacted log validates before writing, routing the rejection through the existing fail-safe-aware `handleWriteFailure`. The README carries the requested note that report mode is not a sandbox, plus the confinement rule for both properties in the configuration table.

TDD: the RED commit demonstrates absolute and traversal values for both properties written outside the reactor root with no exception on unmodified main.

Gates run before pushing (simplify four angles, review: bypass scan, null-input audit, history): no bypass vector survives (Windows separators, drive-relative and UNC forms, NUL bytes, URI forms, paths collapsing onto the root; the shadow outputs use fixed constants and the status writers inherit containment through writeToFile); rejection composes with #151's line-level allowlist (destination rejected before any directory is created) and honours the #137/#89 fail-safe semantics at every write site; the explicitly-empty `scalpel.reportFile` case (reachable, since the default does not apply to explicit empties) is now pinned by a test.

**Deliberate behaviour changes to note:**

* a rejected path means no write at all, so a stale file at the rejected out-of-root location is not overwritten (we refuse to touch it; the in-root #89 overwrite semantics are unchanged)
* an explicitly empty `scalpel.reportFile=` now fails the report write with a clear property-naming message (WARN, build continues under the default failSafe) instead of an obscure directory-write error
* the check is lexical by design and documented as such in the javadoc and README: a pre-existing symlink inside the root pointing elsewhere is not resolved (the issue frames the fix as defence in depth, and `toRealPath` would fail on the not-yet-existing report target)

Full battery green: core 200, extension3 190 unit tests, all 36 integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Report and impacted-log paths are prevented from escaping the project directory, including through absolute paths, empty values, or parent-directory traversal.
  * Invalid path configurations now produce warnings or build failures according to fail-safe settings.
  * Relative paths containing `..` remain supported when they normalize within the project.

* **Documentation**
  * Clarified output-path restrictions for reports and impacted logs.
  * Documented handling of unsupported module paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->