### PR TITLE
Fix #106: cross-platform CI and Windows test fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 .mvn/nisse.properties export-subst
+mvnw text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,37 @@ jobs:
       maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'
       jdk-matrix: '[ "17", "21", "25" ]'
       maven-matrix: '[ "3.9.16" ]'
+
+  # The reusable parent workflow's test job hardcodes runs-on: ubuntu-latest
+  # (the os-matrix input only names artifacts), so Windows and macOS never
+  # execute anything. Until that is fixed in the parent, Scalpel runs its own
+  # per-OS unit-test matrix: path-separator defects are exactly what only a
+  # real Windows leg can catch (#106). Unit tests are ~3s per leg; the heavy
+  # verify (ITs) stays in the build job above.
+  unit-test-matrix:
+    name: Unit tests (${{ matrix.os }}, ${{ matrix.java }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        # The build itself requires JDK 21+ (parent-62 enforcer
+        # requireBuildtimeJavaVersion.range=[21,)); 17 is only the
+        # bytecode floor. Two build JDKs satisfy the issue's ask.
+        java: [ 21, 25 ]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: zulu
+      - name: Cache Maven repository
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-${{ matrix.java }}-
+      - name: Unit tests
+        run: ./mvnw test -e -B -V
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         java: [ 21, 25 ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Maveniverse Scalpel
 
 Requirements:
-* Java: 8+
+* Java: 17+
 * Maven: 3.9.x+
 
 Scalpel is a Maven core extension that detects which modules in a multi-module reactor are affected by a git changeset. It can trim the reactor to only build affected modules, skip tests on unaffected modules, or produce a JSON report of affected modules for consumption by CI scripts.

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelCoreTest.java
@@ -268,8 +268,20 @@ class ScalpelCoreTest {
     @Test
     void detectChanges_notAGitRepo_returnsNull() throws Exception {
         // Create a temp directory outside the project tree to avoid JGit walking up
-        // and discovering the project's own .git (java.io.tmpdir may be inside the repo)
-        Path nonGitDir = Files.createTempDirectory(Path.of("/tmp"), "scalpel-test-no-git");
+        // and discovering the project's own .git (java.io.tmpdir may be inside the repo
+        // because the parent POM's surefire config overrides it to target/surefire-tmp).
+        // On Unix /tmp is fine; on Windows fall back to TEMP/TMP env vars which always
+        // point outside the checkout.
+        Path systemTmp = Path.of("/tmp");
+        if (!Files.isDirectory(systemTmp)) {
+            // Windows: use TEMP or TMP environment variable
+            String envTmp = System.getenv("TEMP");
+            if (envTmp == null) envTmp = System.getenv("TMP");
+            if (envTmp == null) envTmp = System.getenv("TMPDIR");
+            assertNotNull(envTmp, "Cannot locate a system temp directory outside the project tree");
+            systemTmp = Path.of(envTmp);
+        }
+        Path nonGitDir = Files.createTempDirectory(systemTmp, "scalpel-test-no-git");
         try {
             ScalpelCore core = new ScalpelCore(new GitChangeDetector());
             Properties sys = new Properties();

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -587,7 +587,7 @@ class ScalpelReportTest {
         try (InputStream is =
                 getClass().getResourceAsStream("/eu/maveniverse/maven/scalpel/core/golden-report-v2.json")) {
             assertNotNull(is, "golden-report-v2.json must be on the test classpath");
-            expected = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            expected = new String(is.readAllBytes(), StandardCharsets.UTF_8).replace("\r\n", "\n");
         }
 
         assertEquals(

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -2418,6 +2418,9 @@ class PomChangeAnalyzerTest {
     void analyzeChanges_unreadableResourceFileMarksChildAsAffected() throws Exception {
         // When a filtered resource file cannot be read (IOException),
         // the child should be conservatively marked as affected.
+        assumeTrue(
+                tempDir.getFileSystem().supportedFileAttributeViews().contains("posix"),
+                "POSIX file permissions not supported on this filesystem (e.g. Windows NTFS)");
         Path root = setupReactorRoot();
         List<MavenProject> projects = createReactorWithPropertyUsage(root);
 
@@ -2470,6 +2473,9 @@ class PomChangeAnalyzerTest {
     void analyzeChanges_unreadableResourceDirectoryMarksChildAsAffected() throws Exception {
         // When a filtered resource subdirectory cannot be listed (IOException on
         // DirectoryStream), the child should be conservatively marked as affected.
+        assumeTrue(
+                tempDir.getFileSystem().supportedFileAttributeViews().contains("posix"),
+                "POSIX file permissions not supported on this filesystem (e.g. Windows NTFS)");
         Path root = setupReactorRoot();
         List<MavenProject> projects = createReactorWithPropertyUsage(root);
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -3915,6 +3916,10 @@ class ScalpelLifecycleParticipantTest {
 
     @Test
     void impactedLog_newlineInModulePathCannotForgeEntries() throws Exception {
+        // Newline characters are illegal in file paths on Windows
+        assumeTrue(
+                !System.getProperty("os.name", "").startsWith("Win"),
+                "Windows does not allow newline characters in file paths");
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);
 


### PR DESCRIPTION
## Problem

The parent workflow (`maveniverse/parent`) CI has a bug where the `test` job declares an `os` matrix axis but `runs-on` is hardcoded to `ubuntu-latest`, so Windows and macOS legs are actually duplicate Ubuntu runs. This means path-separator defects — exactly what Scalpel needs to catch — go undetected.

## Fix

**New `unit-test-matrix` CI job** that runs unit tests on a real OS matrix:
- **OS**: ubuntu-latest, windows-latest, macOS-latest
- **JDK**: 21, 25 (17 excluded — parent-62 enforcer requires `[21,)`)
- Independent from the existing Verify job (which keeps running ITs via the parent workflow)
- Actions pinned to commit SHAs per repo policy (#102)
- `shell: bash` ensures `./mvnw` works on Windows

**Windows test fixes:**
- `ScalpelCoreTest.detectChanges_notAGitRepo_returnsNull`: hardcoded `Path.of("/tmp")` doesn't exist on Windows — now falls back to `TEMP`/`TMP`/`TMPDIR` env vars
- `ScalpelReportTest.toJson_matchesGoldenFile`: golden file comparison failed on Windows due to CRLF — now normalizes line endings before comparison
- `PomChangeAnalyzerTest`: two POSIX-permission tests (`unreadableResourceFile`, `unreadableResourceDirectory`) now skip on non-POSIX filesystems via `assumeTrue` guard (NTFS doesn't support `setPosixFilePermissions`)
- `ScalpelLifecycleParticipantTest.impactedLog_newlineInModulePathCannotForgeEntries`: skip on Windows where newline characters are illegal in file paths

**Additional fixes:**
- `.gitattributes`: pin `mvnw` to LF so CRLF-default Windows checkouts don't break the wrapper under bash
- README: correct stale Java requirement from `8+` to `17+` (bytecode floor since the JDK 17 bump)

Supersedes #179.
Fixes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the requirements to clarify that Java 17 or newer is required.

- **Quality Improvements**
  - Expanded automated testing across Ubuntu, Windows, and macOS with JDK 21 and 25.
  - Improved test reliability across different operating systems, filesystems, temporary-directory configurations, and line-ending formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->