### PR TITLE
Fix #113: replace linear module scan with hash-based lookup

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -75,6 +75,7 @@ class ModuleMapper {
         // instead of a linear scan: O(M) setup + O(F × depth) lookups.
         Path rootDir = reactorRoot.toAbsolutePath().normalize();
         Map<String, MavenProject> moduleByDir = new HashMap<>();
+        Map<MavenProject, String> pathByProject = new HashMap<>();
         MavenProject rootProject = null;
         for (MavenProject project : projects) {
             String projectPath = getRelativePath(project, rootDir);
@@ -82,13 +83,14 @@ class ModuleMapper {
                 rootProject = project;
             } else {
                 moduleByDir.put(projectPath, project);
+                pathByProject.put(project, projectPath);
             }
         }
 
         for (String changedFile : changedFiles) {
             MavenProject matched = findOwningModule(changedFile, moduleByDir, rootProject);
             if (matched != null) {
-                String projectPath = matched == rootProject ? "" : getRelativePath(matched, rootDir);
+                String projectPath = matched == rootProject ? "" : pathByProject.get(matched);
                 boolean isTest = isTestPath(changedFile, projectPath);
                 Boolean existing = hasMainChange.get(matched);
                 if (existing == null) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -8,8 +8,7 @@
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -70,29 +69,37 @@ class ModuleMapper {
         // Track which changed file triggered each project (explain-mode evidence)
         Map<MavenProject, Set<String>> triggeringFiles = new LinkedHashMap<>();
 
-        // Sort projects by basedir depth (most specific first)
-        List<MavenProject> sortedProjects = new ArrayList<>(projects);
-        sortedProjects.sort(Comparator.comparingInt(
-                        (MavenProject p) -> getRelativePath(p, reactorRoot).length())
-                .reversed());
+        // Precompute the relative path per project once; normalize the reactor root
+        // once rather than on every call. Build a lookup map keyed by module directory
+        // so each changed file can find its owning module via parent-directory walks
+        // instead of a linear scan: O(M) setup + O(F × depth) lookups.
+        Path rootDir = reactorRoot.toAbsolutePath().normalize();
+        Map<String, MavenProject> moduleByDir = new HashMap<>();
+        MavenProject rootProject = null;
+        for (MavenProject project : projects) {
+            String projectPath = getRelativePath(project, rootDir);
+            if (projectPath.isEmpty()) {
+                rootProject = project;
+            } else {
+                moduleByDir.put(projectPath, project);
+            }
+        }
 
         for (String changedFile : changedFiles) {
-            for (MavenProject project : sortedProjects) {
-                String projectPath = getRelativePath(project, reactorRoot);
-                if (isFileInProjectSubtree(changedFile, projectPath)) {
-                    boolean isTest = isTestPath(changedFile, projectPath);
-                    Boolean existing = hasMainChange.get(project);
-                    if (existing == null) {
-                        hasMainChange.put(project, !isTest);
-                    } else if (!isTest) {
-                        hasMainChange.put(project, Boolean.TRUE);
-                    }
-                    if (explain) {
-                        triggeringFiles
-                                .computeIfAbsent(project, k -> new LinkedHashSet<>())
-                                .add(changedFile);
-                    }
-                    break;
+            MavenProject matched = findOwningModule(changedFile, moduleByDir, rootProject);
+            if (matched != null) {
+                String projectPath = matched == rootProject ? "" : getRelativePath(matched, rootDir);
+                boolean isTest = isTestPath(changedFile, projectPath);
+                Boolean existing = hasMainChange.get(matched);
+                if (existing == null) {
+                    hasMainChange.put(matched, !isTest);
+                } else if (!isTest) {
+                    hasMainChange.put(matched, Boolean.TRUE);
+                }
+                if (explain) {
+                    triggeringFiles
+                            .computeIfAbsent(matched, k -> new LinkedHashSet<>())
+                            .add(changedFile);
                 }
             }
         }
@@ -114,6 +121,35 @@ class ModuleMapper {
         return mapToProjectsClassified(changedFiles, projects, reactorRoot).getAllAffected();
     }
 
+    /**
+     * Finds the owning module for a changed file by walking its parent directories from
+     * deepest to root, doing hash lookups. The first match is the most specific (deepest-nested)
+     * module, preserving the same semantics as the previous length-descending sort approach.
+     *
+     * @return the owning project, or {@code null} if no module owns this file
+     */
+    private static MavenProject findOwningModule(
+            String changedFile, Map<String, MavenProject> moduleByDir, MavenProject rootProject) {
+        // Walk parent directories from deepest to shallowest
+        int slash = changedFile.lastIndexOf('/');
+        if (slash <= 0) {
+            // No directory separator (bare file like "README.md") or only at position 0:
+            // root project only matches files in subdirectories, not bare root files
+            return null;
+        }
+        while (slash > 0) {
+            String dir = changedFile.substring(0, slash);
+            MavenProject project = moduleByDir.get(dir);
+            if (project != null) {
+                return project;
+            }
+            slash = dir.lastIndexOf('/');
+        }
+        // No module directory matched; fall back to root project for files
+        // that are in subdirectories (src/main/..., scripts/..., etc.)
+        return rootProject;
+    }
+
     static boolean isTestPath(String changedFile, String projectPath) {
         String relativeToProject;
         if (projectPath.isEmpty()) {
@@ -124,21 +160,16 @@ class ModuleMapper {
         return relativeToProject.startsWith("src/test/");
     }
 
-    private static boolean isFileInProjectSubtree(String changedFile, String projectPath) {
-        if (projectPath.isEmpty()) {
-            // Root project: only match files in subdirectories (src/main/...),
-            // not bare repo-root files (README.md, .gitignore)
-            return changedFile.contains("/");
-        }
-        return changedFile.startsWith(projectPath + "/");
-    }
-
-    private String getRelativePath(MavenProject project, Path reactorRoot) {
+    /**
+     * Computes the relative path of a project directory against an already-normalized reactor root.
+     * The caller must pass {@code reactorRoot.toAbsolutePath().normalize()} to avoid redundant
+     * normalization on every call.
+     */
+    static String getRelativePath(MavenProject project, Path normalizedRoot) {
         Path projectDir = project.getBasedir().toPath().toAbsolutePath().normalize();
-        Path rootDir = reactorRoot.toAbsolutePath().normalize();
-        if (projectDir.equals(rootDir)) {
+        if (projectDir.equals(normalizedRoot)) {
             return "";
         }
-        return rootDir.relativize(projectDir).toString().replace('\\', '/');
+        return normalizedRoot.relativize(projectDir).toString().replace('\\', '/');
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -300,7 +300,9 @@ class PomChangeAnalyzer {
         Set<MavenProject> parents;
         Map<MavenProject, List<MavenProject>> bomImporters;
         List<MavenProject> allProjects;
-        Path reactorRoot;
+        /** Already-normalized reactor root — avoids redundant normalization in loops (#113). */
+        Path normalizedRoot;
+
         boolean explain;
 
         // Accumulators — populated during analysis
@@ -342,10 +344,12 @@ class PomChangeAnalyzer {
             ModelResolutionContext resolutionCtx) {
 
         // Build a map of relative POM path -> MavenProject
+        // Normalize the reactor root once rather than per project (#113)
+        Path normalizedRoot = reactorRoot.toAbsolutePath().normalize();
         Map<String, MavenProject> projectByPomPath = new LinkedHashMap<>();
         for (MavenProject project : allProjects) {
             Path pomPath = project.getFile().toPath().toAbsolutePath().normalize();
-            Path relativePom = reactorRoot.toAbsolutePath().normalize().relativize(pomPath);
+            Path relativePom = normalizedRoot.relativize(pomPath);
             projectByPomPath.put(relativePom.toString().replace('\\', '/'), project);
         }
 
@@ -372,7 +376,7 @@ class PomChangeAnalyzer {
         ctx.parents = parents;
         ctx.bomImporters = bomImporters;
         ctx.allProjects = allProjects;
-        ctx.reactorRoot = reactorRoot;
+        ctx.normalizedRoot = normalizedRoot;
         ctx.explain = explain;
 
         for (String changedPomPath : changedPomPaths) {
@@ -543,9 +547,7 @@ class PomChangeAnalyzer {
         // Use effective models for property and managed dep/plugin diffs.
         // Effective models have properties interpolated and profiles merged.
         Model newEffectiveModel = ctx.newEffectiveModels.getOrDefault(
-                ctx.reactorRoot
-                        .toAbsolutePath()
-                        .normalize()
+                ctx.normalizedRoot
                         .relativize(parentProject
                                 .getFile()
                                 .toPath()
@@ -591,7 +593,7 @@ class PomChangeAnalyzer {
                     changedManagedPlugins);
         }
 
-        Path absReactorRoot = ctx.reactorRoot.toAbsolutePath().normalize();
+        Path absReactorRoot = ctx.normalizedRoot;
 
         // Check each dependent (child or BOM importer) for impact.
         // Compare effective dependencies and plugins (the resolved dependency tree and

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -129,6 +129,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         logger.debug("Configuration: {}", config);
 
         Path reactorRoot = session.getRequest().getMultiModuleProjectDirectory().toPath();
+        // Normalize the reactor root once — hoisted out of all per-project loops (#113)
+        Path normalizedRoot = reactorRoot.toAbsolutePath().normalize();
         List<MavenProject> allProjects = session.getProjects();
 
         Timings timings = new Timings();
@@ -138,7 +140,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> allPomPaths = new LinkedHashSet<>();
             for (MavenProject project : allProjects) {
                 Path pomPath = project.getFile().toPath().toAbsolutePath().normalize();
-                Path relativePom = reactorRoot.toAbsolutePath().normalize().relativize(pomPath);
+                Path relativePom = normalizedRoot.relativize(pomPath);
                 allPomPaths.add(relativePom.toString().replace('\\', '/'));
             }
 
@@ -324,7 +326,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                     writeReport(
                             config,
-                            reactorRoot,
+                            normalizedRoot,
                             allProjects,
                             AnalysisContext.empty(
                                     changedFiles,
@@ -390,7 +392,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                     writeReport(
                             config,
-                            reactorRoot,
+                            normalizedRoot,
                             allProjects,
                             AnalysisContext.empty(
                                     changedFiles,
@@ -417,8 +419,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             List<PathMatcher> includeMatchers = compileGlobMatchers(config.getIncludePaths());
             if (!includeMatchers.isEmpty()) {
                 int beforeCount = allAffected.size();
-                directlyAffected.removeIf(p -> !matchesIncludePaths(p, includeMatchers, reactorRoot));
-                transitivelyAffected.keySet().removeIf(p -> !matchesIncludePaths(p, includeMatchers, reactorRoot));
+                directlyAffected.removeIf(p -> !matchesIncludePaths(p, includeMatchers, normalizedRoot));
+                transitivelyAffected.keySet().removeIf(p -> !matchesIncludePaths(p, includeMatchers, normalizedRoot));
                 testOnlyModules.retainAll(directlyAffected);
                 forceIncluded.retainAll(directlyAffected);
 
@@ -438,7 +440,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         }
                         writeReport(
                                 config,
-                                reactorRoot,
+                                normalizedRoot,
                                 allProjects,
                                 AnalysisContext.empty(
                                         changedFiles,
@@ -457,7 +459,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Write impacted module log if configured
             if (config.getImpactedLog() != null) {
-                writeImpactedLog(config, reactorRoot, allAffected);
+                writeImpactedLog(config, normalizedRoot, allAffected);
             }
 
             if (config.isPassiveMode()) {
@@ -480,7 +482,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
                 writeReport(
                         config,
-                        reactorRoot,
+                        normalizedRoot,
                         allProjects,
                         AnalysisContext.builder(
                                         changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
@@ -527,7 +529,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                     Set<String> wouldHaveBuilt = new LinkedHashSet<>();
                     java.util.function.Function<MavenProject, String> moduleKey = project -> {
-                        String path = relativePath(reactorRoot, project);
+                        String path = relativePath(normalizedRoot, project);
                         // The root aggregator relativizes to the empty string; report it as
                         // "." like the impacted log does (#84) so every module has a name.
                         return path.isEmpty() ? "." : path;
@@ -541,7 +543,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         decisionBuildSet = new ArrayList<>(decisionBuildSet);
                         decisionBuildSet.removeIf(project -> !affected.contains(project)
                                 && !decision.getUpstreamOnly().contains(project)
-                                && !matchesIncludePaths(project, includeMatchers, reactorRoot));
+                                && !matchesIncludePaths(project, includeMatchers, normalizedRoot));
                     }
                     for (MavenProject project : decisionBuildSet) {
                         wouldHaveBuilt.add(moduleKey.apply(project));
@@ -597,7 +599,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             oldEffectiveModels,
                             newEffectiveModels,
                             includeMatchers,
-                            reactorRoot,
+                            normalizedRoot,
                             collectCache,
                             oldCollectCache,
                             timings);
@@ -617,7 +619,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     buildSet = new ArrayList<>(buildSet);
                     buildSet.removeIf(p -> !finalAllAffected.contains(p)
                             && !trimResult.getUpstreamOnly().contains(p)
-                            && !matchesIncludePaths(p, includeMatchers, reactorRoot));
+                            && !matchesIncludePaths(p, includeMatchers, normalizedRoot));
                 }
                 logger.info(
                         "Scalpel: Building {} of {} modules: {}", buildSet.size(), allProjects.size(), keys(buildSet));
@@ -631,7 +633,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 // minus buildSet) is reviewable alongside the green trimmed build (#91)
                 writeReport(
                         config,
-                        reactorRoot,
+                        normalizedRoot,
                         allProjects,
                         AnalysisContext.builder(
                                         changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
@@ -1899,10 +1901,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private static String relativePath(Path reactorRoot, MavenProject project) {
-        return reactorRoot
-                .toAbsolutePath()
-                .normalize()
+    private static String relativePath(Path normalizedRoot, MavenProject project) {
+        return normalizedRoot
                 .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
                 .toString()
                 .replace('\\', '/');

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperTest.java
@@ -167,6 +167,149 @@ class ModuleMapperTest {
                 "src/ files at root should map to the root project");
     }
 
+    // --- Tests for the hash-lookup algorithm (#113) ---
+
+    @Test
+    void mapToProjectsClassified_nestedModulesMapToDeepest() {
+        Path root = tempDir;
+        // parent > parent/child > parent/child/grandchild
+        MavenProject rootProject =
+                createProject("com.example", "root", root.resolve("pom.xml").toFile());
+        MavenProject parentModule = createProject(
+                "com.example", "parent", root.resolve("parent/pom.xml").toFile());
+        MavenProject childModule = createProject(
+                "com.example", "child", root.resolve("parent/child/pom.xml").toFile());
+        MavenProject grandchild = createProject(
+                "com.example",
+                "grandchild",
+                root.resolve("parent/child/grandchild/pom.xml").toFile());
+        List<MavenProject> projects = List.of(rootProject, parentModule, childModule, grandchild);
+
+        // A file in grandchild should map to grandchild, not parent or child
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("parent/child/grandchild/src/main/java/App.java"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(
+                result.getMainAffected().contains(grandchild),
+                "file in deeply nested module should map to the deepest matching module");
+    }
+
+    @Test
+    void mapToProjectsClassified_fileInIntermediateModuleMapsCorrectly() {
+        Path root = tempDir;
+        MavenProject rootProject =
+                createProject("com.example", "root", root.resolve("pom.xml").toFile());
+        MavenProject parentModule = createProject(
+                "com.example", "parent", root.resolve("parent/pom.xml").toFile());
+        MavenProject childModule = createProject(
+                "com.example", "child", root.resolve("parent/child/pom.xml").toFile());
+        List<MavenProject> projects = List.of(rootProject, parentModule, childModule);
+
+        // A file in parent (not in child) should map to parent
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("parent/src/main/java/ParentApp.java"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(
+                result.getMainAffected().contains(parentModule),
+                "file in parent module should map to parent, not child");
+    }
+
+    @Test
+    void mapToProjectsClassified_largeFileSetPerformance() {
+        Path root = tempDir;
+        // Simulate a large reactor with many modules
+        List<MavenProject> projects = new java.util.ArrayList<>();
+        MavenProject rootProject =
+                createProject("com.example", "root", root.resolve("pom.xml").toFile());
+        projects.add(rootProject);
+        for (int i = 0; i < 200; i++) {
+            String moduleName = "module-" + i;
+            projects.add(createProject(
+                    "com.example",
+                    moduleName,
+                    root.resolve(moduleName + "/pom.xml").toFile()));
+        }
+
+        // 2000 changed files across various modules
+        Set<String> changedFiles = new LinkedHashSet<>();
+        for (int i = 0; i < 2000; i++) {
+            String module = "module-" + (i % 200);
+            changedFiles.add(module + "/src/main/java/com/example/Class" + i + ".java");
+        }
+
+        // This should complete quickly with hash-based lookup
+        long start = System.nanoTime();
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+        long elapsed = System.nanoTime() - start;
+
+        // All 200 modules should be affected
+        assertEquals(200, result.getAllAffected().size());
+        // Should complete in well under 1 second (hash lookups are O(1))
+        assertTrue(
+                elapsed < 1_000_000_000L,
+                "Large file set should complete in <1s but took " + (elapsed / 1_000_000) + "ms");
+    }
+
+    @Test
+    void mapToProjectsClassified_fileUnderNonModuleDir_fallsToRoot() {
+        Path root = tempDir;
+        MavenProject rootProject =
+                createProject("com.example", "root", root.resolve("pom.xml").toFile());
+        MavenProject moduleA = createProject(
+                "com.example", "module-a", root.resolve("module-a/pom.xml").toFile());
+        List<MavenProject> projects = List.of(rootProject, moduleA);
+
+        // A file under a directory that isn't a module should fall back to root
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("scripts/build.sh"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(
+                result.getMainAffected().contains(rootProject),
+                "file in non-module dir should fall back to root project");
+    }
+
+    @Test
+    void mapToProjectsClassified_explainDisabled_noTriggeringFiles() {
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("module-a/src/main/java/Foo.java"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root, false);
+
+        assertEquals(1, result.getMainAffected().size());
+        assertTrue(result.getTriggeringFiles().isEmpty(), "triggering files should be empty when explain=false");
+    }
+
+    @Test
+    void getRelativePath_normalizedRootOptimization() {
+        Path root = tempDir;
+        Path normalizedRoot = root.toAbsolutePath().normalize();
+        MavenProject project = createProject(
+                "com.example", "module-a", root.resolve("module-a/pom.xml").toFile());
+
+        // Static getRelativePath should work with pre-normalized root
+        String relPath = ModuleMapper.getRelativePath(project, normalizedRoot);
+        assertEquals("module-a", relPath);
+    }
+
+    @Test
+    void getRelativePath_rootProject() {
+        Path root = tempDir;
+        Path normalizedRoot = root.toAbsolutePath().normalize();
+        MavenProject project =
+                createProject("com.example", "root", root.resolve("pom.xml").toFile());
+
+        String relPath = ModuleMapper.getRelativePath(project, normalizedRoot);
+        assertEquals("", relPath, "root project should have empty relative path");
+    }
+
     private List<MavenProject> createProjects(Path root) {
         MavenProject parent =
                 createProject("com.example", "parent", root.resolve("pom.xml").toFile());


### PR DESCRIPTION
## Summary

Fixes #113: Module lookup was a linear scan with per-file path normalization, causing O(F × M) normalizations on large PRs.

## Changes

### ModuleMapper (core fix)
- **Before:** For each changed file, linear scan through all projects computing `getRelativePath()` (two `toAbsolutePath().normalize()` calls, a `relativize`, a `toString`). Sort comparator added O(M log M) more normalization calls. At F=5000 files × M=500 modules = 2.5M normalizations.
- **After:** Precompute relative paths once per project, build a `HashMap<String, MavenProject>` keyed by module directory. For each changed file, walk parent directories doing O(1) hash lookups. **Complexity: O(M) setup + O(F × depth) lookups** — typically depth ≤ 5, making this effectively O(F).

### ScalpelLifecycleParticipant (hoist normalization)
- Hoist `reactorRoot.toAbsolutePath().normalize()` into a single `normalizedRoot` computed once at the top of `afterProjectsRead`, replacing per-iteration normalization across:
  - POM path collection loop
  - `writeReport`, `matchesIncludePaths`, `writeImpactedLog`, `applySkipTests`, `moduleKey` lambda
  - `relativePath()` method now expects a pre-normalized root

### PomChangeAnalyzer (hoist normalization)
- Same pattern: normalize `reactorRoot` once in `analyzeChanges()`, store as `normalizedRoot` in the `AnalysisContext`
- Eliminated per-call normalization in `analyzeParentPomChange` and `hasEffectiveChanges`

### Tests
- Nested module depth resolution (grandchild gets deepest match)
- Intermediate module mapping (parent module, not child)
- Performance: 200 modules × 2000 files completes in <1s
- Non-module directory fallback to root project
- `explain=false` suppresses triggering file collection
- `getRelativePath` with pre-normalized root

_AI agent (Hermes on behalf of gnodet)_