### PR TITLE
Fix #112: optimize filtered-resource property scanning

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1561,6 +1561,7 @@ class PomChangeAnalyzer {
      * Complexity: O(len + P) where len is content length and P is |propertyNames|,
      * compared to the previous O(P × len) approach of calling {@code contains()} per property.
      */
+    @SuppressWarnings("java:S135") // two breaks are clearer than a convoluted loop condition
     static boolean containsAnyPropertyRef(String content, Set<String> propertyNames) {
         int i = 0;
         while (true) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -647,13 +647,13 @@ class PomChangeAnalyzer {
             }
         }
 
-        int affectedCount = 0;
-        for (MavenProject dep : dependentProjects) {
-            if (ctx.affected.contains(dep)) {
-                affectedCount++;
-            }
-        }
         if (logger.isDebugEnabled()) {
+            int affectedCount = 0;
+            for (MavenProject dep : dependentProjects) {
+                if (ctx.affected.contains(dep)) {
+                    affectedCount++;
+                }
+            }
             logger.debug(
                     "Parent {} analysis complete: {} of {} dependents affected",
                     key(parentProject),
@@ -1359,12 +1359,7 @@ class PomChangeAnalyzer {
             return false;
         }
 
-        List<String> refs = new ArrayList<>();
-        for (String prop : unscanned) {
-            refs.add("${" + prop + "}");
-        }
-
-        if (scanFilteredResources(project, refs, ctx)) {
+        if (scanFilteredResources(project, unscanned, ctx)) {
             return true;
         }
         // No match found — record scanned properties for memoization (#114)
@@ -1394,7 +1389,7 @@ class PomChangeAnalyzer {
      * Scan all filtered resource directories of the given project for any of the given
      * property references.
      */
-    private boolean scanFilteredResources(MavenProject project, List<String> refs, AnalysisContext ctx) {
+    private boolean scanFilteredResources(MavenProject project, Set<String> changedPropertyNames, AnalysisContext ctx) {
         List<Resource> allResources = new ArrayList<>();
         if (project.getResources() != null) {
             allResources.addAll(project.getResources());
@@ -1418,7 +1413,7 @@ class PomChangeAnalyzer {
             if (!Files.isDirectory(resourceDir)) {
                 continue;
             }
-            if (scanDirectoryForPropertyRefs(resourceDir, refs, ctx)) {
+            if (scanDirectoryForPropertyRefs(resourceDir, changedPropertyNames, ctx)) {
                 logger.debug(
                         "Found property reference in filtered resources of {} (dir={})", key(project), resourceDir);
                 return true;
@@ -1430,7 +1425,7 @@ class PomChangeAnalyzer {
     private static final int MAX_RESOURCE_WALK_DEPTH = 32;
     private static final int MAX_RESOURCE_WALK_FILES = 10_000;
 
-    private boolean scanDirectoryForPropertyRefs(Path dir, List<String> refs, AnalysisContext ctx) {
+    private boolean scanDirectoryForPropertyRefs(Path dir, Set<String> changedPropertyNames, AnalysisContext ctx) {
         // Does not follow symbolic links: a symlink could loop forever or point
         // outside the module (leaking file content into the analysis)
         // Every exit path adds the entries it visited to ctx.resourcesVisited (#99).
@@ -1475,7 +1470,7 @@ class PomChangeAnalyzer {
                             if (attrs.isSymbolicLink()) {
                                 return FileVisitResult.CONTINUE;
                             }
-                            if (checkFileForPropertyRefs(file, attrs, refs)) {
+                            if (checkFileForPropertyRefs(file, attrs, changedPropertyNames)) {
                                 foundRef[0] = true;
                                 return FileVisitResult.TERMINATE;
                             }
@@ -1518,9 +1513,10 @@ class PomChangeAnalyzer {
      * {@link BasicFileAttributes} provided by {@code walkFileTree} (no extra stat),
      * and the content is read once with {@code Files.readAllBytes}. Binary detection
      * (NUL-byte scan, same heuristic as git) is performed in-memory on the first
-     * 8000 bytes of the already-read buffer.
+     * 8000 bytes of the already-read buffer. Property matching uses a single-pass
+     * scan (#112): O(len + P) instead of O(P × len).
      */
-    private boolean checkFileForPropertyRefs(Path entry, BasicFileAttributes attrs, List<String> refs) {
+    private boolean checkFileForPropertyRefs(Path entry, BasicFileAttributes attrs, Set<String> changedPropertyNames) {
         try {
             long size = attrs.size();
             if (size > 1024 * 1024) {
@@ -1544,11 +1540,9 @@ class PomChangeAnalyzer {
                 }
             }
             String content = new String(bytes, StandardCharsets.UTF_8);
-            for (String ref : refs) {
-                if (content.contains(ref)) {
-                    return true;
-                }
-            }
+            // Single-pass scan: extract all ${...} placeholder names and check
+            // intersection with changed property names (#112)
+            return containsAnyPropertyRef(content, changedPropertyNames);
         } catch (IOException e) {
             // Conservative: treat an unreadable file as potentially containing
             // property references. Under-building is the worst failure mode.
@@ -1557,6 +1551,33 @@ class PomChangeAnalyzer {
                     entry,
                     e.getMessage());
             return true;
+        }
+    }
+
+    /**
+     * Single-pass scan of {@code content} for Maven property placeholders {@code ${name}}.
+     * Extracts every placeholder token and checks if any appears in {@code propertyNames}.
+     * <p>
+     * Complexity: O(len + P) where len is content length and P is |propertyNames|,
+     * compared to the previous O(P × len) approach of calling {@code contains()} per property.
+     */
+    static boolean containsAnyPropertyRef(String content, Set<String> propertyNames) {
+        int len = content.length();
+        int i = 0;
+        while (i < len - 2) { // need at least "${}"
+            int start = content.indexOf("${", i);
+            if (start < 0) {
+                break;
+            }
+            int end = content.indexOf('}', start + 2);
+            if (end < 0) {
+                break;
+            }
+            String name = content.substring(start + 2, end);
+            if (propertyNames.contains(name)) {
+                return true;
+            }
+            i = end + 1;
         }
         return false;
     }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1562,9 +1562,8 @@ class PomChangeAnalyzer {
      * compared to the previous O(P × len) approach of calling {@code contains()} per property.
      */
     static boolean containsAnyPropertyRef(String content, Set<String> propertyNames) {
-        int len = content.length();
         int i = 0;
-        while (i < len - 2) { // need at least "${}"
+        while (true) {
             int start = content.indexOf("${", i);
             if (start < 0) {
                 break;

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -2363,6 +2363,67 @@ class PomChangeAnalyzerTest {
                 "parent should NOT be self-affected for a property-only change");
     }
 
+    // --- containsAnyPropertyRef single-pass scan tests (#112) ---
+
+    @Test
+    void containsAnyPropertyRef_matchesSingleProperty() {
+        assertTrue(PomChangeAnalyzer.containsAnyPropertyRef("app.version=${dep.version}", Set.of("dep.version")));
+    }
+
+    @Test
+    void containsAnyPropertyRef_matchesOneOfMany() {
+        assertTrue(PomChangeAnalyzer.containsAnyPropertyRef(
+                "v=${dep.version}", Set.of("other.prop", "dep.version", "foo")));
+    }
+
+    @Test
+    void containsAnyPropertyRef_noMatchWhenDifferentProperty() {
+        assertFalse(PomChangeAnalyzer.containsAnyPropertyRef("v=${some.other}", Set.of("dep.version")));
+    }
+
+    @Test
+    void containsAnyPropertyRef_noMatchOnEmptyContent() {
+        assertFalse(PomChangeAnalyzer.containsAnyPropertyRef("", Set.of("dep.version")));
+    }
+
+    @Test
+    void containsAnyPropertyRef_noMatchOnEmptyPropertySet() {
+        assertFalse(PomChangeAnalyzer.containsAnyPropertyRef("v=${dep.version}", Set.of()));
+    }
+
+    @Test
+    void containsAnyPropertyRef_handlesMultiplePlaceholders() {
+        String content = "a=${foo} b=${bar} c=${baz}";
+        assertTrue(PomChangeAnalyzer.containsAnyPropertyRef(content, Set.of("bar")));
+        assertFalse(PomChangeAnalyzer.containsAnyPropertyRef(content, Set.of("qux")));
+    }
+
+    @Test
+    void containsAnyPropertyRef_handlesUnterminatedPlaceholder() {
+        // "${foo" with no closing brace should not match
+        assertFalse(PomChangeAnalyzer.containsAnyPropertyRef("v=${foo", Set.of("foo")));
+    }
+
+    @Test
+    void containsAnyPropertyRef_handlesNestedDollarSigns() {
+        // "$$" is not a placeholder
+        assertFalse(PomChangeAnalyzer.containsAnyPropertyRef("v=$$", Set.of("$")));
+        assertTrue(PomChangeAnalyzer.containsAnyPropertyRef("v=$${prop}", Set.of("prop")));
+    }
+
+    @Test
+    void containsAnyPropertyRef_handlesEmptyPlaceholder() {
+        // "${}" has an empty name, should match if empty string is in the set
+        assertTrue(PomChangeAnalyzer.containsAnyPropertyRef("v=${}", Set.of("")));
+        assertFalse(PomChangeAnalyzer.containsAnyPropertyRef("v=${}", Set.of("x")));
+    }
+
+    @Test
+    void containsAnyPropertyRef_handlesAdjacentPlaceholders() {
+        assertTrue(PomChangeAnalyzer.containsAnyPropertyRef("${a}${b}${c}", Set.of("c")));
+        assertFalse(PomChangeAnalyzer.containsAnyPropertyRef("${a}${b}${c}", Set.of("d")));
+    }
+
     // --- IO error conservative handling tests ---
     //
     // The #131 effective-model rework removed readPomText; the equivalent failure


### PR DESCRIPTION
## Summary

Fixes #112: `[perf] Child POM text re-read and re-scanned per changed property in the parent-POM path`

### Changes

**Single-pass linear scan for property placeholders**

Replaced the O(P × len) per-property `String.contains()` loop in `checkFileForPropertyRefs` with a single-pass `indexOf`-based scan that extracts all `${...}` placeholder tokens and checks set intersection with changed property names. The new complexity is O(len + P) where `len` is the file content length and `P` is the number of changed properties.

The `containsAnyPropertyRef()` method is package-private (`static`) for direct unit testing.

**Debug-only count hoisted into guard**

The `affectedCount` computation (iterating all dependents to count how many are affected) was performed unconditionally but only consumed inside a `logger.isDebugEnabled()` guard. Moved the entire loop inside the guard.

**Signature cleanup**

The `hasFilteredResourcesWithChangedProperty` → `scanDirectoryForPropertyRefs` → `checkFileForPropertyRefs` call chain now passes `Set<String>` property names directly instead of pre-building a `List<String>` of `\${prop}` formatted refs.

### Note on readPomText and Xpp3Dom.toString()

The issue mentions `readPomText` and an `Xpp3Dom.toString()` in a per-property loop. Both were removed by the #131 effective-model rework (commit 3fe6b72). The equivalent performance issue now lives in the filtered-resource scanning path, which this PR addresses.

### Tests

- 9 new unit tests for `containsAnyPropertyRef` covering: single match, one-of-many, no match, empty content, empty property set, multiple placeholders, unterminated placeholder, nested dollar signs, empty placeholder name, adjacent placeholders.
- All existing tests pass (no behavioral changes).

_AI agent (Hermes on behalf of gnodet)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved project change analysis when processing files containing many property references.
  - Reduced unnecessary diagnostic processing when detailed debugging is disabled.

- **Reliability**
  - Expanded coverage for property-reference detection, including multiple, adjacent, empty, nested, and incomplete placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->