### PR TITLE
Fix #114: single-read filtered-resource scan with cross-parent memoization

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1354,13 +1354,7 @@ class PomChangeAnalyzer {
     private boolean hasFilteredResourcesWithChangedProperty(
             MavenProject project, Set<String> changedProperties, AnalysisContext ctx) {
         // Determine which properties still need scanning (cross-parent memoization)
-        Set<String> alreadyScanned = ctx.resourceScannedProperties.getOrDefault(project, Set.of());
-        Set<String> unscanned = new LinkedHashSet<>();
-        for (String prop : changedProperties) {
-            if (!alreadyScanned.contains(prop)) {
-                unscanned.add(prop);
-            }
-        }
+        Set<String> unscanned = filterUnscannedProperties(project, changedProperties, ctx);
         if (unscanned.isEmpty()) {
             return false;
         }
@@ -1370,6 +1364,37 @@ class PomChangeAnalyzer {
             refs.add("${" + prop + "}");
         }
 
+        if (scanFilteredResources(project, refs, ctx)) {
+            return true;
+        }
+        // No match found — record scanned properties for memoization (#114)
+        ctx.resourceScannedProperties
+                .computeIfAbsent(project, k -> new LinkedHashSet<>())
+                .addAll(unscanned);
+        return false;
+    }
+
+    /**
+     * Return the subset of {@code changedProperties} that have not yet been scanned
+     * for this project (cross-parent memoization, #114).
+     */
+    private Set<String> filterUnscannedProperties(
+            MavenProject project, Set<String> changedProperties, AnalysisContext ctx) {
+        Set<String> alreadyScanned = ctx.resourceScannedProperties.getOrDefault(project, Set.of());
+        Set<String> unscanned = new LinkedHashSet<>();
+        for (String prop : changedProperties) {
+            if (!alreadyScanned.contains(prop)) {
+                unscanned.add(prop);
+            }
+        }
+        return unscanned;
+    }
+
+    /**
+     * Scan all filtered resource directories of the given project for any of the given
+     * property references.
+     */
+    private boolean scanFilteredResources(MavenProject project, List<String> refs, AnalysisContext ctx) {
         List<Resource> allResources = new ArrayList<>();
         if (project.getResources() != null) {
             allResources.addAll(project.getResources());
@@ -1399,10 +1424,6 @@ class PomChangeAnalyzer {
                 return true;
             }
         }
-        // No match found — record scanned properties for memoization (#114)
-        ctx.resourceScannedProperties
-                .computeIfAbsent(project, k -> new LinkedHashSet<>())
-                .addAll(unscanned);
         return false;
     }
 
@@ -1516,7 +1537,7 @@ class PomChangeAnalyzer {
             }
             byte[] bytes = Files.readAllBytes(entry);
             // Binary detection: scan for NUL byte in the first 8000 bytes (git heuristic)
-            int binaryCheckLen = (int) Math.min(bytes.length, 8000);
+            int binaryCheckLen = Math.min(bytes.length, 8000);
             for (int i = 0; i < binaryCheckLen; i++) {
                 if (bytes[i] == 0) {
                     return false; // binary file — skip

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -13,7 +13,6 @@ import static java.util.Objects.requireNonNull;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
@@ -310,6 +309,14 @@ class PomChangeAnalyzer {
         final List<String> unmatchedPomPaths = new ArrayList<>();
         /** Filesystem entries visited by filtered-resource scans (instrumentation, #99). */
         long resourcesVisited;
+
+        /**
+         * Cross-parent memoization for filtered-resource scans (#114).
+         * Tracks which property refs have already been scanned per child project.
+         * When multiple parent POMs change, the same child's resource tree is not
+         * re-walked for properties that were already checked.
+         */
+        final Map<MavenProject, Set<String>> resourceScannedProperties = new LinkedHashMap<>();
     }
 
     /**
@@ -1339,11 +1346,27 @@ class PomChangeAnalyzer {
      * Check if a project has filtered resources that reference any of the changed properties.
      * Filtered resources live outside the POM model, so effective model comparison cannot
      * detect property substitutions in resource files.
+     * <p>
+     * Cross-parent memoization (#114): tracks which properties have already been scanned
+     * per child project. Only unscanned properties trigger a new walk; if all requested
+     * properties were already checked (and found no match), the walk is skipped entirely.
      */
     private boolean hasFilteredResourcesWithChangedProperty(
             MavenProject project, Set<String> changedProperties, AnalysisContext ctx) {
-        List<String> refs = new ArrayList<>();
+        // Determine which properties still need scanning (cross-parent memoization)
+        Set<String> alreadyScanned = ctx.resourceScannedProperties.getOrDefault(project, Set.of());
+        Set<String> unscanned = new LinkedHashSet<>();
         for (String prop : changedProperties) {
+            if (!alreadyScanned.contains(prop)) {
+                unscanned.add(prop);
+            }
+        }
+        if (unscanned.isEmpty()) {
+            return false;
+        }
+
+        List<String> refs = new ArrayList<>();
+        for (String prop : unscanned) {
             refs.add("${" + prop + "}");
         }
 
@@ -1376,6 +1399,10 @@ class PomChangeAnalyzer {
                 return true;
             }
         }
+        // No match found — record scanned properties for memoization (#114)
+        ctx.resourceScannedProperties
+                .computeIfAbsent(project, k -> new LinkedHashSet<>())
+                .addAll(unscanned);
         return false;
     }
 
@@ -1427,7 +1454,7 @@ class PomChangeAnalyzer {
                             if (attrs.isSymbolicLink()) {
                                 return FileVisitResult.CONTINUE;
                             }
-                            if (checkFileForPropertyRefs(file, refs)) {
+                            if (checkFileForPropertyRefs(file, attrs, refs)) {
                                 foundRef[0] = true;
                                 return FileVisitResult.TERMINATE;
                             }
@@ -1463,12 +1490,18 @@ class PomChangeAnalyzer {
         return foundRef[0];
     }
 
-    private boolean checkFileForPropertyRefs(Path entry, List<String> refs) {
+    /**
+     * Check whether a file contains any of the given property references.
+     * <p>
+     * Uses a single filesystem read (#114): the file size comes from
+     * {@link BasicFileAttributes} provided by {@code walkFileTree} (no extra stat),
+     * and the content is read once with {@code Files.readAllBytes}. Binary detection
+     * (NUL-byte scan, same heuristic as git) is performed in-memory on the first
+     * 8000 bytes of the already-read buffer.
+     */
+    private boolean checkFileForPropertyRefs(Path entry, BasicFileAttributes attrs, List<String> refs) {
         try {
-            long size = Files.size(entry);
-            if (isBinaryFile(entry, size)) {
-                return false;
-            }
+            long size = attrs.size();
             if (size > 1024 * 1024) {
                 // Conservative: the pre-#131 analyzer treated filtered resources larger
                 // than the scan limit as affected; keep failing toward affected so an
@@ -1481,7 +1514,15 @@ class PomChangeAnalyzer {
                         size);
                 return true;
             }
-            String content = new String(Files.readAllBytes(entry), StandardCharsets.UTF_8);
+            byte[] bytes = Files.readAllBytes(entry);
+            // Binary detection: scan for NUL byte in the first 8000 bytes (git heuristic)
+            int binaryCheckLen = (int) Math.min(bytes.length, 8000);
+            for (int i = 0; i < binaryCheckLen; i++) {
+                if (bytes[i] == 0) {
+                    return false; // binary file — skip
+                }
+            }
+            String content = new String(bytes, StandardCharsets.UTF_8);
             for (String ref : refs) {
                 if (content.contains(ref)) {
                     return true;
@@ -1495,31 +1536,6 @@ class PomChangeAnalyzer {
                     entry,
                     e.getMessage());
             return true;
-        }
-        return false;
-    }
-
-    /**
-     * Detect binary files using the same heuristic as git: scan for a NUL byte (0x00)
-     * in the first 8000 bytes of the file.
-     */
-    private boolean isBinaryFile(Path file, long fileSize) {
-        int bytesToRead = (int) Math.min(fileSize, 8000);
-        if (bytesToRead == 0) {
-            return false;
-        }
-        byte[] buffer = new byte[bytesToRead];
-        try (InputStream in = Files.newInputStream(file)) {
-            int read = in.read(buffer, 0, bytesToRead);
-            for (int i = 0; i < read; i++) {
-                if (buffer[i] == 0) {
-                    return true;
-                }
-            }
-        } catch (IOException e) {
-            // Treat as non-binary so the caller proceeds to read the full file,
-            // which will also fail and trigger the conservative "mark affected" path.
-            logger.warn("Cannot check binary status of {}: {}", file, e.getMessage());
         }
         return false;
     }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -2575,6 +2575,264 @@ class PomChangeAnalyzerTest {
                         + " should be conservatively marked as affected");
     }
 
+    // --- Issue #114 optimization tests ---
+
+    @Test
+    void analyzeChanges_singleReadOptimization_binaryFileSkipped() throws Exception {
+        // Binary files (containing NUL bytes) should still be skipped by the
+        // single-read optimization: the NUL-check on the read buffer must detect
+        // them and return false (not affected) even though the file's text-decoded
+        // content might match a property ref pattern.
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root);
+
+        // Create a resource directory with a binary file that contains ${dep.version}
+        // after a NUL byte — should be skipped as binary
+        Path resourceDir = root.resolve("module-a/src/main/resources");
+        Files.createDirectories(resourceDir);
+        byte[] binaryContent = new byte[100];
+        binaryContent[50] = 0; // NUL byte at position 50
+        byte[] propRef = "${dep.version}".getBytes(StandardCharsets.UTF_8);
+        System.arraycopy(propRef, 0, binaryContent, 60, propRef.length);
+        Files.write(resourceDir.resolve("data.bin"), binaryContent);
+
+        MavenProject moduleA = projects.get(1);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleA.getModel().setBuild(build);
+
+        // Old parent POM had dep.version=1.0
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
+
+        PomChangeAnalyzer.Result result = analyzeChanges(
+                Set.of("pom.xml"), Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)), projects, root);
+
+        assertFalse(
+                result.getAffectedProjects().contains(moduleA),
+                "module-a with only a binary resource file (NUL byte in first 8000 bytes) should NOT be marked as affected");
+    }
+
+    @Test
+    void analyzeChanges_singleReadOptimization_textFileDetectsPropertyRef() throws Exception {
+        // Text files (no NUL bytes) should be scanned for property refs.
+        // The single-read optimization must still detect property references.
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root);
+
+        // Create a resource directory with a text file referencing ${dep.version}
+        Path resourceDir = root.resolve("module-a/src/main/resources");
+        Files.createDirectories(resourceDir);
+        Files.write(
+                resourceDir.resolve("application.properties"),
+                "app.version=${dep.version}\n".getBytes(StandardCharsets.UTF_8));
+
+        MavenProject moduleA = projects.get(1);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleA.getModel().setBuild(build);
+
+        // Old parent POM had dep.version=1.0
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
+
+        PomChangeAnalyzer.Result result = analyzeChanges(
+                Set.of("pom.xml"), Map.of("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8)), projects, root);
+
+        assertTrue(
+                result.getAffectedProjects().contains(moduleA),
+                "module-a with a text resource referencing ${dep.version} should be marked as affected");
+    }
+
+    @Test
+    void analyzeChanges_crossParentMemoization_sharedChildScannedOnce() throws Exception {
+        // When two parent POMs change and share a child, the cross-parent memoization
+        // should prevent re-scanning the child's resource tree for properties already
+        // checked. The resourcesVisited count should reflect only one scan, not two.
+        Path root = tempDir.resolve("memo-project");
+        Files.createDirectories(root);
+        Files.createDirectories(root.resolve("mid"));
+        Files.createDirectories(root.resolve("leaf"));
+
+        // Structure: root-parent -> mid-parent -> leaf
+        // root-parent changes root.prop and shared.prop.
+        // mid-parent inherits from root-parent and adds no own properties.
+        // When both POMs are in the changed set, the effective property diff for
+        // mid-parent is a subset of root-parent's (both see root.prop, shared.prop
+        // via inheritance), so the second scan of leaf should be skipped by memoization.
+
+        String rootParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>root-parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>mid</module><module>leaf</module></modules>
+                  <properties>
+                    <root.prop>2.0</root.prop>
+                    <shared.prop>new-value</shared.prop>
+                  </properties>
+                </project>
+                """;
+        writePom(root.resolve("pom.xml"), rootParentPom);
+
+        // mid-parent inherits root-parent's properties, adds no new ones.
+        String midParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>root-parent</artifactId><version>1.0</version></parent>
+                  <artifactId>mid-parent</artifactId>
+                  <packaging>pom</packaging>
+                </project>
+                """;
+        writePom(root.resolve("mid/pom.xml"), midParentPom);
+
+        String leafPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>mid-parent</artifactId><version>1.0</version></parent>
+                  <artifactId>leaf-module</artifactId>
+                </project>
+                """;
+        writePom(root.resolve("leaf/pom.xml"), leafPom);
+
+        // Create a filtered resource in leaf that does NOT reference any changed property
+        Path leafResourceDir = root.resolve("leaf/src/main/resources");
+        Files.createDirectories(leafResourceDir);
+        Files.write(
+                leafResourceDir.resolve("config.properties"),
+                "app.name=my-app\nversion=fixed\n".getBytes(StandardCharsets.UTF_8));
+
+        // Register reactor pom files
+        reactorPomFiles.put(
+                "com.example:root-parent:1.0", root.resolve("pom.xml").toFile());
+        reactorPomFiles.put(
+                "com.example:mid-parent:1.0", root.resolve("mid/pom.xml").toFile());
+        reactorPomFiles.put(
+                "com.example:leaf-module:1.0", root.resolve("leaf/pom.xml").toFile());
+
+        MavenProject rootProject = createProject(
+                "com.example", "root-parent", "1.0", root.resolve("pom.xml").toFile());
+        rootProject.setOriginalModel(parseModel(rootParentPom));
+        rootProject.getModel().setPackaging("pom");
+        setEffectiveModel(rootProject, rootParentPom);
+
+        MavenProject midProject = createProject(
+                "com.example", "mid-parent", "1.0", root.resolve("mid/pom.xml").toFile());
+        midProject.setOriginalModel(parseModel(midParentPom));
+        midProject.setParent(rootProject);
+        midProject.getModel().setPackaging("pom");
+        setEffectiveModel(midProject, midParentPom);
+
+        MavenProject leafProject = createProject(
+                "com.example",
+                "leaf-module",
+                "1.0",
+                root.resolve("leaf/pom.xml").toFile());
+        leafProject.setOriginalModel(parseModel(leafPom));
+        leafProject.setParent(midProject);
+        setEffectiveModel(leafProject, leafPom);
+
+        // Add filtered resources to leaf
+        Resource resource = new Resource();
+        resource.setDirectory(leafResourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        leafProject.getModel().setBuild(build);
+
+        List<MavenProject> allProjects = List.of(rootProject, midProject, leafProject);
+
+        // Old POMs: root-parent had root.prop=1.0, shared.prop=old-value
+        // mid-parent was the same structure (no own properties, only inheritance)
+        String oldRootParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>root-parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>mid</module><module>leaf</module></modules>
+                  <properties>
+                    <root.prop>1.0</root.prop>
+                    <shared.prop>old-value</shared.prop>
+                  </properties>
+                </project>
+                """;
+
+        // mid-parent's old POM has the same structure (no own properties)
+        String oldMidParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>root-parent</artifactId><version>1.0</version></parent>
+                  <artifactId>mid-parent</artifactId>
+                  <packaging>pom</packaging>
+                </project>
+                """;
+
+        // Both parents changed — but mid-parent's effective property diff is a subset
+        // of root-parent's (both see root.prop, shared.prop via inheritance).
+        // Memoization should skip the second scan of leaf.
+        PomChangeAnalyzer.Result result = analyzeChanges(
+                Set.of("pom.xml", "mid/pom.xml"),
+                Map.of(
+                        "pom.xml", oldRootParentPom.getBytes(StandardCharsets.UTF_8),
+                        "mid/pom.xml", oldMidParentPom.getBytes(StandardCharsets.UTF_8)),
+                allProjects,
+                root);
+
+        // The leaf doesn't reference any changed properties, so it shouldn't be affected
+        assertFalse(
+                result.getAffectedProjects().contains(leafProject),
+                "leaf-module should not be affected (no property reference in resources)");
+
+        // The key assertion: resourcesVisited should show efficiency from memoization.
+        // Without memoization, leaf's resource dir would be walked twice (once per parent).
+        // With memoization, the second walk is skipped because root.prop and shared.prop
+        // were already scanned during the root-parent analysis.
+        // One traversal visits 2 entries (the directory + 1 file).
+        long visited = result.getResourcesVisited();
+        assertTrue(
+                visited <= 2,
+                "Cross-parent memoization should prevent double-scanning: expected ≤2 entries visited, got " + visited);
+    }
+
     // --- Helper methods ---
 
     private Path setupReactorRootWithBom() throws IOException {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -2586,8 +2586,8 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
         List<MavenProject> projects = createReactorWithPropertyUsage(root);
 
-        // Create a resource directory with a binary file that contains ${dep.version}
-        // after a NUL byte — should be skipped as binary
+        // Set up a resource directory with a binary file whose content includes a
+        // property reference after a NUL byte. The file should be skipped as binary.
         Path resourceDir = root.resolve("module-a/src/main/resources");
         Files.createDirectories(resourceDir);
         byte[] binaryContent = new byte[100];
@@ -2635,7 +2635,7 @@ class PomChangeAnalyzerTest {
         Path root = setupReactorRoot();
         List<MavenProject> projects = createReactorWithPropertyUsage(root);
 
-        // Create a resource directory with a text file referencing ${dep.version}
+        // Set up a resource directory with a text file that references a changed property.
         Path resourceDir = root.resolve("module-a/src/main/resources");
         Files.createDirectories(resourceDir);
         Files.write(


### PR DESCRIPTION
Fixes #114

## Changes

### Single-read per file
The filtered-resource scan previously performed three filesystem round trips per file:
1. `Files.size()` — stat
2. `isBinaryFile()` — open + read first 8KB
3. `Files.readAllBytes()` — open + read entire file

Now uses `BasicFileAttributes.size()` from `walkFileTree` (free) and reads the file once with `Files.readAllBytes()`. Binary detection (NUL-check on first 8000 bytes) is performed in-memory on the already-read byte array. The standalone `isBinaryFile()` method is removed.

### Cross-parent memoization
When multiple parent POMs change, the same child module resource tree was scanned once per parent. Now tracks which properties have already been scanned per child via `resourceScannedProperties` in `AnalysisContext`, so each resource directory is visited at most once per build when the effective property diffs overlap.

### Tests added
- `analyzeChanges_singleReadOptimization_binaryFileSkipped` — verifies binary files (with NUL bytes) are still correctly skipped
- `analyzeChanges_singleReadOptimization_textFileDetectsPropertyRef` — verifies text files with property references are still correctly detected
- `analyzeChanges_crossParentMemoization_sharedChildScannedOnce` — verifies that a shared child's resource tree is only scanned once when two parents change with overlapping property diffs

_AI agent (Hermes on behalf of gnodet)_