### PR TITLE
Fix #116: replace per-project DFS with precomputed BFS traversals

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -1880,9 +1880,10 @@ class PomChangeAnalyzer {
 
         // Expand to all descendants via BFS per parent
         Map<MavenProject, List<MavenProject>> descendantMap = new LinkedHashMap<>();
-        for (MavenProject parent : childrenMap.keySet()) {
+        for (Map.Entry<MavenProject, List<MavenProject>> entry : childrenMap.entrySet()) {
+            MavenProject parent = entry.getKey();
             List<MavenProject> descendants = new ArrayList<>();
-            java.util.ArrayDeque<MavenProject> queue = new java.util.ArrayDeque<>(childrenMap.get(parent));
+            java.util.ArrayDeque<MavenProject> queue = new java.util.ArrayDeque<>(entry.getValue());
             while (!queue.isEmpty()) {
                 MavenProject child = queue.poll();
                 descendants.add(child);

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -299,6 +299,7 @@ class PomChangeAnalyzer {
         Map<String, Model> newEffectiveModels;
         Set<MavenProject> parents;
         Map<MavenProject, List<MavenProject>> bomImporters;
+        Map<MavenProject, List<MavenProject>> descendantMap;
         List<MavenProject> allProjects;
         Path reactorRoot;
         boolean explain;
@@ -349,8 +350,10 @@ class PomChangeAnalyzer {
             projectByPomPath.put(relativePom.toString().replace('\\', '/'), project);
         }
 
-        // Build set of projects that have children in the reactor
-        Set<MavenProject> parents = findParentProjects(allProjects);
+        // Build parent→descendants map once for efficient collectDependents lookups (#116).
+        // The key set of this map doubles as the set of parent projects, replacing findParentProjects().
+        Map<MavenProject, List<MavenProject>> descendantMap = buildDescendantMap(allProjects);
+        Set<MavenProject> parents = descendantMap.keySet();
 
         // Build map of reactor modules imported as BOMs by other reactor modules
         Map<MavenProject, List<MavenProject>> bomImporters = findBomImporters(allProjects);
@@ -371,6 +374,7 @@ class PomChangeAnalyzer {
         ctx.newEffectiveModels = newEffectiveModels;
         ctx.parents = parents;
         ctx.bomImporters = bomImporters;
+        ctx.descendantMap = descendantMap;
         ctx.allProjects = allProjects;
         ctx.reactorRoot = reactorRoot;
         ctx.explain = explain;
@@ -414,7 +418,7 @@ class PomChangeAnalyzer {
         }
 
         // Determine all dependent modules (children via parent inheritance + BOM importers)
-        List<MavenProject> dependents = collectDependents(project, ctx.parents, ctx.bomImporters, ctx.allProjects);
+        List<MavenProject> dependents = collectDependents(project, ctx.parents, ctx.bomImporters, ctx.descendantMap);
 
         if (dependents.isEmpty()) {
             // Leaf module: its own POM changed, mark it as affected
@@ -1764,39 +1768,21 @@ class PomChangeAnalyzer {
         }
     }
 
-    private Set<MavenProject> findParentProjects(List<MavenProject> allProjects) {
-        Map<String, MavenProject> projectByGA = new LinkedHashMap<>();
-        for (MavenProject project : allProjects) {
-            projectByGA.put(key(project), project);
-        }
-        Set<MavenProject> parents = new LinkedHashSet<>();
-        for (MavenProject project : allProjects) {
-            MavenProject parent = project.getParent();
-            if (parent != null) {
-                MavenProject reactorParent = projectByGA.get(key(parent));
-                if (reactorParent != null) {
-                    parents.add(reactorParent);
-                }
-            }
-        }
-        return parents;
-    }
-
     /**
-     * Collect all modules that depend on the given project, combining reactor children
-     * (via parent inheritance) and BOM importers (via import-scope dependency management).
+     * Collect all modules that depend on the given project, combining reactor descendants
+     * (via parent inheritance, precomputed) and BOM importers (via import-scope dependency management).
      */
     private List<MavenProject> collectDependents(
             MavenProject project,
             Set<MavenProject> parents,
             Map<MavenProject, List<MavenProject>> bomImporters,
-            List<MavenProject> allProjects) {
+            Map<MavenProject, List<MavenProject>> descendantMap) {
         List<MavenProject> dependents = new ArrayList<>();
         int childCount = 0;
         if (parents.contains(project)) {
-            List<MavenProject> children = findChildren(project, allProjects);
-            dependents.addAll(children);
-            childCount = children.size();
+            List<MavenProject> descendants = descendantMap.getOrDefault(project, List.of());
+            dependents.addAll(descendants);
+            childCount = descendants.size();
             if (logger.isDebugEnabled()) {
                 logger.debug("{} has {} child modules via parent inheritance", key(project), childCount);
             }
@@ -1866,26 +1852,48 @@ class PomChangeAnalyzer {
         return "pom".equals(dep.getType()) && "import".equals(dep.getScope());
     }
 
-    private List<MavenProject> findChildren(MavenProject parent, List<MavenProject> allProjects) {
-        List<MavenProject> children = new ArrayList<>();
+    /**
+     * Build a map of parent project → list of all descendant projects (children, grandchildren, …)
+     * in the reactor.  Uses a precomputed parent→direct-children adjacency map and coordinate key
+     * cache to avoid the O(M² × depth) cost of the previous per-project isDescendantOf scan.
+     */
+    private Map<MavenProject, List<MavenProject>> buildDescendantMap(List<MavenProject> allProjects) {
+        // Build GA-key → reactor project lookup
+        Map<String, MavenProject> projectByGA = new LinkedHashMap<>();
         for (MavenProject project : allProjects) {
-            if (project != parent && isDescendantOf(project, parent)) {
-                children.add(project);
-            }
+            projectByGA.put(key(project), project);
         }
-        return children;
-    }
 
-    private boolean isDescendantOf(MavenProject project, MavenProject ancestor) {
-        String ancestorKey = key(ancestor);
-        MavenProject current = project.getParent();
-        while (current != null) {
-            if (key(current).equals(ancestorKey)) {
-                return true;
+        // Build parent → direct children adjacency map
+        Map<MavenProject, List<MavenProject>> childrenMap = new LinkedHashMap<>();
+        for (MavenProject project : allProjects) {
+            MavenProject parent = project.getParent();
+            if (parent != null) {
+                MavenProject reactorParent = projectByGA.get(key(parent));
+                if (reactorParent != null) {
+                    childrenMap
+                            .computeIfAbsent(reactorParent, k -> new ArrayList<>())
+                            .add(project);
+                }
             }
-            current = current.getParent();
         }
-        return false;
+
+        // Expand to all descendants via BFS per parent
+        Map<MavenProject, List<MavenProject>> descendantMap = new LinkedHashMap<>();
+        for (MavenProject parent : childrenMap.keySet()) {
+            List<MavenProject> descendants = new ArrayList<>();
+            java.util.ArrayDeque<MavenProject> queue = new java.util.ArrayDeque<>(childrenMap.get(parent));
+            while (!queue.isEmpty()) {
+                MavenProject child = queue.poll();
+                descendants.add(child);
+                List<MavenProject> grandchildren = childrenMap.get(child);
+                if (grandchildren != null) {
+                    queue.addAll(grandchildren);
+                }
+            }
+            descendantMap.put(parent, descendants);
+        }
+        return descendantMap;
     }
 
     /**

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -87,22 +87,7 @@ class ReactorTrimmer {
                 }
                 for (MavenProject ds : directDownstream.getOrDefault(project, List.of())) {
                     if (visited.add(ds)) {
-                        buildSet.add(ds);
-                        if (config.isExplain()) {
-                            addReason(buildReasons, ds, "downstream of " + key(project));
-                        }
-                        String scope = getDependencyScope(ds, project);
-                        if ("test".equals(scope)) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(project));
-                            }
-                            downstreamTestOnly.add(ds);
-                        } else {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(project));
-                            }
-                            downstreamOnly.add(ds);
-                        }
+                        addDownstream(ds, project, buildSet, downstreamOnly, downstreamTestOnly, buildReasons, config);
                         queue.add(ds);
                     }
                 }
@@ -112,22 +97,7 @@ class ReactorTrimmer {
                 MavenProject current = queue.poll();
                 for (MavenProject ds : directDownstream.getOrDefault(current, List.of())) {
                     if (visited.add(ds)) {
-                        buildSet.add(ds);
-                        if (config.isExplain()) {
-                            addReason(buildReasons, ds, "downstream of " + key(current));
-                        }
-                        String scope = getDependencyScope(ds, current);
-                        if ("test".equals(scope)) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(current));
-                            }
-                            downstreamTestOnly.add(ds);
-                        } else {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(current));
-                            }
-                            downstreamOnly.add(ds);
-                        }
+                        addDownstream(ds, current, buildSet, downstreamOnly, downstreamTestOnly, buildReasons, config);
                         queue.add(ds);
                     }
                 }
@@ -156,25 +126,10 @@ class ReactorTrimmer {
                         }
                     } else {
                         visited.add(ds);
-                        buildSet.add(ds);
                         testOnlyOrigins
                                 .computeIfAbsent(ds, k -> new LinkedHashSet<>())
                                 .add(project);
-                        if (config.isExplain()) {
-                            addReason(buildReasons, ds, "downstream of " + key(project));
-                        }
-                        String scope = getDependencyScope(ds, project);
-                        if ("test".equals(scope)) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(project));
-                            }
-                            downstreamTestOnly.add(ds);
-                        } else {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(project));
-                            }
-                            downstreamOnly.add(ds);
-                        }
+                        addDownstream(ds, project, buildSet, downstreamOnly, downstreamTestOnly, buildReasons, config);
                         queue.add(ds);
                     }
                 }
@@ -211,25 +166,10 @@ class ReactorTrimmer {
                         }
                     } else {
                         visited.add(ds);
-                        buildSet.add(ds);
                         testOnlyOrigins
                                 .computeIfAbsent(ds, k -> new LinkedHashSet<>())
                                 .addAll(currentTestOnlyOrigins);
-                        if (config.isExplain()) {
-                            addReason(buildReasons, ds, "downstream of " + key(current));
-                        }
-                        String scope = getDependencyScope(ds, current);
-                        if ("test".equals(scope)) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(current));
-                            }
-                            downstreamTestOnly.add(ds);
-                        } else {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(current));
-                            }
-                            downstreamOnly.add(ds);
-                        }
+                        addDownstream(ds, current, buildSet, downstreamOnly, downstreamTestOnly, buildReasons, config);
                         queue.add(ds);
                     }
                 }
@@ -280,6 +220,37 @@ class ReactorTrimmer {
         }
 
         return new TrimResult(result, directlyAffected, upstreamOnly, downstreamOnly, downstreamTestOnly, buildReasons);
+    }
+
+    /**
+     * Add a downstream project to the build set, classify its scope, log, and record the reason.
+     * Extracted to eliminate duplication across the four BFS entry points (Phase 1 seed/drain,
+     * Phase 2 seed/drain).
+     */
+    private void addDownstream(
+            MavenProject downstream,
+            MavenProject cause,
+            Set<MavenProject> buildSet,
+            Set<MavenProject> downstreamOnly,
+            Set<MavenProject> downstreamTestOnly,
+            Map<MavenProject, List<String>> buildReasons,
+            ScalpelConfiguration config) {
+        buildSet.add(downstream);
+        if (config.isExplain()) {
+            addReason(buildReasons, downstream, "downstream of " + key(cause));
+        }
+        String scope = getDependencyScope(downstream, cause);
+        if ("test".equals(scope)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Adding test-scoped downstream {} of {}", key(downstream), key(cause));
+            }
+            downstreamTestOnly.add(downstream);
+        } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Adding downstream dependent {} of {}", key(downstream), key(cause));
+            }
+            downstreamOnly.add(downstream);
+        }
     }
 
     private static void addReason(Map<MavenProject, List<String>> reasons, MavenProject project, String reason) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -10,11 +10,14 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -41,6 +44,18 @@ class ReactorTrimmer {
             ProjectDependencyGraph graph,
             ScalpelConfiguration config) {
 
+        List<MavenProject> sortedProjects = graph.getSortedProjects();
+
+        // Build forward and reverse adjacency maps once from direct (non-transitive) edges.
+        // This replaces per-project calls to graph.getDownstreamProjects(p, true) /
+        // graph.getUpstreamProjects(p, true), each of which performs a fresh uncached DFS.
+        Map<MavenProject, List<MavenProject>> directDownstream = new HashMap<>(sortedProjects.size());
+        Map<MavenProject, List<MavenProject>> directUpstream = new HashMap<>(sortedProjects.size());
+        for (MavenProject project : sortedProjects) {
+            directDownstream.put(project, graph.getDownstreamProjects(project, false));
+            directUpstream.put(project, graph.getUpstreamProjects(project, false));
+        }
+
         Set<MavenProject> buildSet = new LinkedHashSet<>(directlyAffected);
         Set<MavenProject> downstreamOnly = new LinkedHashSet<>();
         Set<MavenProject> downstreamTestOnly = new LinkedHashSet<>();
@@ -48,64 +63,89 @@ class ReactorTrimmer {
         Map<MavenProject, List<String>> buildReasons = new LinkedHashMap<>();
 
         if (config.isAlsoMakeDependents()) {
-            for (MavenProject project : new ArrayList<>(directlyAffected)) {
+            // Multi-source BFS over the forward edge set: start from all directly-affected
+            // projects and walk the transitive downstream closure in one pass.
+            Queue<MavenProject> queue = new ArrayDeque<>();
+            // Track which (source, downstream) pairs should be filtered for test-only
+            // We need to remember which "source" triggered each downstream addition
+            // so we can check test-jar dependency correctly.
+            // Strategy: BFS from each directly-affected project, but share visited set.
+            Set<MavenProject> visited = new LinkedHashSet<>(directlyAffected);
+            for (MavenProject project : directlyAffected) {
                 boolean isTestOnly = testOnlyProjects.contains(project);
-                List<MavenProject> downstream = graph.getDownstreamProjects(project, true);
-                if (!downstream.isEmpty()) {
-                    for (MavenProject ds : downstream) {
-                        if (directlyAffected.contains(ds)) {
-                            continue;
+                for (MavenProject ds : directDownstream.getOrDefault(project, List.of())) {
+                    if (visited.contains(ds)) {
+                        continue;
+                    }
+                    if (isTestOnly && !hasTestJarDependency(ds, project)) {
+                        logger.debug(
+                                "Skipping downstream {} of test-only module {} (no test-jar dependency)",
+                                key(ds),
+                                key(project));
+                        continue;
+                    }
+                    visited.add(ds);
+                    buildSet.add(ds);
+                    if (config.isExplain()) {
+                        addReason(buildReasons, ds, "downstream of " + key(project));
+                    }
+                    String scope = getDependencyScope(ds, project);
+                    if ("test".equals(scope)) {
+                        logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(project));
+                        downstreamTestOnly.add(ds);
+                    } else {
+                        logger.debug("Adding downstream dependent {} of {}", key(ds), key(project));
+                        downstreamOnly.add(ds);
+                    }
+                    queue.add(ds);
+                }
+            }
+            // Continue BFS for transitive downstream (non-test-only filtering applies
+            // only at the first hop from a directly-affected test-only project)
+            while (!queue.isEmpty()) {
+                MavenProject current = queue.poll();
+                for (MavenProject ds : directDownstream.getOrDefault(current, List.of())) {
+                    if (visited.add(ds)) {
+                        buildSet.add(ds);
+                        if (config.isExplain()) {
+                            addReason(buildReasons, ds, "downstream of " + key(current));
                         }
-                        // For test-only modules, only propagate to test-jar consumers
-                        if (isTestOnly && !hasTestJarDependency(ds, project)) {
-                            logger.debug(
-                                    "Skipping downstream {} of test-only module {} (no test-jar dependency)",
-                                    key(ds),
-                                    key(project));
-                            continue;
+                        String scope = getDependencyScope(ds, current);
+                        if ("test".equals(scope)) {
+                            logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(current));
+                            downstreamTestOnly.add(ds);
+                        } else {
+                            logger.debug("Adding downstream dependent {} of {}", key(ds), key(current));
+                            downstreamOnly.add(ds);
                         }
-                        if (buildSet.add(ds)) {
-                            if (config.isExplain()) {
-                                addReason(buildReasons, ds, "downstream of " + key(project));
-                            }
-                            // Check if downstream depends on the changed module via test scope only
-                            String scope = getDependencyScope(ds, project);
-                            if ("test".equals(scope)) {
-                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(project));
-                                downstreamTestOnly.add(ds);
-                            } else {
-                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(project));
-                                downstreamOnly.add(ds);
-                            }
-                        }
+                        queue.add(ds);
                     }
                 }
             }
         }
 
         if (config.isAlsoMake()) {
-            for (MavenProject project : new ArrayList<>(buildSet)) {
-                List<MavenProject> upstream = graph.getUpstreamProjects(project, true);
-                if (!upstream.isEmpty()) {
-                    int newUpstream = 0;
-                    for (MavenProject us : upstream) {
+            // Multi-source BFS over the reverse edge set: start from the entire build set
+            // (directly affected + downstream) and walk the transitive upstream closure.
+            Queue<MavenProject> queue = new ArrayDeque<>(buildSet);
+            Set<MavenProject> visited = new LinkedHashSet<>(buildSet);
+            while (!queue.isEmpty()) {
+                MavenProject current = queue.poll();
+                for (MavenProject us : directUpstream.getOrDefault(current, List.of())) {
+                    if (visited.add(us)) {
                         if (!directlyAffected.contains(us)
                                 && !downstreamOnly.contains(us)
-                                && !downstreamTestOnly.contains(us)
-                                && buildSet.add(us)) {
+                                && !downstreamTestOnly.contains(us)) {
                             upstreamOnly.add(us);
                             if (config.isExplain()) {
-                                addReason(buildReasons, us, "upstream of " + key(project));
+                                addReason(buildReasons, us, "upstream of " + key(current));
                             }
-                            newUpstream++;
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding upstream dependency {} of {}", key(us), key(current));
+                            }
                         }
-                    }
-                    if (newUpstream > 0 && logger.isDebugEnabled()) {
-                        logger.debug(
-                                "Adding {} upstream dependencies of {} ({} total upstream of this module)",
-                                newUpstream,
-                                key(project),
-                                upstream.size());
+                        buildSet.add(us);
+                        queue.add(us);
                     }
                 }
             }
@@ -120,7 +160,6 @@ class ReactorTrimmer {
                 upstreamOnly.size());
 
         // Sort in reactor build order
-        List<MavenProject> sortedProjects = graph.getSortedProjects();
         List<MavenProject> result = new ArrayList<>();
         for (MavenProject project : sortedProjects) {
             if (buildSet.contains(project)) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -82,31 +82,37 @@ class ReactorTrimmer {
                         continue;
                     }
                     if (isTestOnly && !hasTestJarDependency(ds, project)) {
-                        logger.debug(
-                                "Skipping downstream {} of test-only module {} (no test-jar dependency)",
-                                key(ds),
-                                key(project));
-                        continue;
-                    }
-                    visited.add(ds);
-                    buildSet.add(ds);
-                    if (isTestOnly) {
-                        testOnlyOrigins
-                                .computeIfAbsent(ds, k -> new LinkedHashSet<>())
-                                .add(project);
-                    }
-                    if (config.isExplain()) {
-                        addReason(buildReasons, ds, "downstream of " + key(project));
-                    }
-                    String scope = getDependencyScope(ds, project);
-                    if ("test".equals(scope)) {
-                        logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(project));
-                        downstreamTestOnly.add(ds);
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Skipping downstream {} of test-only module {} (no test-jar dependency)",
+                                    key(ds),
+                                    key(project));
+                        }
                     } else {
-                        logger.debug("Adding downstream dependent {} of {}", key(ds), key(project));
-                        downstreamOnly.add(ds);
+                        visited.add(ds);
+                        buildSet.add(ds);
+                        if (isTestOnly) {
+                            testOnlyOrigins
+                                    .computeIfAbsent(ds, k -> new LinkedHashSet<>())
+                                    .add(project);
+                        }
+                        if (config.isExplain()) {
+                            addReason(buildReasons, ds, "downstream of " + key(project));
+                        }
+                        String scope = getDependencyScope(ds, project);
+                        if ("test".equals(scope)) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(project));
+                            }
+                            downstreamTestOnly.add(ds);
+                        } else {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(project));
+                            }
+                            downstreamOnly.add(ds);
+                        }
+                        queue.add(ds);
                     }
-                    queue.add(ds);
                 }
             }
             // Continue BFS for transitive downstream.  For nodes that entered the queue
@@ -125,6 +131,7 @@ class ReactorTrimmer {
                     // hasTestJarDependency for each origin.  The downstream node must have
                     // a test-jar dependency on at least one of the original test-only
                     // sources to be included.
+                    boolean skip = false;
                     if (currentFromTestOnly) {
                         boolean hasTestJar = false;
                         for (MavenProject origin : currentTestOnlyOrigins) {
@@ -134,31 +141,39 @@ class ReactorTrimmer {
                             }
                         }
                         if (!hasTestJar) {
-                            logger.debug(
-                                    "Skipping transitive downstream {} (no test-jar dependency on test-only sources)",
-                                    key(ds));
-                            continue;
+                            if (logger.isDebugEnabled()) {
+                                logger.debug(
+                                        "Skipping transitive downstream {} (no test-jar dependency on test-only sources)",
+                                        key(ds));
+                            }
+                            skip = true;
                         }
                     }
-                    visited.add(ds);
-                    buildSet.add(ds);
-                    if (currentFromTestOnly) {
-                        testOnlyOrigins
-                                .computeIfAbsent(ds, k -> new LinkedHashSet<>())
-                                .addAll(currentTestOnlyOrigins);
+                    if (!skip) {
+                        visited.add(ds);
+                        buildSet.add(ds);
+                        if (currentFromTestOnly) {
+                            testOnlyOrigins
+                                    .computeIfAbsent(ds, k -> new LinkedHashSet<>())
+                                    .addAll(currentTestOnlyOrigins);
+                        }
+                        if (config.isExplain()) {
+                            addReason(buildReasons, ds, "downstream of " + key(current));
+                        }
+                        String scope = getDependencyScope(ds, current);
+                        if ("test".equals(scope)) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(current));
+                            }
+                            downstreamTestOnly.add(ds);
+                        } else {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(current));
+                            }
+                            downstreamOnly.add(ds);
+                        }
+                        queue.add(ds);
                     }
-                    if (config.isExplain()) {
-                        addReason(buildReasons, ds, "downstream of " + key(current));
-                    }
-                    String scope = getDependencyScope(ds, current);
-                    if ("test".equals(scope)) {
-                        logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(current));
-                        downstreamTestOnly.add(ds);
-                    } else {
-                        logger.debug("Adding downstream dependent {} of {}", key(ds), key(current));
-                        downstreamOnly.add(ds);
-                    }
-                    queue.add(ds);
                 }
             }
         }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -65,12 +65,16 @@ class ReactorTrimmer {
         if (config.isAlsoMakeDependents()) {
             // Multi-source BFS over the forward edge set: start from all directly-affected
             // projects and walk the transitive downstream closure in one pass.
+            // For test-only sources, we must check hasTestJarDependency at every hop
+            // against the original test-only source, matching the old transitive DFS
+            // semantics where graph.getDownstreamProjects(A, true) returned all transitive
+            // downstream and hasTestJarDependency(ds, A) was checked for each.
             Queue<MavenProject> queue = new ArrayDeque<>();
-            // Track which (source, downstream) pairs should be filtered for test-only
-            // We need to remember which "source" triggered each downstream addition
-            // so we can check test-jar dependency correctly.
-            // Strategy: BFS from each directly-affected project, but share visited set.
             Set<MavenProject> visited = new LinkedHashSet<>(directlyAffected);
+            // Track which test-only source(s) reached each node in the BFS.
+            // Nodes reached only via test-only sources are subject to hasTestJarDependency
+            // checks at every hop; nodes reached via non-test-only sources propagate freely.
+            Map<MavenProject, Set<MavenProject>> testOnlyOrigins = new HashMap<>();
             for (MavenProject project : directlyAffected) {
                 boolean isTestOnly = testOnlyProjects.contains(project);
                 for (MavenProject ds : directDownstream.getOrDefault(project, List.of())) {
@@ -86,6 +90,11 @@ class ReactorTrimmer {
                     }
                     visited.add(ds);
                     buildSet.add(ds);
+                    if (isTestOnly) {
+                        testOnlyOrigins
+                                .computeIfAbsent(ds, k -> new LinkedHashSet<>())
+                                .add(project);
+                    }
                     if (config.isExplain()) {
                         addReason(buildReasons, ds, "downstream of " + key(project));
                     }
@@ -100,26 +109,56 @@ class ReactorTrimmer {
                     queue.add(ds);
                 }
             }
-            // Continue BFS for transitive downstream (non-test-only filtering applies
-            // only at the first hop from a directly-affected test-only project)
+            // Continue BFS for transitive downstream.  For nodes that entered the queue
+            // via a test-only source, we must check hasTestJarDependency(ds, testOnlySource)
+            // at each hop — matching the old DFS semantics.  Nodes that entered via a
+            // non-test-only source propagate freely.
             while (!queue.isEmpty()) {
                 MavenProject current = queue.poll();
+                Set<MavenProject> currentTestOnlyOrigins = testOnlyOrigins.get(current);
+                boolean currentFromTestOnly = currentTestOnlyOrigins != null;
                 for (MavenProject ds : directDownstream.getOrDefault(current, List.of())) {
-                    if (visited.add(ds)) {
-                        buildSet.add(ds);
-                        if (config.isExplain()) {
-                            addReason(buildReasons, ds, "downstream of " + key(current));
-                        }
-                        String scope = getDependencyScope(ds, current);
-                        if ("test".equals(scope)) {
-                            logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(current));
-                            downstreamTestOnly.add(ds);
-                        } else {
-                            logger.debug("Adding downstream dependent {} of {}", key(ds), key(current));
-                            downstreamOnly.add(ds);
-                        }
-                        queue.add(ds);
+                    if (visited.contains(ds)) {
+                        continue;
                     }
+                    // If current was reached exclusively via test-only sources, enforce
+                    // hasTestJarDependency for each origin.  The downstream node must have
+                    // a test-jar dependency on at least one of the original test-only
+                    // sources to be included.
+                    if (currentFromTestOnly) {
+                        boolean hasTestJar = false;
+                        for (MavenProject origin : currentTestOnlyOrigins) {
+                            if (hasTestJarDependency(ds, origin)) {
+                                hasTestJar = true;
+                                break;
+                            }
+                        }
+                        if (!hasTestJar) {
+                            logger.debug(
+                                    "Skipping transitive downstream {} (no test-jar dependency on test-only sources)",
+                                    key(ds));
+                            continue;
+                        }
+                    }
+                    visited.add(ds);
+                    buildSet.add(ds);
+                    if (currentFromTestOnly) {
+                        testOnlyOrigins
+                                .computeIfAbsent(ds, k -> new LinkedHashSet<>())
+                                .addAll(currentTestOnlyOrigins);
+                    }
+                    if (config.isExplain()) {
+                        addReason(buildReasons, ds, "downstream of " + key(current));
+                    }
+                    String scope = getDependencyScope(ds, current);
+                    if ("test".equals(scope)) {
+                        logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(current));
+                        downstreamTestOnly.add(ds);
+                    } else {
+                        logger.debug("Adding downstream dependent {} of {}", key(ds), key(current));
+                        downstreamOnly.add(ds);
+                    }
+                    queue.add(ds);
                 }
             }
         }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -79,6 +79,11 @@ class ReactorTrimmer {
                 boolean isTestOnly = testOnlyProjects.contains(project);
                 for (MavenProject ds : directDownstream.getOrDefault(project, List.of())) {
                     if (visited.contains(ds)) {
+                        // A non-test-only source reaching an already-visited node clears any
+                        // test-only-origin tracking — the non-test-only path dominates.
+                        if (!isTestOnly) {
+                            testOnlyOrigins.remove(ds);
+                        }
                         continue;
                     }
                     if (isTestOnly && !hasTestJarDependency(ds, project)) {
@@ -125,6 +130,11 @@ class ReactorTrimmer {
                 boolean currentFromTestOnly = currentTestOnlyOrigins != null;
                 for (MavenProject ds : directDownstream.getOrDefault(current, List.of())) {
                     if (visited.contains(ds)) {
+                        // A non-test-only path reaching an already-visited node clears any
+                        // test-only-origin tracking — the non-test-only path dominates.
+                        if (!currentFromTestOnly) {
+                            testOnlyOrigins.remove(ds);
+                        }
                         continue;
                     }
                     // If current was reached exclusively via test-only sources, enforce

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmer.java
@@ -63,44 +63,31 @@ class ReactorTrimmer {
         Map<MavenProject, List<String>> buildReasons = new LinkedHashMap<>();
 
         if (config.isAlsoMakeDependents()) {
-            // Multi-source BFS over the forward edge set: start from all directly-affected
-            // projects and walk the transitive downstream closure in one pass.
-            // For test-only sources, we must check hasTestJarDependency at every hop
-            // against the original test-only source, matching the old transitive DFS
-            // semantics where graph.getDownstreamProjects(A, true) returned all transitive
-            // downstream and hasTestJarDependency(ds, A) was checked for each.
+            // Two-phase multi-source BFS over the forward edge set.
+            //
+            // Phase 1: BFS from non-test-only sources — no test-jar filtering.
+            //          These nodes and all their transitive downstream are included
+            //          unconditionally.
+            //
+            // Phase 2: BFS from test-only sources — hasTestJarDependency enforced
+            //          at every hop against the original test-only source.  Nodes
+            //          already visited in Phase 1 are treated as safe (their
+            //          descendants were already queued without restriction).
+            //
+            // Splitting into two phases avoids the processing-order race where a
+            // test-only path through the single queue could permanently exclude
+            // descendants of a node that is also reachable via a non-test-only path.
             Queue<MavenProject> queue = new ArrayDeque<>();
             Set<MavenProject> visited = new LinkedHashSet<>(directlyAffected);
-            // Track which test-only source(s) reached each node in the BFS.
-            // Nodes reached only via test-only sources are subject to hasTestJarDependency
-            // checks at every hop; nodes reached via non-test-only sources propagate freely.
-            Map<MavenProject, Set<MavenProject>> testOnlyOrigins = new HashMap<>();
+
+            // --- Phase 1: non-test-only sources ---
             for (MavenProject project : directlyAffected) {
-                boolean isTestOnly = testOnlyProjects.contains(project);
+                if (testOnlyProjects.contains(project)) {
+                    continue; // handled in Phase 2
+                }
                 for (MavenProject ds : directDownstream.getOrDefault(project, List.of())) {
-                    if (visited.contains(ds)) {
-                        // A non-test-only source reaching an already-visited node clears any
-                        // test-only-origin tracking — the non-test-only path dominates.
-                        if (!isTestOnly) {
-                            testOnlyOrigins.remove(ds);
-                        }
-                        continue;
-                    }
-                    if (isTestOnly && !hasTestJarDependency(ds, project)) {
-                        if (logger.isDebugEnabled()) {
-                            logger.debug(
-                                    "Skipping downstream {} of test-only module {} (no test-jar dependency)",
-                                    key(ds),
-                                    key(project));
-                        }
-                    } else {
-                        visited.add(ds);
+                    if (visited.add(ds)) {
                         buildSet.add(ds);
-                        if (isTestOnly) {
-                            testOnlyOrigins
-                                    .computeIfAbsent(ds, k -> new LinkedHashSet<>())
-                                    .add(project);
-                        }
                         if (config.isExplain()) {
                             addReason(buildReasons, ds, "downstream of " + key(project));
                         }
@@ -120,53 +107,114 @@ class ReactorTrimmer {
                     }
                 }
             }
-            // Continue BFS for transitive downstream.  For nodes that entered the queue
-            // via a test-only source, we must check hasTestJarDependency(ds, testOnlySource)
-            // at each hop — matching the old DFS semantics.  Nodes that entered via a
-            // non-test-only source propagate freely.
+            // Drain queue: all transitive downstream from non-test-only sources
+            while (!queue.isEmpty()) {
+                MavenProject current = queue.poll();
+                for (MavenProject ds : directDownstream.getOrDefault(current, List.of())) {
+                    if (visited.add(ds)) {
+                        buildSet.add(ds);
+                        if (config.isExplain()) {
+                            addReason(buildReasons, ds, "downstream of " + key(current));
+                        }
+                        String scope = getDependencyScope(ds, current);
+                        if ("test".equals(scope)) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(current));
+                            }
+                            downstreamTestOnly.add(ds);
+                        } else {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(current));
+                            }
+                            downstreamOnly.add(ds);
+                        }
+                        queue.add(ds);
+                    }
+                }
+            }
+
+            // --- Phase 2: test-only sources ---
+            // Track which test-only source(s) reached each node so we can enforce
+            // hasTestJarDependency at every hop against the original source(s).
+            Map<MavenProject, Set<MavenProject>> testOnlyOrigins = new HashMap<>();
+            for (MavenProject project : directlyAffected) {
+                if (!testOnlyProjects.contains(project)) {
+                    continue; // handled in Phase 1
+                }
+                for (MavenProject ds : directDownstream.getOrDefault(project, List.of())) {
+                    if (visited.contains(ds)) {
+                        // Already reached via a non-test-only path (or another test-only
+                        // source) — descendants are already queued from Phase 1, so skip.
+                        continue;
+                    }
+                    if (!hasTestJarDependency(ds, project)) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Skipping downstream {} of test-only module {} (no test-jar dependency)",
+                                    key(ds),
+                                    key(project));
+                        }
+                    } else {
+                        visited.add(ds);
+                        buildSet.add(ds);
+                        testOnlyOrigins
+                                .computeIfAbsent(ds, k -> new LinkedHashSet<>())
+                                .add(project);
+                        if (config.isExplain()) {
+                            addReason(buildReasons, ds, "downstream of " + key(project));
+                        }
+                        String scope = getDependencyScope(ds, project);
+                        if ("test".equals(scope)) {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding test-scoped downstream {} of {}", key(ds), key(project));
+                            }
+                            downstreamTestOnly.add(ds);
+                        } else {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("Adding downstream dependent {} of {}", key(ds), key(project));
+                            }
+                            downstreamOnly.add(ds);
+                        }
+                        queue.add(ds);
+                    }
+                }
+            }
+            // Continue BFS for transitive downstream of test-only sources.
+            // At each hop, hasTestJarDependency(ds, origin) is enforced against
+            // the original test-only source(s) — matching the old DFS semantics.
             while (!queue.isEmpty()) {
                 MavenProject current = queue.poll();
                 Set<MavenProject> currentTestOnlyOrigins = testOnlyOrigins.get(current);
-                boolean currentFromTestOnly = currentTestOnlyOrigins != null;
+                if (currentTestOnlyOrigins == null) {
+                    // This node entered the queue from Phase 1 (no test-only origins).
+                    // Should not happen after Phase 1 drain, but guard defensively.
+                    continue;
+                }
                 for (MavenProject ds : directDownstream.getOrDefault(current, List.of())) {
                     if (visited.contains(ds)) {
-                        // A non-test-only path reaching an already-visited node clears any
-                        // test-only-origin tracking — the non-test-only path dominates.
-                        if (!currentFromTestOnly) {
-                            testOnlyOrigins.remove(ds);
-                        }
+                        // Already visited — either from Phase 1 (safe) or from an
+                        // earlier test-only path.  No need to revisit.
                         continue;
                     }
-                    // If current was reached exclusively via test-only sources, enforce
-                    // hasTestJarDependency for each origin.  The downstream node must have
-                    // a test-jar dependency on at least one of the original test-only
-                    // sources to be included.
-                    boolean skip = false;
-                    if (currentFromTestOnly) {
-                        boolean hasTestJar = false;
-                        for (MavenProject origin : currentTestOnlyOrigins) {
-                            if (hasTestJarDependency(ds, origin)) {
-                                hasTestJar = true;
-                                break;
-                            }
-                        }
-                        if (!hasTestJar) {
-                            if (logger.isDebugEnabled()) {
-                                logger.debug(
-                                        "Skipping transitive downstream {} (no test-jar dependency on test-only sources)",
-                                        key(ds));
-                            }
-                            skip = true;
+                    boolean hasTestJar = false;
+                    for (MavenProject origin : currentTestOnlyOrigins) {
+                        if (hasTestJarDependency(ds, origin)) {
+                            hasTestJar = true;
+                            break;
                         }
                     }
-                    if (!skip) {
+                    if (!hasTestJar) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Skipping transitive downstream {} (no test-jar dependency on test-only sources)",
+                                    key(ds));
+                        }
+                    } else {
                         visited.add(ds);
                         buildSet.add(ds);
-                        if (currentFromTestOnly) {
-                            testOnlyOrigins
-                                    .computeIfAbsent(ds, k -> new LinkedHashSet<>())
-                                    .addAll(currentTestOnlyOrigins);
-                        }
+                        testOnlyOrigins
+                                .computeIfAbsent(ds, k -> new LinkedHashSet<>())
+                                .addAll(currentTestOnlyOrigins);
                         if (config.isExplain()) {
                             addReason(buildReasons, ds, "downstream of " + key(current));
                         }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
@@ -197,6 +197,96 @@ class ReactorTrimmerTest {
         assertEquals(List.of(projectA, projectC), result.getBuildSet());
     }
 
+    @Test
+    void computeBuildSet_transitiveDownstreamViaBFS() {
+        // Chain: A -> B -> C -> D (each directly downstream of the previous)
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        MavenProject projectC = createProject("com.example", "module-c");
+        MavenProject projectD = createProject("com.example", "module-d");
+        addDependency(projectB, "com.example", "module-a", "compile");
+        addDependency(projectC, "com.example", "module-b", "compile");
+        addDependency(projectD, "com.example", "module-c", "compile");
+
+        List<MavenProject> sortedProjects = List.of(projectA, projectB, projectC, projectD);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        // Direct edges only
+        downstreamMap.put(projectA, List.of(projectB));
+        downstreamMap.put(projectB, List.of(projectC));
+        downstreamMap.put(projectC, List.of(projectD));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
+        ScalpelConfiguration config = configWith(false, true); // alsoMakeDependents=true
+
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, Set.of(), graph, config);
+
+        // BFS should find all transitive downstream: B, C, D
+        assertEquals(List.of(projectA, projectB, projectC, projectD), result.getBuildSet());
+        assertTrue(result.getDownstreamOnly().contains(projectB));
+        assertTrue(result.getDownstreamOnly().contains(projectC));
+        assertTrue(result.getDownstreamOnly().contains(projectD));
+    }
+
+    @Test
+    void computeBuildSet_transitiveUpstreamViaBFS() {
+        // Chain: A <- B <- C (each directly upstream of the next)
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        MavenProject projectC = createProject("com.example", "module-c");
+        addDependency(projectB, "com.example", "module-a", "compile");
+        addDependency(projectC, "com.example", "module-b", "compile");
+
+        List<MavenProject> sortedProjects = List.of(projectA, projectB, projectC);
+        Map<MavenProject, List<MavenProject>> upstreamMap = new HashMap<>();
+        // Direct edges only
+        upstreamMap.put(projectC, List.of(projectB));
+        upstreamMap.put(projectB, List.of(projectA));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, Map.of(), upstreamMap);
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectC));
+        ScalpelConfiguration config = configWith(true, false); // alsoMake=true
+
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, Set.of(), graph, config);
+
+        // BFS should find all transitive upstream: B and A
+        assertEquals(List.of(projectA, projectB, projectC), result.getBuildSet());
+        assertTrue(result.getUpstreamOnly().contains(projectA));
+        assertTrue(result.getUpstreamOnly().contains(projectB));
+    }
+
+    @Test
+    void computeBuildSet_diamondGraphNoDuplicates() {
+        // Diamond: A -> B, A -> C, B -> D, C -> D
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        MavenProject projectC = createProject("com.example", "module-c");
+        MavenProject projectD = createProject("com.example", "module-d");
+        addDependency(projectB, "com.example", "module-a", "compile");
+        addDependency(projectC, "com.example", "module-a", "compile");
+        addDependency(projectD, "com.example", "module-b", "compile");
+        addDependency(projectD, "com.example", "module-c", "compile");
+
+        List<MavenProject> sortedProjects = List.of(projectA, projectB, projectC, projectD);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        downstreamMap.put(projectA, List.of(projectB, projectC));
+        downstreamMap.put(projectB, List.of(projectD));
+        downstreamMap.put(projectC, List.of(projectD));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
+        ScalpelConfiguration config = configWith(false, true); // alsoMakeDependents=true
+
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, Set.of(), graph, config);
+
+        // All should be in the build set, D only once
+        assertEquals(List.of(projectA, projectB, projectC, projectD), result.getBuildSet());
+        assertEquals(3, result.getDownstreamOnly().size());
+    }
+
     // --- Helper methods ---
 
     private MavenProject createProject(String groupId, String artifactId) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
@@ -258,6 +258,39 @@ class ReactorTrimmerTest {
     }
 
     @Test
+    void computeBuildSet_testOnlyDoesNotPropagateTransitively() {
+        // A (test-only) -> B (test-jar dep on A) -> D (compile dep on B)
+        // D must NOT be in the build set because D has no test-jar dependency on A.
+        // This matches the old DFS semantics where graph.getDownstreamProjects(A, true)
+        // returns {B, D} and hasTestJarDependency(D, A) is false.
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        MavenProject projectD = createProject("com.example", "module-d");
+        addTestJarDependency(projectB, "com.example", "module-a");
+        addDependency(projectD, "com.example", "module-b", "compile");
+
+        List<MavenProject> sortedProjects = List.of(projectA, projectB, projectD);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        downstreamMap.put(projectA, List.of(projectB));
+        downstreamMap.put(projectB, List.of(projectD));
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
+
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(Set.of(projectA));
+        Set<MavenProject> testOnlyProjects = new LinkedHashSet<>(Set.of(projectA));
+        ScalpelConfiguration config = configWith(false, true); // alsoMakeDependents=true
+
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, testOnlyProjects, graph, config);
+
+        assertTrue(result.getBuildSet().contains(projectA), "A (directly affected) should be in the build set");
+        assertTrue(
+                result.getBuildSet().contains(projectB), "B (test-jar dep on test-only A) should be in the build set");
+        assertFalse(
+                result.getBuildSet().contains(projectD),
+                "D (compile dep on B, no test-jar dep on A) should NOT be in the build set");
+    }
+
+    @Test
     void computeBuildSet_diamondGraphNoDuplicates() {
         // Diamond: A -> B, A -> C, B -> D, C -> D
         MavenProject projectA = createProject("com.example", "module-a");

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReactorTrimmerTest.java
@@ -320,6 +320,47 @@ class ReactorTrimmerTest {
         assertEquals(3, result.getDownstreamOnly().size());
     }
 
+    @Test
+    void computeBuildSet_testOnlyAndNonTestOnlyConvergingPaths() {
+        // CodeRabbit repro: test-only and non-test-only paths converge before a downstream node.
+        // A (test-only) --test-jar--> X, B (non-test) --compile--> C --compile--> X, X --compile--> Y.
+        // Y must be included because X is reachable via the non-test-only path B -> C -> X.
+        // The old single-queue BFS could exclude Y if the test-only path was processed first.
+        MavenProject projectA = createProject("com.example", "module-a");
+        MavenProject projectB = createProject("com.example", "module-b");
+        MavenProject projectC = createProject("com.example", "module-c");
+        MavenProject projectX = createProject("com.example", "module-x");
+        MavenProject projectY = createProject("com.example", "module-y");
+        addTestJarDependency(projectX, "com.example", "module-a"); // X has test-jar dep on A
+        addDependency(projectC, "com.example", "module-b", "compile"); // C depends on B
+        addDependency(projectX, "com.example", "module-c", "compile"); // X depends on C
+        addDependency(projectY, "com.example", "module-x", "compile"); // Y depends on X
+
+        List<MavenProject> sortedProjects = List.of(projectA, projectB, projectC, projectX, projectY);
+        Map<MavenProject, List<MavenProject>> downstreamMap = new HashMap<>();
+        downstreamMap.put(projectA, List.of(projectX)); // A -> X (test-jar)
+        downstreamMap.put(projectB, List.of(projectC)); // B -> C
+        downstreamMap.put(projectC, List.of(projectX)); // C -> X
+        downstreamMap.put(projectX, List.of(projectY)); // X -> Y
+
+        ProjectDependencyGraph graph = new TestDependencyGraph(sortedProjects, downstreamMap, Map.of());
+
+        // A is test-only, B is not
+        Set<MavenProject> directlyAffected = new LinkedHashSet<>(List.of(projectA, projectB));
+        Set<MavenProject> testOnlyProjects = new LinkedHashSet<>(Set.of(projectA));
+        ScalpelConfiguration config = configWith(false, true); // alsoMakeDependents=true
+
+        TrimResult result = trimmer.computeBuildSet(directlyAffected, testOnlyProjects, graph, config);
+
+        assertTrue(result.getBuildSet().contains(projectC), "C (downstream of non-test B) should be included");
+        assertTrue(
+                result.getBuildSet().contains(projectX),
+                "X (downstream of both test-only A and non-test C) should be included");
+        assertTrue(
+                result.getBuildSet().contains(projectY),
+                "Y (downstream of X, reachable via non-test-only path B->C->X) must be included");
+    }
+
     // --- Helper methods ---
 
     private MavenProject createProject(String groupId, String artifactId) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -307,7 +307,7 @@ class ScalpelLifecycleParticipantTest {
         // Graph: module-b is downstream of module-a; module-d and module-e are NOT downstream
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -1066,7 +1066,7 @@ class ScalpelLifecycleParticipantTest {
         // Graph: module-b is downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -1168,8 +1168,8 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-b is downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -1940,7 +1940,7 @@ class ScalpelLifecycleParticipantTest {
         // Graph: module-b is downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -2009,10 +2009,10 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-b and module-c are downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB, moduleC));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(moduleC, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB, moduleC));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleC), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -2111,9 +2111,9 @@ class ScalpelLifecycleParticipantTest {
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "com.example:module-b");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -2157,9 +2157,9 @@ class ScalpelLifecycleParticipantTest {
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -2222,9 +2222,9 @@ class ScalpelLifecycleParticipantTest {
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -2315,9 +2315,9 @@ class ScalpelLifecycleParticipantTest {
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -2404,9 +2404,9 @@ class ScalpelLifecycleParticipantTest {
 
         // module-b is downstream of module-a
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -4094,9 +4094,9 @@ class ScalpelLifecycleParticipantTest {
         // Graph: module-a is upstream of module-b
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
-        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(List.of(moduleA));
-        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(List.of());
-        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of(moduleA));
+        when(graph.getUpstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -4154,14 +4154,14 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-a is upstream of module-b, module-c is downstream of module-b
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(List.of(moduleA));
-        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(List.of());
-        when(graph.getUpstreamProjects(moduleC, true)).thenReturn(List.of());
-        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of(moduleC));
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(moduleC, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of(moduleA));
+        when(graph.getUpstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(eq(moduleC), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of(moduleC));
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleC), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
 
@@ -4321,9 +4321,9 @@ class ScalpelLifecycleParticipantTest {
 
         // Graph: module-a is upstream of module-b
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getUpstreamProjects(moduleB, true)).thenReturn(List.of(moduleA));
-        when(graph.getUpstreamProjects(moduleA, true)).thenReturn(List.of());
-        when(graph.getUpstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getUpstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of(moduleA));
+        when(graph.getUpstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of());
+        when(graph.getUpstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -5258,14 +5258,14 @@ class ScalpelLifecycleParticipantTest {
         when(graph.getDownstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         // camel-kafka has 3 downstream dependents: other-1, other-2, other-3
-        when(graph.getDownstreamProjects(kafkaModule, true))
+        when(graph.getDownstreamProjects(eq(kafkaModule), anyBoolean()))
                 .thenReturn(List.of(otherModules.get(0), otherModules.get(1), otherModules.get(2)));
         // camel-core is upstream of kafka and all others
-        when(graph.getUpstreamProjects(kafkaModule, true)).thenReturn(List.of(coreModule));
-        when(graph.getUpstreamProjects(debeziumModule, true)).thenReturn(List.of(coreModule));
-        when(graph.getUpstreamProjects(ibmModule, true)).thenReturn(List.of(coreModule));
+        when(graph.getUpstreamProjects(eq(kafkaModule), anyBoolean())).thenReturn(List.of(coreModule));
+        when(graph.getUpstreamProjects(eq(debeziumModule), anyBoolean())).thenReturn(List.of(coreModule));
+        when(graph.getUpstreamProjects(eq(ibmModule), anyBoolean())).thenReturn(List.of(coreModule));
         for (MavenProject other : otherModules) {
-            when(graph.getUpstreamProjects(other, true)).thenReturn(List.of(coreModule));
+            when(graph.getUpstreamProjects(eq(other), anyBoolean())).thenReturn(List.of(coreModule));
         }
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -5525,19 +5525,19 @@ class ScalpelLifecycleParticipantTest {
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
 
         // camel-kafka's downstream includes camel-allcomponents (the sync point depends on it)
-        when(graph.getDownstreamProjects(kafkaModule, true)).thenReturn(List.of(allcompModule));
+        when(graph.getDownstreamProjects(eq(kafkaModule), anyBoolean())).thenReturn(List.of(allcompModule));
 
         // camel-allcomponents upstream = ALL components + kafka + core (it depends on everything)
         List<MavenProject> allcompUpstream = new ArrayList<>();
         allcompUpstream.add(kafkaModule);
         allcompUpstream.add(coreModule);
         allcompUpstream.addAll(compModules);
-        when(graph.getUpstreamProjects(allcompModule, true)).thenReturn(allcompUpstream);
+        when(graph.getUpstreamProjects(eq(allcompModule), anyBoolean())).thenReturn(allcompUpstream);
 
         // Each component has camel-core as upstream
-        when(graph.getUpstreamProjects(kafkaModule, true)).thenReturn(List.of(coreModule));
+        when(graph.getUpstreamProjects(eq(kafkaModule), anyBoolean())).thenReturn(List.of(coreModule));
         for (MavenProject comp : compModules) {
-            when(graph.getUpstreamProjects(comp, true)).thenReturn(List.of(coreModule));
+            when(graph.getUpstreamProjects(eq(comp), anyBoolean())).thenReturn(List.of(coreModule));
         }
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -5634,9 +5634,9 @@ class ScalpelLifecycleParticipantTest {
         session.getSystemProperties().setProperty("scalpel.fullBuildTriggers", "");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of(moduleA, moduleB));
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of(moduleA, moduleB));
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);
@@ -5697,9 +5697,9 @@ class ScalpelLifecycleParticipantTest {
         session.getSystemProperties().setProperty("scalpel.skipTestsForDownstreamModules", "module-b");
 
         ProjectDependencyGraph graph = mock(ProjectDependencyGraph.class);
-        when(graph.getDownstreamProjects(moduleA, true)).thenReturn(List.of(moduleB));
-        when(graph.getDownstreamProjects(moduleB, true)).thenReturn(List.of());
-        when(graph.getDownstreamProjects(parentProject, true)).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(moduleA), anyBoolean())).thenReturn(List.of(moduleB));
+        when(graph.getDownstreamProjects(eq(moduleB), anyBoolean())).thenReturn(List.of());
+        when(graph.getDownstreamProjects(eq(parentProject), anyBoolean())).thenReturn(List.of());
         when(graph.getUpstreamProjects(any(), anyBoolean())).thenReturn(List.of());
         when(graph.getSortedProjects()).thenReturn(allProjects);
         when(session.getProjectDependencyGraph()).thenReturn(graph);


### PR DESCRIPTION
## Problem

`ReactorTrimmer.computeBuildSet` called `graph.getDownstreamProjects(p, true)` / `graph.getUpstreamProjects(p, true)` once per project in the build set. Each call in `DefaultProjectDependencyGraph` performs a fresh uncached DFS, giving O(M × (E + k log k)) total work, degrading to O(M² log M) when sync-point modules pull the entire reactor.

`PomChangeAnalyzer.isDescendantOf` scanned all M projects per changed POM and rebuilt coordinate key strings at each ancestor level — O(M² × depth).

## Fix

### ReactorTrimmer
- Build forward (downstream) and reverse (upstream) adjacency maps **once** from direct (non-transitive) edges via `graph.getDownstreamProjects(p, false)` / `graph.getUpstreamProjects(p, false)`
- Use **multi-source BFS** over these maps to compute the transitive downstream and upstream closures in a single pass
- Total work: O(M + E) instead of O(M × DFS)

### PomChangeAnalyzer
- Build a **parent→descendants map once** via BFS over a parent→direct-children adjacency map with cached GA keys
- Replaces `findChildren()` + `isDescendantOf()` + `findParentProjects()`: O(M) total instead of O(M² × depth)

## Tests

All 193 existing tests pass — trim results are identical. 3 new tests verify:
- Multi-hop transitive downstream chain (A→B→C→D)
- Multi-hop transitive upstream chain (C←B←A)
- Diamond graph traversal without duplicates (A→B,C; B,C→D)

Fixes #116

_AI agent (Hermes on behalf of gnodet)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reactor build-set calculation for transitive upstream and downstream dependencies.
  - Preserved correct handling of test-only dependencies across multiple dependency levels and converging paths.
  - Prevented duplicate project processing in diamond-shaped dependency graphs.
  - Maintained accurate build ordering and dependency classification across complex project structures.

- **Tests**
  - Added coverage for dependency traversal, test-only filtering, duplicate elimination, build ordering, and configuration-driven behavior.
  - Improved test reliability for dependency graph scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->