### PR TITLE
Fix #96: Add escaping tests and replace substring JSON extraction with parsed assertions

### DIFF
--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -481,7 +481,7 @@ class ScalpelReportTest {
     }
 
     @Test
-    void toJson_escapesSpecialCharacters() {
+    void toJson_escapesDoubleQuotes() {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch("origin/main")
                 .fullBuildTriggered(false)
@@ -489,7 +489,94 @@ class ScalpelReportTest {
                 .build();
 
         String json = report.toJson();
-        assertTrue(json.contains("path/with\\\"quotes.java"));
+        Object parsed = ScalpelReportSchemaTest.Json.parse(json);
+        @SuppressWarnings("unchecked")
+        List<String> changedFiles = (List<String>) ((java.util.Map<String, Object>) parsed).get("changedFiles");
+        assertEquals(List.of("path/with\"quotes.java"), changedFiles);
+    }
+
+    @Test
+    void toJson_escapesBackslashes() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("path\\with\\backslashes.java"))
+                .build();
+
+        String json = report.toJson();
+        Object parsed = ScalpelReportSchemaTest.Json.parse(json);
+        @SuppressWarnings("unchecked")
+        List<String> changedFiles = (List<String>) ((java.util.Map<String, Object>) parsed).get("changedFiles");
+        assertEquals(List.of("path\\with\\backslashes.java"), changedFiles);
+    }
+
+    @Test
+    void toJson_escapesNewlinesAndCarriageReturns() {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("line1\nline2\r\nline3"))
+                .build();
+
+        String json = report.toJson();
+        // Must produce \n and \r escapes, never literal newlines inside the JSON string
+        assertFalse(json.contains("line1\nline2"), "literal newline must not appear in JSON output");
+        assertTrue(json.contains("\\n"), "newline must be escaped as \\n");
+        assertTrue(json.contains("\\r"), "carriage return must be escaped as \\r");
+        Object parsed = ScalpelReportSchemaTest.Json.parse(json);
+        @SuppressWarnings("unchecked")
+        List<String> changedFiles = (List<String>) ((java.util.Map<String, Object>) parsed).get("changedFiles");
+        assertEquals(List.of("line1\nline2\r\nline3"), changedFiles);
+    }
+
+    @Test
+    void toJson_escapesTabsAndControlCharacters() {
+        // Tab (\t) and a control character (BEL, 0x07) must be escaped
+        String nameWithTab = "module\twith-tab";
+        String nameWithCtrl = "ctrl-" + (char) 0x07 + "-bel";
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of(nameWithTab, nameWithCtrl))
+                .build();
+
+        String json = report.toJson();
+        assertTrue(json.contains("\\t"), "tab must be escaped as \\t");
+        assertTrue(json.contains("\\u0007"), "BEL control char must be escaped as \\u0007");
+        Object parsed = ScalpelReportSchemaTest.Json.parse(json);
+        @SuppressWarnings("unchecked")
+        List<String> changedFiles = (List<String>) ((java.util.Map<String, Object>) parsed).get("changedFiles");
+        assertTrue(changedFiles.contains(nameWithTab), "tab round-trips through JSON");
+        assertTrue(changedFiles.contains(nameWithCtrl), "control char round-trips through JSON");
+    }
+
+    @Test
+    void toJson_escapesSpecialCharsInModuleFields() {
+        // Escaping must work in all string fields, not just changedFiles
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch("branch/with\"special\\chars\nnewline")
+                .fullBuildTriggered(false)
+                .changedFiles(Set.of("a.java"))
+                .addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                                "com.example\"quoted",
+                                "art\\ifact",
+                                "path\nwith\tnewlines",
+                                List.of(ScalpelReport.REASON_SOURCE_CHANGE))
+                        .category(ScalpelReport.CATEGORY_DIRECT)
+                        .build())
+                .build();
+
+        String json = report.toJson();
+        Object parsed = ScalpelReportSchemaTest.Json.parse(json);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> root = (java.util.Map<String, Object>) parsed;
+        assertEquals("branch/with\"special\\chars\nnewline", root.get("baseBranch"));
+        @SuppressWarnings("unchecked")
+        List<java.util.Map<String, Object>> modules = (List<java.util.Map<String, Object>>) root.get("affectedModules");
+        java.util.Map<String, Object> module = modules.get(0);
+        assertEquals("com.example\"quoted", module.get("groupId"));
+        assertEquals("art\\ifact", module.get("artifactId"));
+        assertEquals("path\nwith\tnewlines", module.get("path"));
     }
 
     // ---------------------------------------------------------------

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -1315,49 +1316,25 @@ class ScalpelLifecycleParticipantTest {
     }
 
     private boolean skippedModulePresent(String json, String artifactId) {
-        String skippedSection = extractSection(json, "skippedModules");
-        return skippedSection != null && skippedSection.contains("\"artifactId\": \"" + artifactId + "\"");
+        return findSkippedModule(json, artifactId) != null;
     }
 
     private boolean skippedModuleHasReason(String json, String artifactId, String reason) {
-        String skippedSection = extractSection(json, "skippedModules");
-        if (skippedSection == null) {
-            return false;
-        }
-        String marker = "\"artifactId\": \"" + artifactId + "\"";
-        int idx = skippedSection.indexOf(marker);
-        if (idx < 0) {
-            return false;
-        }
-        int end = skippedSection.indexOf("}", idx);
-        if (end < 0) {
-            return false;
-        }
-        return skippedSection.substring(idx, end).contains("\"reason\": \"" + reason + "\"");
+        Map<String, Object> module = findSkippedModule(json, artifactId);
+        return module != null && reason.equals(module.get("reason"));
     }
 
-    private String extractSection(String json, String sectionName) {
-        int start = json.indexOf("\"" + sectionName + "\":");
-        if (start < 0) {
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> findSkippedModule(String json, String artifactId) {
+        Map<String, Object> root = (Map<String, Object>) parseJson(json);
+        List<Map<String, Object>> modules = (List<Map<String, Object>>) root.get("skippedModules");
+        if (modules == null) {
             return null;
         }
-        int bracketStart = json.indexOf("[", start);
-        if (bracketStart < 0) {
-            return null;
-        }
-        int depth = 0;
-        for (int i = bracketStart; i < json.length(); i++) {
-            if (json.charAt(i) == '[') {
-                depth++;
-            }
-            if (json.charAt(i) == ']') {
-                depth--;
-            }
-            if (depth == 0) {
-                return json.substring(bracketStart, i + 1);
-            }
-        }
-        return null;
+        return modules.stream()
+                .filter(m -> artifactId.equals(m.get("artifactId")))
+                .findFirst()
+                .orElse(null);
     }
 
     @Test
@@ -4383,9 +4360,12 @@ class ScalpelLifecycleParticipantTest {
         Path reportFile = root.resolve("target/scalpel-report.json");
         assertTrue(Files.exists(reportFile));
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
-        String block = extractModuleBlock(json, "module-a");
+        Map<String, Object> module = findAffectedModule(json, "module-a");
+        assertNotNull(module, "module-a should be in the report");
+        @SuppressWarnings("unchecked")
+        List<String> evidence = (List<String>) module.get("evidence");
         assertTrue(
-                block != null && block.contains("\"module-a/src/main/java/Foo.java\""),
+                evidence != null && evidence.contains("module-a/src/main/java/Foo.java"),
                 "module-a evidence must name the triggering changed file");
     }
 
@@ -4449,11 +4429,16 @@ class ScalpelLifecycleParticipantTest {
         Path reportFile = root.resolve("target/scalpel-report.json");
         assertTrue(Files.exists(reportFile));
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
-        String block = extractModuleBlock(json, "module-x");
+        Map<String, Object> module = findAffectedModule(json, "module-x");
+        assertNotNull(module, "module-x should be in the report");
+        @SuppressWarnings("unchecked")
+        List<String> evidence = (List<String>) module.get("evidence");
         assertTrue(
-                block != null
-                        && (block.contains("effective dep org.example:lib") || block.contains("property foo.version")),
-                "module-x evidence must name the changed dependency or property, block was: " + block);
+                evidence != null
+                        && evidence.stream()
+                                .anyMatch(e -> e.contains("effective dep org.example:lib")
+                                        || e.contains("property foo.version")),
+                "module-x evidence must name the changed dependency or property, evidence was: " + evidence);
         assertFalse(modulePresent(json, "module-y"), "module-y does not reference the property, must not be affected");
     }
 
@@ -4757,31 +4742,30 @@ class ScalpelLifecycleParticipantTest {
     }
 
     private boolean modulePresent(String json, String artifactId) {
-        String affectedSection = extractSection(json, "affectedModules");
-        return affectedSection != null && affectedSection.contains("\"artifactId\": \"" + artifactId + "\"");
+        return findAffectedModule(json, artifactId) != null;
     }
 
-    private String extractModuleBlock(String json, String artifactId) {
-        String affectedSection = extractSection(json, "affectedModules");
-        if (affectedSection == null) {
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> findAffectedModule(String json, String artifactId) {
+        Map<String, Object> root = (Map<String, Object>) parseJson(json);
+        List<Map<String, Object>> modules = (List<Map<String, Object>>) root.get("affectedModules");
+        if (modules == null) {
             return null;
         }
-        String marker = "\"artifactId\": \"" + artifactId + "\"";
-        int idx = affectedSection.indexOf(marker);
-        if (idx < 0) {
-            return null;
-        }
-        int start = affectedSection.lastIndexOf("{", idx);
-        int end = affectedSection.indexOf("}", idx);
-        if (start < 0 || end < 0) {
-            return null;
-        }
-        return affectedSection.substring(start, end + 1);
+        return modules.stream()
+                .filter(m -> artifactId.equals(m.get("artifactId")))
+                .findFirst()
+                .orElse(null);
     }
 
+    @SuppressWarnings("unchecked")
     private boolean moduleHasReason(String json, String artifactId, String reason) {
-        String block = extractModuleBlock(json, artifactId);
-        return block != null && block.contains("\"" + reason + "\"");
+        Map<String, Object> module = findAffectedModule(json, artifactId);
+        if (module == null) {
+            return false;
+        }
+        List<String> reasons = (List<String>) module.get("reasons");
+        return reasons != null && reasons.contains(reason);
     }
 
     /**
@@ -4811,18 +4795,18 @@ class ScalpelLifecycleParticipantTest {
     }
 
     private boolean moduleHasAnySourceSet(String json, String artifactId) {
-        String block = extractModuleBlock(json, artifactId);
-        return block != null && block.contains("\"sourceSet\":");
+        Map<String, Object> module = findAffectedModule(json, artifactId);
+        return module != null && module.containsKey("sourceSet");
     }
 
     private boolean moduleHasSourceSet(String json, String artifactId, String sourceSet) {
-        String block = extractModuleBlock(json, artifactId);
-        return block != null && block.contains("\"sourceSet\": \"" + sourceSet + "\"");
+        Map<String, Object> module = findAffectedModule(json, artifactId);
+        return module != null && sourceSet.equals(module.get("sourceSet"));
     }
 
     private boolean moduleHasField(String json, String artifactId, String field, String value) {
-        String block = extractModuleBlock(json, artifactId);
-        return block != null && block.contains("\"" + field + "\": \"" + value + "\"");
+        Map<String, Object> module = findAffectedModule(json, artifactId);
+        return module != null && value.equals(module.get(field));
     }
 
     private Model parseModel(String xml) {
@@ -5711,19 +5695,21 @@ class ScalpelLifecycleParticipantTest {
         String json = new String(Files.readAllBytes(reportFile), StandardCharsets.UTF_8);
 
         // module-b should have both testsSkipped boolean and testsSkippedReason string
-        String moduleBBlock = extractModuleBlock(json, "module-b");
-        assertTrue(moduleBBlock != null, "module-b should be in the report");
-        assertTrue(
-                moduleBBlock.contains("\"testsSkipped\": true"),
+        Map<String, Object> moduleBMap = findAffectedModule(json, "module-b");
+        assertNotNull(moduleBMap, "module-b should be in the report");
+        assertEquals(
+                Boolean.TRUE,
+                moduleBMap.get("testsSkipped"),
                 "module-b should have testsSkipped=true boolean for jq compatibility");
-        assertTrue(
-                moduleBBlock.contains("\"testsSkippedReason\": \"EXCLUDED_DOWNSTREAM\""),
+        assertEquals(
+                "EXCLUDED_DOWNSTREAM",
+                moduleBMap.get("testsSkippedReason"),
                 "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM");
 
         // module-a should NOT have testsSkipped (it's DIRECT, not excluded downstream)
-        String moduleABlock = extractModuleBlock(json, "module-a");
-        assertTrue(moduleABlock != null, "module-a should be in the report");
-        assertFalse(moduleABlock.contains("\"testsSkipped\""), "module-a should NOT have testsSkipped (it's DIRECT)");
+        Map<String, Object> moduleAMap = findAffectedModule(json, "module-a");
+        assertNotNull(moduleAMap, "module-a should be in the report");
+        assertFalse(moduleAMap.containsKey("testsSkipped"), "module-a should NOT have testsSkipped (it's DIRECT)");
     }
 
     @Test
@@ -6449,5 +6435,204 @@ class ScalpelLifecycleParticipantTest {
         assertFalse(
                 json.contains("\"operations\""),
                 "status-only documents must omit operations entirely (null-input rule); json was: " + json);
+    }
+
+    // ---------------------------------------------------------------
+    // Minimal JSON parser for report assertions (replaces substring
+    // extraction that was fragile with nested objects, see #96).
+    // Mirrors the Json reader from ScalpelReportSchemaTest in core.
+    // ---------------------------------------------------------------
+
+    private static Object parseJson(String text) {
+        return new JsonReader(text).read();
+    }
+
+    /**
+     * Compact recursive-descent JSON reader producing {@code Map<String,Object>},
+     * {@code List<Object>}, {@code String}, {@code Long}, {@code Double},
+     * {@code Boolean}, and {@code null}. Sufficient for report assertions.
+     */
+    private static final class JsonReader {
+        private final String text;
+        private int pos;
+
+        JsonReader(String text) {
+            this.text = text;
+        }
+
+        Object read() {
+            skipWs();
+            Object value = parseValue();
+            skipWs();
+            if (pos != text.length()) {
+                throw error("trailing content");
+            }
+            return value;
+        }
+
+        private Object parseValue() {
+            if (pos >= text.length()) {
+                throw error("unexpected end");
+            }
+            char c = text.charAt(pos);
+            return switch (c) {
+                case '{' -> parseObject();
+                case '[' -> parseArray();
+                case '"' -> parseString();
+                case 't' -> {
+                    expect("true");
+                    yield Boolean.TRUE;
+                }
+                case 'f' -> {
+                    expect("false");
+                    yield Boolean.FALSE;
+                }
+                case 'n' -> {
+                    expect("null");
+                    yield null;
+                }
+                default -> {
+                    if (c == '-' || (c >= '0' && c <= '9')) {
+                        yield parseNumber();
+                    }
+                    throw error("unexpected '" + c + "'");
+                }
+            };
+        }
+
+        private Map<String, Object> parseObject() {
+            Map<String, Object> result = new java.util.LinkedHashMap<>();
+            pos++;
+            skipWs();
+            if (peek() == '}') {
+                pos++;
+                return result;
+            }
+            while (true) {
+                skipWs();
+                String key = parseString();
+                skipWs();
+                if (peek() != ':') throw error("expected ':'");
+                pos++;
+                skipWs();
+                result.put(key, parseValue());
+                skipWs();
+                char c = peek();
+                if (c == ',') {
+                    pos++;
+                } else if (c == '}') {
+                    pos++;
+                    return result;
+                } else throw error("expected ',' or '}'");
+            }
+        }
+
+        private List<Object> parseArray() {
+            List<Object> result = new ArrayList<>();
+            pos++;
+            skipWs();
+            if (peek() == ']') {
+                pos++;
+                return result;
+            }
+            while (true) {
+                skipWs();
+                result.add(parseValue());
+                skipWs();
+                char c = peek();
+                if (c == ',') {
+                    pos++;
+                } else if (c == ']') {
+                    pos++;
+                    return result;
+                } else throw error("expected ',' or ']'");
+            }
+        }
+
+        private String parseString() {
+            StringBuilder sb = new StringBuilder();
+            pos++; // opening '"'
+            while (true) {
+                if (pos >= text.length()) throw error("unterminated string");
+                char c = text.charAt(pos++);
+                if (c == '"') return sb.toString();
+                if (c == '\\') {
+                    if (pos >= text.length()) throw error("unterminated escape");
+                    char e = text.charAt(pos++);
+                    switch (e) {
+                        case '"':
+                            sb.append('"');
+                            break;
+                        case '\\':
+                            sb.append('\\');
+                            break;
+                        case '/':
+                            sb.append('/');
+                            break;
+                        case 'b':
+                            sb.append('\b');
+                            break;
+                        case 'f':
+                            sb.append('\f');
+                            break;
+                        case 'n':
+                            sb.append('\n');
+                            break;
+                        case 'r':
+                            sb.append('\r');
+                            break;
+                        case 't':
+                            sb.append('\t');
+                            break;
+                        case 'u':
+                            if (pos + 4 > text.length()) throw error("truncated \\u");
+                            sb.append((char) Integer.parseInt(text.substring(pos, pos + 4), 16));
+                            pos += 4;
+                            break;
+                        default:
+                            throw error("invalid escape '\\" + e + "'");
+                    }
+                } else {
+                    sb.append(c);
+                }
+            }
+        }
+
+        private Object parseNumber() {
+            int start = pos;
+            while (pos < text.length()) {
+                char c = text.charAt(pos);
+                if ((c >= '0' && c <= '9') || c == '-' || c == '+' || c == '.' || c == 'e' || c == 'E') {
+                    pos++;
+                } else {
+                    break;
+                }
+            }
+            String lit = text.substring(start, pos);
+            if (lit.indexOf('.') < 0 && lit.indexOf('e') < 0 && lit.indexOf('E') < 0) {
+                return Long.parseLong(lit);
+            }
+            return Double.parseDouble(lit);
+        }
+
+        private void expect(String literal) {
+            if (!text.startsWith(literal, pos)) throw error("expected '" + literal + "'");
+            pos += literal.length();
+        }
+
+        private char peek() {
+            if (pos >= text.length()) throw error("unexpected end");
+            return text.charAt(pos);
+        }
+
+        private void skipWs() {
+            while (pos < text.length() && Character.isWhitespace(text.charAt(pos))) pos++;
+        }
+
+        private IllegalArgumentException error(String msg) {
+            int from = Math.max(0, pos - 20);
+            int to = Math.min(text.length(), pos + 20);
+            return new IllegalArgumentException(msg + " at " + pos + " near \"" + text.substring(from, to) + "\"");
+        }
     }
 }

--- a/it/extension3-its/src/it/shadow-failure/verify.groovy
+++ b/it/extension3-its/src/it/shadow-failure/verify.groovy
@@ -20,15 +20,13 @@ assert !log.contains('Scalpel: Building ') : "shadow mode must not trim the reac
 // module-a is an upstream prerequisite of the changed module-b and must NOT be flagged.
 File shadowFile = new File(basedir, 'target/scalpel-shadow.json')
 assert shadowFile.exists() : "shadow json must be written even when the build fails"
-String shadow = shadowFile.text
-assert shadow.contains('module-b')
-def fnStart = shadow.indexOf('"wouldHaveSkippedButFailed": [')
-assert fnStart >= 0 : "shadow json must carry wouldHaveSkippedButFailed"
-def fnOpen = shadow.indexOf('[', fnStart)
-def fnClose = shadow.indexOf(']', fnOpen)
-def fnSet = shadow.substring(fnOpen, fnClose)
-assert fnSet.contains('module-c') : "module-c must be flagged as would-have-skipped-but-failed"
-assert !fnSet.contains('module-a') : "module-a would have been built and must not be flagged"
+def shadow = new groovy.json.JsonSlurper().parseText(shadowFile.text)
+assert shadow.wouldHaveBuilt.any { it.contains('module-b') }
+assert shadow.wouldHaveSkippedButFailed != null : "shadow json must carry wouldHaveSkippedButFailed"
+assert shadow.wouldHaveSkippedButFailed.any { it.contains('module-c') } : \
+    "module-c must be flagged as would-have-skipped-but-failed"
+assert !shadow.wouldHaveSkippedButFailed.any { it.contains('module-a') } : \
+    "module-a would have been built and must not be flagged"
 
 File history = new File(basedir, 'target/scalpel-shadow-history.jsonl')
 assert history.exists() : "history jsonl must be appended even on failure"

--- a/it/extension3-its/src/it/shadow-includepaths/verify.groovy
+++ b/it/extension3-its/src/it/shadow-includepaths/verify.groovy
@@ -20,18 +20,13 @@ assert !log.contains('Scalpel: Building ') : "shadow mode must not trim the reac
 // duration counts toward the savings estimate.
 File shadowFile = new File(basedir, 'target/scalpel-shadow.json')
 assert shadowFile.exists() : "shadow json should be written"
-String shadow = shadowFile.text
-def skipStart = shadow.indexOf('"wouldHaveSkipped": [')
-def skipOpen = shadow.indexOf('[', skipStart)
-def skipClose = shadow.indexOf(']', skipOpen)
-def skipSet = shadow.substring(skipOpen, skipClose)
-assert skipSet.contains('module-b') : "downstream module-b outside includePaths must be in the would-skip set"
-def builtStart = shadow.indexOf('"wouldHaveBuilt": [')
-def builtOpen = shadow.indexOf('[', builtStart)
-def builtClose = shadow.indexOf(']', builtOpen)
-def builtSet = shadow.substring(builtOpen, builtClose)
-assert builtSet.contains('module-a') : "the changed module must be in the would-build set"
-assert !builtSet.contains('module-b') : "module-b outside includePaths scope must not be in the would-build set"
+def shadow = new groovy.json.JsonSlurper().parseText(shadowFile.text)
+assert shadow.wouldHaveSkipped.any { it.contains('module-b') } : \
+    "downstream module-b outside includePaths must be in the would-skip set"
+assert shadow.wouldHaveBuilt.any { it.contains('module-a') } : \
+    "the changed module must be in the would-build set"
+assert !shadow.wouldHaveBuilt.any { it.contains('module-b') } : \
+    "module-b outside includePaths scope must not be in the would-build set"
 
 File history = new File(basedir, 'target/scalpel-shadow-history.jsonl')
 assert history.exists()

--- a/it/extension3-its/src/it/shadow-mode/verify.groovy
+++ b/it/extension3-its/src/it/shadow-mode/verify.groovy
@@ -34,18 +34,16 @@ assert report.contains('SOURCE_CHANGE') : "module-b should have SOURCE_CHANGE re
 // independent module-c would be skipped.
 File shadowFile = new File(basedir, 'target/scalpel-shadow.json')
 assert shadowFile.exists() : "shadow json should be written at session end"
-String shadow = shadowFile.text
-assert shadow.contains('"mode": "shadow"')
-assert shadow.contains('"estimatedSecondsSaved"')
-assert shadow.contains('"wouldHaveSkippedButFailed"')
-assert shadow.contains('"wouldHaveBuilt"')
-def skipStart = shadow.indexOf('"wouldHaveSkipped": [')
-def skipOpen = shadow.indexOf('[', skipStart)
-def skipClose = shadow.indexOf(']', skipOpen)
-def skipSet = shadow.substring(skipOpen, skipClose)
-assert skipSet.contains('module-c') : "module-c must be in the would-skip set"
-assert !skipSet.contains('module-a') : "module-a is an upstream prerequisite and must NOT be in the would-skip set"
-assert shadow.contains('module-b')
+def shadow = new groovy.json.JsonSlurper().parseText(shadowFile.text)
+assert shadow.mode == 'shadow'
+assert shadow.estimatedSecondsSaved != null
+assert shadow.wouldHaveSkippedButFailed != null
+assert shadow.wouldHaveBuilt != null
+assert shadow.wouldHaveSkipped.any { it.contains('module-c') } : \
+    "module-c must be in the would-skip set"
+assert !shadow.wouldHaveSkipped.any { it.contains('module-a') } : \
+    "module-a is an upstream prerequisite and must NOT be in the would-skip set"
+assert shadow.wouldHaveBuilt.any { it.contains('module-b') }
 
 // Decision parity with report mode, scoped to what it actually proves: this fixture has
 // no transitively affected modules, so the report's skippedModules (report-mode

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
@@ -23,30 +23,25 @@ assert log.contains('BUILD SUCCESS')
 File reportFile = new File(basedir, 'target/scalpel-report.json')
 assert reportFile.exists() : "Report file should have been created at target/scalpel-report.json"
 
-String json = reportFile.text
-assert json.contains('"version": "2"') : "Report should contain version field"
-assert json.contains('"fullBuildTriggered": false') : "fullBuildTriggered should be false"
+def report = new groovy.json.JsonSlurper().parseText(reportFile.text)
+assert report.version == '2' : "Report should contain version 2"
+assert report.fullBuildTriggered == false : "fullBuildTriggered should be false"
 
 // module-a should be directly affected with SOURCE_CHANGE
-assert json.contains('"module-a"') : "module-a should appear in report"
-assert json.contains('"SOURCE_CHANGE"') : "module-a should have SOURCE_CHANGE reason"
-assert json.contains('"category": "DIRECT"') : "module-a should have DIRECT category"
+def moduleA = report.affectedModules.find { it.artifactId == 'module-a' }
+assert moduleA != null : "module-a should appear in report"
+assert moduleA.reasons.contains('SOURCE_CHANGE') : "module-a should have SOURCE_CHANGE reason"
+assert moduleA.category == 'DIRECT' : "module-a should have DIRECT category"
 
 // module-b should be downstream with testsSkippedReason=EXCLUDED_DOWNSTREAM
-assert json.contains('"module-b"') : "module-b should appear in report"
-assert json.contains('"DOWNSTREAM_DEPENDENT"') : "module-b should have DOWNSTREAM_DEPENDENT reason"
-
-// Parse module-b block and verify testsSkippedReason
-def moduleBStart = json.indexOf('"module-b"')
-assert moduleBStart >= 0
-def moduleBBlock = json.substring(json.lastIndexOf('{', moduleBStart), json.indexOf('}', moduleBStart) + 1)
-assert moduleBBlock.contains('"testsSkippedReason": "EXCLUDED_DOWNSTREAM"') : \
-    "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM in report, got: $moduleBBlock"
+def moduleB = report.affectedModules.find { it.artifactId == 'module-b' }
+assert moduleB != null : "module-b should appear in report"
+assert moduleB.reasons.contains('DOWNSTREAM_DEPENDENT') : "module-b should have DOWNSTREAM_DEPENDENT reason"
+assert moduleB.testsSkippedReason == 'EXCLUDED_DOWNSTREAM' : \
+    "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM in report, got: $moduleB"
 
 // module-c should be downstream but WITHOUT testsSkippedReason
-assert json.contains('"module-c"') : "module-c should appear in report"
-def moduleCStart = json.indexOf('"module-c"')
-assert moduleCStart >= 0
-def moduleCBlock = json.substring(json.lastIndexOf('{', moduleCStart), json.indexOf('}', moduleCStart) + 1)
-assert !moduleCBlock.contains('testsSkippedReason') : \
-    "module-c should NOT have testsSkippedReason in report, got: $moduleCBlock"
+def moduleC = report.affectedModules.find { it.artifactId == 'module-c' }
+assert moduleC != null : "module-c should appear in report"
+assert moduleC.testsSkippedReason == null : \
+    "module-c should NOT have testsSkippedReason in report, got: $moduleC"


### PR DESCRIPTION
## Summary

Fixes #96 — the report JSON contract had no escaping tests and test assertions relied on fragile substring extraction (`indexOf`/`lastIndexOf`) that would silently break with nested objects.

## Changes

### Escaping tests (core — `ScalpelReportTest`)
- **`toJson_escapesDoubleQuotes`** — quotes in `changedFiles` round-trip through the JSON parser
- **`toJson_escapesBackslashes`** — backslashes survive serialization/parsing
- **`toJson_escapesNewlinesAndCarriageReturns`** — literal newlines/CRs never appear in the JSON output; `\\n`/`\\r` escapes are verified both in raw output and by round-tripping
- **`toJson_escapesTabsAndControlCharacters`** — tabs produce `\\t`, BEL (0x07) produces `\\u0007`
- **`toJson_escapesSpecialCharsInModuleFields`** — compound test exercising quotes, backslashes, newlines and tabs in `baseBranch`, `groupId`, `artifactId`, and `path` fields

### Parsed JSON assertions (extension3 — `ScalpelLifecycleParticipantTest`)
Replaced all substring-based JSON helpers with proper parsed JSON navigation:
- `extractSection`, `extractModuleBlock` (indexOf/lastIndexOf on braces) → removed
- `modulePresent`, `moduleHasReason`, `moduleHasSourceSet`, `moduleHasField`, `moduleHasAnySourceSet`, `skippedModulePresent`, `skippedModuleHasReason` → rewritten to use `findAffectedModule`/`findSkippedModule` which parse the JSON and search the typed structure
- Evidence assertions now check the parsed `List<String>` instead of doing substring matches on hand-sliced blocks
- Added a compact `JsonReader` (mirrors core's `ScalpelReportSchemaTest.Json`)

### What was already in place
The golden-file test (`toJson_matchesGoldenFile`) and frozen field-set assertion (`schemaTopLevelProperties_matchEmittableFields`) already existed on `main` — this PR completes the remaining items from #96.

_AI agent (Hermes on behalf of gnodet)_