### PR TITLE
Fix #125: extract single-responsibility collaborators from ScalpelLifecycleParticipant

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifier.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifier.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Classifies changed files into POM changes vs source changes, applies exclusion/inclusion
+ * filters, and detects disable/full-build triggers.
+ */
+class ChangedFileClassifier {
+
+    private static final String GLOB_PREFIX = "glob:";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Result of classifying changed files into POM changes and source changes.
+     */
+    static final class ClassificationResult {
+        final Set<String> pomChanges;
+        final Set<String> sourceChanges;
+
+        ClassificationResult(Set<String> pomChanges, Set<String> sourceChanges) {
+            this.pomChanges = pomChanges;
+            this.sourceChanges = sourceChanges;
+        }
+    }
+
+    /**
+     * Separates the given changed files into POM changes and source changes.
+     * Files under {@code .mvn/} are ignored (build infrastructure).
+     */
+    ClassificationResult classifyChanges(Set<String> changedFiles) {
+        Set<String> pomChanges = new LinkedHashSet<>();
+        Set<String> sourceChanges = new LinkedHashSet<>();
+        for (String file : changedFiles) {
+            if (file.endsWith("/pom.xml") || file.equals("pom.xml")) {
+                pomChanges.add(file);
+            } else if (file.startsWith(".mvn/")) {
+                logger.debug("Ignoring build infrastructure file: {}", file);
+            } else {
+                sourceChanges.add(file);
+            }
+        }
+        return new ClassificationResult(pomChanges, sourceChanges);
+    }
+
+    /**
+     * Returns {@code true} if any changed file matches one of the configured disable triggers.
+     */
+    boolean matchesDisableTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
+        for (String pattern : config.getDisableTriggers()) {
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
+            for (String changedFile : changedFiles) {
+                if (matcher.matches(Path.of(changedFile))) {
+                    logger.info(
+                            "Scalpel: Disabled due to change in {} (matches disable trigger {})", changedFile, pattern);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Removes files matching exclusion path patterns from the changed file set.
+     */
+    Set<String> filterExcludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
+        List<PathMatcher> excludeMatchers = compileGlobMatchers(config.getExcludePaths());
+        if (excludeMatchers.isEmpty()) {
+            return changedFiles;
+        }
+        Set<String> filtered = new LinkedHashSet<>();
+        for (String file : changedFiles) {
+            boolean excluded = false;
+            for (PathMatcher matcher : excludeMatchers) {
+                if (matcher.matches(Path.of(file))) {
+                    excluded = true;
+                    break;
+                }
+            }
+            if (!excluded) {
+                filtered.add(file);
+            }
+        }
+        int excludedCount = changedFiles.size() - filtered.size();
+        if (excludedCount > 0) {
+            logger.info("Scalpel: {} files excluded by path filters", excludedCount);
+        }
+        return filtered;
+    }
+
+    /**
+     * Returns the first changed file matching a full-build trigger pattern, or {@code null}
+     * if no trigger matches.
+     */
+    String findFullBuildTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
+        for (String pattern : config.getFullBuildTriggers()) {
+            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
+            for (String changedFile : changedFiles) {
+                if (matcher.matches(Path.of(changedFile))) {
+                    logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
+                    return changedFile;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if the project's module path matches at least one of the
+     * given include-paths matchers.
+     */
+    static boolean matchesIncludePaths(MavenProject project, List<PathMatcher> matchers, Path reactorRoot) {
+        String relPath = relativePath(reactorRoot, project);
+        Path modulePath = Path.of(relPath);
+        for (PathMatcher matcher : matchers) {
+            if (matcher.matches(modulePath) || matcher.matches(modulePath.resolve("pom.xml"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Compiles a list of glob patterns into PathMatcher instances.
+     */
+    static List<PathMatcher> compileGlobMatchers(List<String> patterns) {
+        if (patterns.isEmpty()) {
+            return List.of();
+        }
+        List<PathMatcher> matchers = new ArrayList<>(patterns.size());
+        for (String pattern : patterns) {
+            matchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern)));
+        }
+        return matchers;
+    }
+
+    /**
+     * Normalizes a user-supplied glob pattern so that bare patterns (those containing no path
+     * separator) match files at any depth in the repository tree.
+     */
+    static String normalizeGlobPattern(String pattern) {
+        if (pattern.contains("/")) {
+            return pattern;
+        }
+        return "{" + pattern + ",**/" + pattern + "}";
+    }
+
+    /**
+     * Computes the relative path from the (pre-normalized) reactor root to the project's
+     * base directory.  Callers must pass a root that has already been normalized via
+     * {@code Path.toAbsolutePath().normalize()} — this method does NOT re-normalize the
+     * root on every call (#113).
+     */
+    static String relativePath(Path normalizedRoot, MavenProject project) {
+        return normalizedRoot
+                .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
+                .toString()
+                .replace('\\', '/');
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifier.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifier.java
@@ -127,8 +127,8 @@ class ChangedFileClassifier {
      * Returns {@code true} if the project's module path matches at least one of the
      * given include-paths matchers.
      */
-    static boolean matchesIncludePaths(MavenProject project, List<PathMatcher> matchers, Path reactorRoot) {
-        String relPath = relativePath(reactorRoot, project);
+    static boolean matchesIncludePaths(MavenProject project, List<PathMatcher> matchers, Path normalizedRoot) {
+        String relPath = relativePath(normalizedRoot, project);
         Path modulePath = Path.of(relPath);
         for (PathMatcher matcher : matchers) {
             if (matcher.matches(modulePath) || matcher.matches(modulePath.resolve("pom.xml"))) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ForceBuildMatcher.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ForceBuildMatcher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+
+import eu.maveniverse.maven.scalpel.core.BoundedRegexMatcher;
+import java.util.List;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Matches projects against {@code forceBuildModules} regex patterns using a bounded
+ * regex matcher to defend against adversarial input.
+ */
+class ForceBuildMatcher {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final BoundedRegexMatcher regexMatcher = new BoundedRegexMatcher();
+
+    /**
+     * Returns the matching pattern if the project's artifactId matches any of the
+     * given patterns, or {@code null} if no match.
+     */
+    String matchesForceBuild(MavenProject project, List<String> patterns) {
+        for (String pattern : patterns) {
+            if (regexMatcher.matches(project.getArtifactId(), pattern, "forceBuildModules", logger)) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
+                }
+                return pattern;
+            }
+        }
+        return null;
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ImpactedLogWriter.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ImpactedLogWriter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import eu.maveniverse.maven.scalpel.core.ScalpelReport;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Writes the impacted-module log file, validating paths for shell safety.
+ */
+class ImpactedLogWriter {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ReportAssembler reportAssembler;
+
+    ImpactedLogWriter(ReportAssembler reportAssembler) {
+        this.reportAssembler = reportAssembler;
+    }
+
+    /**
+     * Writes the list of affected modules to the configured impacted-log file.
+     */
+    void writeImpactedLog(ScalpelConfiguration config, Path reactorRoot, Set<MavenProject> affectedModules)
+            throws MavenExecutionException {
+        String impactedLog = config.getImpactedLog();
+        if (impactedLog == null || impactedLog.trim().isEmpty()) {
+            return;
+        }
+        Path logPath;
+        try {
+            logPath = ScalpelReport.resolveContained(reactorRoot, impactedLog, ScalpelConfiguration.IMPACTED_LOG);
+        } catch (IOException e) {
+            reportAssembler.handleWriteFailure(config, "Rejected impacted log path", e);
+            return;
+        }
+        try {
+            Files.createDirectories(logPath.getParent());
+            List<String> lines = new ArrayList<>();
+            for (MavenProject project : affectedModules) {
+                String relPath = ChangedFileClassifier.relativePath(reactorRoot, project);
+                if (relPath.isEmpty()) {
+                    relPath = ".";
+                }
+                if (!isSafeImpactedLogPath(relPath)) {
+                    if (logger.isWarnEnabled()) {
+                        logger.warn(
+                                "Scalpel: Skipping module {} in impacted log: path '{}' uses characters outside the"
+                                        + " safe set (letters, digits, '-', '_', '.', '/'; see README)",
+                                key(project),
+                                escapeControlChars(relPath));
+                    }
+                    continue;
+                }
+                lines.add(relPath);
+            }
+            Files.write(logPath, lines, StandardCharsets.UTF_8);
+            logger.info("Scalpel: Impacted modules written to {}", config.getImpactedLog());
+        } catch (IOException e) {
+            reportAssembler.handleWriteFailure(config, "Failed to write impacted log", e);
+        }
+    }
+
+    /**
+     * Safe character set for impacted-log lines.
+     */
+    static boolean isSafeImpactedLogPath(String path) {
+        if (path == null || path.isEmpty() || path.charAt(0) == '-') {
+            return false;
+        }
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            boolean allowed = (c >= 'a' && c <= 'z')
+                    || (c >= 'A' && c <= 'Z')
+                    || (c >= '0' && c <= '9')
+                    || c == '-'
+                    || c == '_'
+                    || c == '.'
+                    || c == '/';
+            if (!allowed) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Escapes control characters so a rejected path cannot forge extra lines in the
+     * skip warning itself.
+     */
+    static String escapeControlChars(String value) {
+        StringBuilder escaped = new StringBuilder(value.length() + 8);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (Character.isISOControl(c)) {
+                escaped.append("\\u%04x".formatted((int) c));
+            } else {
+                escaped.append(c);
+            }
+        }
+        return escaped.toString();
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/Projects.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/Projects.java
@@ -25,4 +25,24 @@ final class Projects {
         }
         return keys;
     }
+
+    /**
+     * Returns {@code true} if the project matches at least one downstream exclusion pattern.
+     * Patterns containing {@code ':'} are matched against the full {@code groupId:artifactId} key;
+     * bare patterns are matched against the artifact ID only.
+     */
+    static boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
+        for (String pattern : patterns) {
+            if (pattern.contains(":")) {
+                if (key(project).equals(pattern)) {
+                    return true;
+                }
+            } else {
+                if (project.getArtifactId().equals(pattern)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssembler.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssembler.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import eu.maveniverse.maven.scalpel.core.ScalpelReport;
+import eu.maveniverse.maven.scalpel.core.Timings;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Assembles and writes Scalpel reports: the main JSON report, status-only reports,
+ * shadow status documents, and full-build-triggered reports.
+ */
+class ReportAssembler {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    ReportAssembler() {}
+
+    void writeReport(
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            List<MavenProject> allProjects,
+            AnalysisContext ctx,
+            Timings timings,
+            long analysisStartNano)
+            throws MavenExecutionException {
+        ScalpelReport.Builder builder = ScalpelReport.builder()
+                .baseBranch(config.getBaseBranch())
+                .fullBuildTriggered(false)
+                .changedFiles(ctx.changedFiles)
+                .changedProperties(ctx.changedProperties)
+                .changedManagedDependencies(ctx.changedManagedDepGAs)
+                .changedManagedPlugins(ctx.changedManagedPluginGAs)
+                .unmatchedPomPaths(ctx.unmatchedPomPaths)
+                .timings(timings, millisSince(analysisStartNano));
+
+        logger.debug(
+                "Building report: {} directly affected, {} transitively affected, trim result has {} upstream / {} downstream / {} downstream-test",
+                ctx.directlyAffected.size(),
+                ctx.transitivelyAffected.size(),
+                ctx.trimResult != null ? ctx.trimResult.getUpstreamOnly().size() : 0,
+                ctx.trimResult != null ? ctx.trimResult.getDownstreamOnly().size() : 0,
+                ctx.trimResult != null ? ctx.trimResult.getDownstreamTestOnly().size() : 0);
+
+        addDirectlyAffectedModules(builder, ctx, reactorRoot);
+        addTransitivelyAffectedModules(builder, ctx, config, reactorRoot);
+        int excludedUpstream = addTrimResultModules(builder, ctx, config, reactorRoot);
+        builder.excludedUpstreamCount(excludedUpstream);
+        addSkippedModules(builder, allProjects, ctx, reactorRoot);
+
+        try {
+            ScalpelReport report = builder.build();
+            report.writeToFile(reactorRoot, config.getReportFile());
+            logger.info("Scalpel: Report written to {}", config.getReportFile());
+        } catch (IOException e) {
+            handleWriteFailure(config, "Failed to write report", e);
+        }
+    }
+
+    void writeStatusReport(ScalpelConfiguration config, Path reactorRoot, String status, String reason) {
+        String baseBranch = config.getBaseBranch();
+        try {
+            if (config.isModeShadow()) {
+                writeShadowStatus(reactorRoot, status, reason);
+            }
+            ScalpelReport report = ScalpelReport.builder()
+                    .baseBranch(baseBranch != null ? baseBranch : "(unconfigured)")
+                    .status(status)
+                    .reason(reason)
+                    .fullBuildTriggered(true)
+                    .build();
+            report.writeToFile(reactorRoot, config.getReportFile());
+            logger.warn(
+                    "Scalpel: Analysis did not complete (status={}, reason={}), report at {} overwritten",
+                    status,
+                    reason,
+                    config.getReportFile());
+        } catch (Exception e) {
+            logger.warn("Scalpel: Could not overwrite report with {} status: {}", status, e.toString());
+        }
+    }
+
+    void writeShadowStatus(Path reactorRoot, String status, String reason) {
+        try {
+            Files.createDirectories(
+                    reactorRoot.resolve(ShadowBuildMonitor.SHADOW_FILE).getParent());
+            Files.write(
+                    reactorRoot.resolve(ShadowBuildMonitor.SHADOW_FILE),
+                    ShadowBuildMonitor.statusDocument(status, reason).getBytes(StandardCharsets.UTF_8));
+            logger.warn(
+                    "Scalpel: Shadow document at {} overwritten with {} status",
+                    ShadowBuildMonitor.SHADOW_FILE,
+                    status);
+        } catch (Exception e) {
+            logger.warn("Scalpel: Could not overwrite shadow document with {} status: {}", status, e.toString());
+        }
+    }
+
+    void writeFullBuildReport(
+            ScalpelConfiguration config, Path reactorRoot, String triggerFile, Set<String> changedFiles)
+            throws MavenExecutionException {
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch(config.getBaseBranch())
+                .fullBuildTriggered(true)
+                .triggerFile(triggerFile)
+                .changedFiles(changedFiles)
+                .build();
+        try {
+            if (config.isModeShadow()) {
+                writeShadowStatus(reactorRoot, "skipped", "full build triggered by " + triggerFile);
+            }
+            report.writeToFile(reactorRoot, config.getReportFile());
+            logger.info("Scalpel: Report written to {}", config.getReportFile());
+        } catch (IOException e) {
+            handleWriteFailure(config, "Failed to write report", e);
+        }
+    }
+
+    void writeFailedStatusReport(ScalpelConfiguration config, Path reactorRoot, String reason) {
+        writeStatusReport(config, reactorRoot, "failed", reason);
+    }
+
+    void handleWriteFailure(ScalpelConfiguration config, String message, IOException e) throws MavenExecutionException {
+        if (config.isFailSafe()) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Scalpel: {} (failSafe=true, continuing build): {}", message, e.toString());
+            }
+        } else {
+            throw new MavenExecutionException("Scalpel: " + message, e);
+        }
+    }
+
+    private void addDirectlyAffectedModules(ScalpelReport.Builder builder, AnalysisContext ctx, Path reactorRoot) {
+        for (MavenProject project : ctx.directlyAffected) {
+            String path = ChangedFileClassifier.relativePath(reactorRoot, project);
+            List<String> reasons = new ArrayList<>();
+            String sourceSet = null;
+            if (ctx.affectedBySource.contains(project)) {
+                if (ctx.testOnlyBySource.contains(project)) {
+                    reasons.add(ScalpelReport.REASON_TEST_CHANGE);
+                    sourceSet = "test";
+                } else {
+                    reasons.add(ScalpelReport.REASON_SOURCE_CHANGE);
+                    sourceSet = "main";
+                }
+            }
+            if (ctx.affectedByPom.contains(project)) {
+                reasons.add(ScalpelReport.REASON_POM_CHANGE);
+            }
+            if (ctx.forceIncluded.contains(project)) {
+                reasons.add(ScalpelReport.REASON_FORCE_BUILD);
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("Report: {} -> category=DIRECT, reasons={}", key(project), reasons);
+            }
+            builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                            project.getGroupId(), project.getArtifactId(), path, reasons)
+                    .category(ScalpelReport.CATEGORY_DIRECT)
+                    .sourceSet(sourceSet)
+                    .evidence(ctx.evidence.get(project))
+                    .build());
+        }
+    }
+
+    private void addTransitivelyAffectedModules(
+            ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
+        for (Map.Entry<MavenProject, List<String>> entry : ctx.transitivelyAffected.entrySet()) {
+            MavenProject project = entry.getKey();
+            String path = ChangedFileClassifier.relativePath(reactorRoot, project);
+            String category = null;
+            String testsSkippedReason = null;
+            if (ctx.trimResult != null) {
+                if (ctx.trimResult.getUpstreamOnly().contains(project)) {
+                    category = ScalpelReport.CATEGORY_UPSTREAM;
+                } else if (ctx.trimResult.getDownstreamOnly().contains(project)
+                        || ctx.trimResult.getDownstreamTestOnly().contains(project)) {
+                    category = ScalpelReport.CATEGORY_DOWNSTREAM;
+                    if (matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
+                        testsSkippedReason = ScalpelReport.REASON_EXCLUDED_DOWNSTREAM;
+                    }
+                }
+            }
+            if (category == null) {
+                category = ScalpelReport.CATEGORY_TRANSITIVE;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("Report: {} -> category={}, reasons={}", key(project), category, entry.getValue());
+            }
+            builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                            project.getGroupId(), project.getArtifactId(), path, entry.getValue())
+                    .category(category)
+                    .testsSkippedReason(testsSkippedReason)
+                    .evidence(ctx.evidence.get(project))
+                    .build());
+        }
+    }
+
+    private int addTrimResultModules(
+            ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
+        if (ctx.trimResult == null) {
+            return 0;
+        }
+        int upstreamCount = 0;
+        for (MavenProject project : ctx.trimResult.getUpstreamOnly()) {
+            if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
+                upstreamCount++;
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                            "Excluding upstream build-prerequisite {} from report (not genuinely affected)",
+                            key(project));
+                }
+            }
+        }
+        if (upstreamCount > 0) {
+            logger.info(
+                    "Scalpel: {} upstream build-prerequisite modules excluded from report (use trim/skip-tests mode for full build set)",
+                    upstreamCount);
+        }
+        addDownstreamModules(
+                builder,
+                ctx,
+                config,
+                reactorRoot,
+                ctx.trimResult.getDownstreamOnly(),
+                ScalpelReport.REASON_DOWNSTREAM_DEPENDENT);
+        addDownstreamModules(
+                builder,
+                ctx,
+                config,
+                reactorRoot,
+                ctx.trimResult.getDownstreamTestOnly(),
+                ScalpelReport.REASON_DOWNSTREAM_TEST);
+        return upstreamCount;
+    }
+
+    private void addDownstreamModules(
+            ScalpelReport.Builder builder,
+            AnalysisContext ctx,
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            Set<MavenProject> downstreamProjects,
+            String reason) {
+        List<PathMatcher> includeMatchers = ChangedFileClassifier.compileGlobMatchers(config.getIncludePaths());
+        for (MavenProject project : downstreamProjects) {
+            if (ctx.directlyAffected.contains(project) || ctx.transitivelyAffected.containsKey(project)) {
+                continue;
+            }
+            addSingleDownstreamModule(builder, ctx, config, reactorRoot, includeMatchers, project, reason);
+        }
+    }
+
+    private void addSingleDownstreamModule(
+            ScalpelReport.Builder builder,
+            AnalysisContext ctx,
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            List<PathMatcher> includeMatchers,
+            MavenProject project,
+            String reason) {
+        // Skip downstream modules outside includePaths scope
+        if (!includeMatchers.isEmpty()
+                && !ChangedFileClassifier.matchesIncludePaths(project, includeMatchers, reactorRoot)) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Excluding downstream module {} from report (outside includePaths)", key(project));
+            }
+            return;
+        }
+        String path = ChangedFileClassifier.relativePath(reactorRoot, project);
+        String testsSkippedReason = matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
+                ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
+                : null;
+        if (logger.isDebugEnabled()) {
+            logger.debug("Report: {} -> category=DOWNSTREAM, reason={}", key(project), reason);
+        }
+        builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
+                        project.getGroupId(), project.getArtifactId(), path, List.of(reason))
+                .category(ScalpelReport.CATEGORY_DOWNSTREAM)
+                .testsSkippedReason(testsSkippedReason)
+                .evidence(ctx.evidence.get(project))
+                .build());
+    }
+
+    private void addSkippedModules(
+            ScalpelReport.Builder builder, List<MavenProject> allProjects, AnalysisContext ctx, Path reactorRoot) {
+        Set<MavenProject> included = new LinkedHashSet<>(ctx.directlyAffected);
+        included.addAll(ctx.transitivelyAffected.keySet());
+        if (ctx.trimResult != null) {
+            if (ctx.filteredBuildSet != null) {
+                included.addAll(ctx.filteredBuildSet);
+            } else {
+                included.addAll(ctx.trimResult.getBuildSet());
+            }
+        }
+        for (MavenProject project : allProjects) {
+            if (!included.contains(project)) {
+                String path = ChangedFileClassifier.relativePath(reactorRoot, project);
+                builder.addSkippedModule(new ScalpelReport.SkippedModule(
+                        project.getGroupId(), project.getArtifactId(), path, ScalpelReport.SKIP_REASON_NOT_AFFECTED));
+            }
+        }
+    }
+
+    private boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
+        for (String pattern : patterns) {
+            if (pattern.contains(":")) {
+                if (key(project).equals(pattern)) {
+                    return true;
+                }
+            } else {
+                if (project.getArtifactId().equals(pattern)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static long millisSince(long startNano) {
+        return (System.nanoTime() - startNano) / 1_000_000;
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssembler.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssembler.java
@@ -8,6 +8,7 @@
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.matchesDownstreamExclusion;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import eu.maveniverse.maven.scalpel.core.ScalpelReport;
@@ -319,21 +320,6 @@ class ReportAssembler {
                         project.getGroupId(), project.getArtifactId(), path, ScalpelReport.SKIP_REASON_NOT_AFFECTED));
             }
         }
-    }
-
-    private boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
-        for (String pattern : patterns) {
-            if (pattern.contains(":")) {
-                if (key(project).equals(pattern)) {
-                    return true;
-                }
-            } else {
-                if (project.getArtifactId().equals(pattern)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     static long millisSince(long startNano) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -11,28 +11,19 @@ import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
 import static java.util.Objects.requireNonNull;
 
-import eu.maveniverse.maven.scalpel.core.BoundedRegexMatcher;
 import eu.maveniverse.maven.scalpel.core.ChangeDetectionResult;
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import eu.maveniverse.maven.scalpel.core.ScalpelCore;
 import eu.maveniverse.maven.scalpel.core.ScalpelException;
-import eu.maveniverse.maven.scalpel.core.ScalpelReport;
 import eu.maveniverse.maven.scalpel.core.Timings;
 import eu.maveniverse.maven.scalpel.core.Version;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -41,14 +32,9 @@ import org.apache.maven.AbstractMavenLifecycleParticipant;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Model;
-import org.apache.maven.project.DefaultDependencyResolutionRequest;
-import org.apache.maven.project.DependencyResolutionException;
 import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectDependenciesResolver;
-import org.eclipse.aether.graph.Dependency;
-import org.eclipse.aether.graph.DependencyFilter;
-import org.eclipse.aether.graph.DependencyNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,18 +42,19 @@ import org.slf4j.LoggerFactory;
 @Named
 class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
-    private static final String MAVEN_TEST_SKIP = "maven.test.skip";
-    private static final String SKIP_TESTS = "skipTests";
-    private static final String GLOB_PREFIX = "glob:";
-    private static final String UNRESOLVED_GA = "(unresolved)";
-
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final ScalpelCore scalpelCore;
     private final ModuleMapper moduleMapper;
     private final PomChangeAnalyzer pomChangeAnalyzer;
     private final ReactorTrimmer reactorTrimmer;
-    private final ProjectDependenciesResolver dependenciesResolver;
-    private final BoundedRegexMatcher regexMatcher = new BoundedRegexMatcher();
+
+    // Internal collaborators (not DI components)
+    private final ChangedFileClassifier changedFileClassifier;
+    private final ForceBuildMatcher forceBuildMatcher;
+    private final TransitiveImpactAnalyzer transitiveImpactAnalyzer;
+    private final SkipTestsApplier skipTestsApplier;
+    private final ReportAssembler reportAssembler;
+    private final ImpactedLogWriter impactedLogWriter;
 
     @Inject
     public ScalpelLifecycleParticipant(
@@ -80,7 +67,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         this.moduleMapper = requireNonNull(moduleMapper, "moduleMapper");
         this.pomChangeAnalyzer = requireNonNull(pomChangeAnalyzer, "pomChangeAnalyzer");
         this.reactorTrimmer = requireNonNull(reactorTrimmer, "reactorTrimmer");
-        this.dependenciesResolver = requireNonNull(dependenciesResolver, "dependenciesResolver");
+
+        this.changedFileClassifier = new ChangedFileClassifier();
+        this.forceBuildMatcher = new ForceBuildMatcher();
+        this.transitiveImpactAnalyzer = new TransitiveImpactAnalyzer(dependenciesResolver, pomChangeAnalyzer);
+        this.skipTestsApplier = new SkipTestsApplier(reactorTrimmer, transitiveImpactAnalyzer);
+        this.reportAssembler = new ReportAssembler();
+        this.impactedLogWriter = new ImpactedLogWriter(reportAssembler);
     }
 
     @Override
@@ -89,8 +82,6 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         try {
             config = ScalpelConfiguration.fromProperties(session.getSystemProperties(), session.getUserProperties());
         } catch (Exception e) {
-            // Default for failSafe is true; if config parsing fails we cannot check the flag,
-            // so default to the safe behaviour: warn and let the build proceed normally.
             logger.warn("Scalpel: Error parsing configuration, building all modules: {}", e.getMessage());
             logger.debug("Configuration parsing error details", e);
             return;
@@ -113,9 +104,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (selectedProjects != null && !selectedProjects.isEmpty()) {
                 logger.info("Scalpel {} disabled due to -pl project selection", version);
                 if (config.isModeShadow()) {
-                    // This exit predates any measurement; a previous run's shadow document
-                    // must not survive it (#89 semantics, shadow twin).
-                    writeShadowStatus(
+                    reportAssembler.writeShadowStatus(
                             session.getRequest()
                                     .getMultiModuleProjectDirectory()
                                     .toPath(),
@@ -151,9 +140,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 if (config.isPassiveMode()) {
                     String skipReason = scalpelCore.getLastDetectionSkipReason();
                     if (skipReason != null) {
-                        writeStatusReport(config, reactorRoot, "skipped", skipReason);
+                        reportAssembler.writeStatusReport(config, reactorRoot, "skipped", skipReason);
                     } else {
-                        writeStatusReport(
+                        reportAssembler.writeStatusReport(
                                 config, reactorRoot, "failed", "change detection did not run (see build log)");
                     }
                 }
@@ -166,62 +155,52 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     logger.info("Scalpel: No changes detected, building all modules (buildAllIfNoChanges=true)");
                 }
                 if (config.isPassiveMode()) {
-                    writeStatusReport(config, reactorRoot, "skipped", "no changes detected");
+                    reportAssembler.writeStatusReport(config, reactorRoot, "skipped", "no changes detected");
                 }
                 return;
             }
 
             logger.info("Scalpel: {} changed files detected", changedFiles.size());
 
-            // Check disable triggers (bail out entirely if any changed file matches)
-            if (matchesDisableTrigger(changedFiles, config)) {
+            // Check disable triggers
+            if (changedFileClassifier.matchesDisableTrigger(changedFiles, config)) {
                 if (config.isPassiveMode()) {
-                    writeStatusReport(config, reactorRoot, "skipped", "disabled by disableTriggers match");
+                    reportAssembler.writeStatusReport(
+                            config, reactorRoot, "skipped", "disabled by disableTriggers match");
                 }
                 return;
             }
 
             // Filter out excluded paths
-            changedFiles = filterExcludedPaths(changedFiles, config);
+            changedFiles = changedFileClassifier.filterExcludedPaths(changedFiles, config);
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: All changed files excluded by path filters, building all modules");
                 if (config.isPassiveMode()) {
-                    writeStatusReport(config, reactorRoot, "skipped", "all changed files excluded by path filters");
+                    reportAssembler.writeStatusReport(
+                            config, reactorRoot, "skipped", "all changed files excluded by path filters");
                 }
                 return;
             }
 
             // Check full build triggers
-            String triggerFile = findFullBuildTrigger(changedFiles, config);
+            String triggerFile = changedFileClassifier.findFullBuildTrigger(changedFiles, config);
             if (triggerFile != null) {
                 if (config.isPassiveMode()) {
-                    writeFullBuildReport(config, reactorRoot, triggerFile, changedFiles);
+                    reportAssembler.writeFullBuildReport(config, reactorRoot, triggerFile, changedFiles);
                 }
                 return;
             }
 
             // Separate POM changes from source changes
-            // .mvn/ files are Maven build infrastructure (extensions.xml, maven.config, jvm.config)
-            // and should not be mapped to the root module as source changes — doing so would
-            // make the root DIRECT and cascade every reactor module as DOWNSTREAM.
-            Set<String> pomChanges = new LinkedHashSet<>();
-            Set<String> sourceChanges = new LinkedHashSet<>();
-            for (String file : changedFiles) {
-                if (file.endsWith("/pom.xml") || file.equals("pom.xml")) {
-                    pomChanges.add(file);
-                } else if (file.startsWith(".mvn/")) {
-                    logger.debug("Ignoring build infrastructure file: {}", file);
-                } else {
-                    sourceChanges.add(file);
-                }
-            }
+            ChangedFileClassifier.ClassificationResult classification =
+                    changedFileClassifier.classifyChanges(changedFiles);
 
-            // Map source changes to modules (classifying test-only vs main changes)
+            // Map source changes to modules
             ModuleMapper.Result sourceResult;
             timings.start(Timings.PHASE_MODULE_MAPPING);
             try {
                 sourceResult = moduleMapper.mapToProjectsClassified(
-                        sourceChanges, allProjects, reactorRoot, config.isExplain());
+                        classification.sourceChanges, allProjects, reactorRoot, config.isExplain());
             } finally {
                 timings.stop(Timings.PHASE_MODULE_MAPPING);
             }
@@ -232,21 +211,21 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         "Test-only modules (no downstream propagation): {}", keys(sourceResult.getTestOnlyAffected()));
             }
 
-            // Analyze POM changes directly (no model building needed)
+            // Analyze POM changes
             Set<MavenProject> affectedByPom = new LinkedHashSet<>();
             Map<String, Model> oldEffectiveModels = Map.of();
             Map<String, Model> newEffectiveModels = Map.of();
             Set<String> changedProperties = new LinkedHashSet<>();
             Map<MavenProject, Set<String>> pomEvidence = Map.of();
             Set<String> unmatchedPomPaths = new LinkedHashSet<>();
-            if (!pomChanges.isEmpty()) {
-                logger.debug("POM changes detected: {}", pomChanges);
+            if (!classification.pomChanges.isEmpty()) {
+                logger.debug("POM changes detected: {}", classification.pomChanges);
                 try {
                     PomChangeAnalyzer.Result pomResult;
                     timings.start(Timings.PHASE_POM_ANALYSIS);
                     try {
                         pomResult = pomChangeAnalyzer.analyzeChanges(
-                                pomChanges,
+                                classification.pomChanges,
                                 result.getOldPomContents(),
                                 allProjects,
                                 reactorRoot,
@@ -273,7 +252,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         logger.warn("Scalpel: Error analyzing POM changes, building all modules: {}", e.getMessage());
                         logger.debug("POM analysis error details", e);
                         if (config.isPassiveMode()) {
-                            writeFailedStatusReport(config, reactorRoot, "error analyzing POM changes");
+                            reportAssembler.writeFailedStatusReport(config, reactorRoot, "error analyzing POM changes");
                         }
                         return;
                     } else {
@@ -283,19 +262,18 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 logger.debug("Modules affected by POM changes: {}", keys(affectedByPom));
             }
 
-            // Derive changed managed dep/plugin GAs from effective models (for report only)
-            Set<String> changedManagedDepGAs = deriveChangedManagedDeps(oldEffectiveModels, newEffectiveModels);
-            Set<String> changedManagedPluginGAs = deriveChangedManagedPlugins(oldEffectiveModels, newEffectiveModels);
+            // Derive changed managed dep/plugin GAs
+            Set<String> changedManagedDepGAs =
+                    transitiveImpactAnalyzer.deriveChangedManagedDeps(oldEffectiveModels, newEffectiveModels);
+            Set<String> changedManagedPluginGAs =
+                    transitiveImpactAnalyzer.deriveChangedManagedPlugins(oldEffectiveModels, newEffectiveModels);
 
-            // Combine
+            // Combine directly affected
             Set<MavenProject> directlyAffected = new LinkedHashSet<>();
             directlyAffected.addAll(affectedBySource);
             directlyAffected.addAll(affectedByPom);
 
-            // Compute test-only modules for downstream propagation control
-            // Modules with only test source changes don't propagate downstream
-            // (unless downstream depends on test-jar). Modules also affected by POM
-            // changes are NOT test-only since POM changes can affect production builds.
+            // Compute test-only modules
             Set<MavenProject> testOnlyModules = new LinkedHashSet<>(sourceResult.getTestOnlyAffected());
             testOnlyModules.removeAll(affectedByPom);
 
@@ -307,7 +285,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     if (directlyAffected.contains(project)) {
                         continue;
                     }
-                    String pattern = matchesForceBuild(project, config.getForceBuildModules());
+                    String pattern = forceBuildMatcher.matchesForceBuild(project, config.getForceBuildModules());
                     if (pattern != null) {
                         directlyAffected.add(project);
                         forceIncluded.add(project);
@@ -316,30 +294,24 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 }
             }
 
-            // Force-included modules are not test-only
             testOnlyModules.removeAll(forceIncluded);
 
-            if (directlyAffected.isEmpty() && oldEffectiveModels.isEmpty()) {
-                logger.info("Scalpel: No modules affected by changes");
-                if (config.isPassiveMode()) {
-                    if (config.isModeShadow()) {
-                        writeShadowStatus(reactorRoot, "skipped", "no modules affected by changes");
-                    }
-                    writeReport(
-                            config,
-                            normalizedRoot,
-                            allProjects,
-                            AnalysisContext.empty(
-                                    changedFiles,
-                                    changedProperties,
-                                    changedManagedDepGAs,
-                                    changedManagedPluginGAs,
-                                    unmatchedPomPaths),
-                            timings,
-                            analysisStartNano);
-                } else if (config.isModeSkipTests()) {
-                    skipTestsOnAll(allProjects);
-                }
+            ChangesetContext cctx = new ChangesetContext(
+                    config,
+                    normalizedRoot,
+                    allProjects,
+                    changedFiles,
+                    changedProperties,
+                    changedManagedDepGAs,
+                    changedManagedPluginGAs,
+                    unmatchedPomPaths,
+                    timings,
+                    analysisStartNano);
+
+            if (handleNoAffectedModules(
+                    directlyAffected.isEmpty() && oldEffectiveModels.isEmpty(),
+                    "no modules affected by changes",
+                    cctx)) {
                 return;
             }
 
@@ -348,34 +320,26 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         "Scalpel: {} modules directly affected: {}", directlyAffected.size(), keys(directlyAffected));
             }
 
-            // Shared caches for dependency collection results — used by both
-            // computeTransitivelyAffected and applySkipTests to avoid resolving the same
-            // module twice.  Separate caches for old (from effective models) and new (current).
+            // Shared caches for dependency collection results
             Map<MavenProject, DependencyResolutionResult> collectCache = new LinkedHashMap<>();
             Map<MavenProject, DependencyResolutionResult> oldCollectCache = new LinkedHashMap<>();
+            TransitiveImpactAnalyzer.ResolutionContext rctx = new TransitiveImpactAnalyzer.ResolutionContext(
+                    normalizedRoot, session, collectCache, oldCollectCache, timings);
+            TransitiveImpactAnalyzer.EffectiveModels models =
+                    new TransitiveImpactAnalyzer.EffectiveModels(oldEffectiveModels, newEffectiveModels);
 
-            // Compute transitively affected modules by comparing old vs new dependency trees
+            // Compute transitively affected modules
             Map<MavenProject, List<String>> transitiveEvidence = new LinkedHashMap<>();
             Map<MavenProject, List<String>> transitivelyAffected;
             timings.start(Timings.PHASE_TRANSITIVE_RESOLVE);
             try {
-                transitivelyAffected = computeTransitivelyAffected(
-                        allProjects,
-                        directlyAffected,
-                        oldEffectiveModels,
-                        newEffectiveModels,
-                        reactorRoot,
-                        session,
-                        collectCache,
-                        oldCollectCache,
-                        timings,
-                        config.isExplain(),
-                        transitiveEvidence);
+                transitivelyAffected = transitiveImpactAnalyzer.computeTransitivelyAffected(
+                        allProjects, directlyAffected, models, rctx, config.isExplain(), transitiveEvidence);
             } finally {
                 timings.stop(Timings.PHASE_TRANSITIVE_RESOLVE);
             }
 
-            // Explain-mode evidence: which specific input triggered each module
+            // Explain-mode evidence
             Map<MavenProject, List<String>> evidence = config.isExplain()
                     ? buildEvidence(
                             sourceResult.getTriggeringFiles(),
@@ -385,43 +349,26 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             forceBuildPatterns)
                     : Map.of();
 
-            if (directlyAffected.isEmpty() && transitivelyAffected.isEmpty()) {
-                logger.info("Scalpel: No modules affected by changes");
-                if (config.isPassiveMode()) {
-                    if (config.isModeShadow()) {
-                        writeShadowStatus(reactorRoot, "skipped", "no modules affected by changes");
-                    }
-                    writeReport(
-                            config,
-                            normalizedRoot,
-                            allProjects,
-                            AnalysisContext.empty(
-                                    changedFiles,
-                                    changedProperties,
-                                    changedManagedDepGAs,
-                                    changedManagedPluginGAs,
-                                    unmatchedPomPaths),
-                            timings,
-                            analysisStartNano);
-                } else if (config.isModeSkipTests()) {
-                    skipTestsOnAll(allProjects);
-                }
+            if (handleNoAffectedModules(
+                    directlyAffected.isEmpty() && transitivelyAffected.isEmpty(),
+                    "no modules affected by changes",
+                    cctx)) {
                 return;
             }
 
-            // Include transitively affected modules (from managed dep/plugin changes) in the affected set
+            // Include transitively affected modules
             Set<MavenProject> allAffected = new LinkedHashSet<>(directlyAffected);
             allAffected.addAll(transitivelyAffected.keySet());
 
-            // Apply includePaths module filter: restrict affected modules by path while
-            // keeping full diff visibility for change detection and POM analysis above.
-            // The matchers are compiled once here and reused later in trim/report/skip-tests
-            // mode to also filter downstream expansions and managed-dep re-enabling.
-            List<PathMatcher> includeMatchers = compileGlobMatchers(config.getIncludePaths());
+            // Apply includePaths module filter
+            List<PathMatcher> includeMatchers = ChangedFileClassifier.compileGlobMatchers(config.getIncludePaths());
             if (!includeMatchers.isEmpty()) {
                 int beforeCount = allAffected.size();
-                directlyAffected.removeIf(p -> !matchesIncludePaths(p, includeMatchers, normalizedRoot));
-                transitivelyAffected.keySet().removeIf(p -> !matchesIncludePaths(p, includeMatchers, normalizedRoot));
+                directlyAffected.removeIf(
+                        p -> !ChangedFileClassifier.matchesIncludePaths(p, includeMatchers, normalizedRoot));
+                transitivelyAffected
+                        .keySet()
+                        .removeIf(p -> !ChangedFileClassifier.matchesIncludePaths(p, includeMatchers, normalizedRoot));
                 testOnlyModules.retainAll(directlyAffected);
                 forceIncluded.retainAll(directlyAffected);
 
@@ -433,40 +380,18 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     logger.info("Scalpel: {} modules excluded by includePaths filters", removedCount);
                 }
 
-                if (allAffected.isEmpty()) {
-                    logger.info("Scalpel: No modules match includePaths filters");
-                    if (config.isPassiveMode()) {
-                        if (config.isModeShadow()) {
-                            writeShadowStatus(reactorRoot, "skipped", "no modules match includePaths filters");
-                        }
-                        writeReport(
-                                config,
-                                normalizedRoot,
-                                allProjects,
-                                AnalysisContext.empty(
-                                        changedFiles,
-                                        changedProperties,
-                                        changedManagedDepGAs,
-                                        changedManagedPluginGAs,
-                                        unmatchedPomPaths),
-                                timings,
-                                analysisStartNano);
-                    } else if (config.isModeSkipTests()) {
-                        skipTestsOnAll(allProjects);
-                    }
+                if (handleNoAffectedModules(allAffected.isEmpty(), "no modules match includePaths filters", cctx)) {
                     return;
                 }
             }
 
             // Write impacted module log if configured
             if (config.getImpactedLog() != null) {
-                writeImpactedLog(config, normalizedRoot, allAffected);
+                impactedLogWriter.writeImpactedLog(config, normalizedRoot, allAffected);
             }
 
             if (config.isPassiveMode()) {
                 // Compute upstream/downstream categorization for report enrichment
-                // Use directlyAffected here (not allAffected) to preserve correct DOWNSTREAM categorization;
-                // transitively affected modules are added to the report separately via addTransitivelyAffectedModules
                 TrimResult trimResult = null;
                 if (!directlyAffected.isEmpty()) {
                     timings.start(Timings.PHASE_TRIM);
@@ -481,7 +406,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     mergeTrimReasons(evidence, trimResult);
                 }
 
-                writeReport(
+                reportAssembler.writeReport(
                         config,
                         normalizedRoot,
                         allProjects,
@@ -508,14 +433,6 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     logExplainDecisions(allProjects, reportedModules, evidence);
                 }
                 if (config.isModeShadow()) {
-                    // Shadow mode (#92): hand the would-be trim decision to a monitor wrapped
-                    // around the session's ExecutionListener; the full build below runs
-                    // unmodified while per-module wall-clock and failures are recorded, and at
-                    // session end the join is written to target/scalpel-shadow.json plus one
-                    // JSONL history line. The decision uses the same ReactorTrimmer call trim
-                    // mode runs on the same inputs, so shadow and trim decisions agree by
-                    // construction; when nothing is transitively affected, the report branch
-                    // above already computed that exact set.
                     TrimResult decision;
                     if (trimResult != null && allAffected.equals(directlyAffected)) {
                         decision = trimResult;
@@ -530,21 +447,19 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                     Set<String> wouldHaveBuilt = new LinkedHashSet<>();
                     java.util.function.Function<MavenProject, String> moduleKey = project -> {
-                        String path = relativePath(normalizedRoot, project);
+                        String path = ChangedFileClassifier.relativePath(normalizedRoot, project);
                         // The root aggregator relativizes to the empty string; report it as
                         // "." like the impacted log does (#84) so every module has a name.
                         return path.isEmpty() ? "." : path;
                     };
                     List<MavenProject> decisionBuildSet = decision.getBuildSet();
                     if (!includeMatchers.isEmpty()) {
-                        // Mirror the post-computeBuildSet filter trim mode applies, so the
-                        // shadow decision is the set trim would actually build: downstream
-                        // modules outside the includePaths scope are dropped here too.
                         Set<MavenProject> affected = allAffected;
                         decisionBuildSet = new ArrayList<>(decisionBuildSet);
                         decisionBuildSet.removeIf(project -> !affected.contains(project)
                                 && !decision.getUpstreamOnly().contains(project)
-                                && !matchesIncludePaths(project, includeMatchers, normalizedRoot));
+                                && !ChangedFileClassifier.matchesIncludePaths(
+                                        project, includeMatchers, normalizedRoot));
                     }
                     for (MavenProject project : decisionBuildSet) {
                         wouldHaveBuilt.add(moduleKey.apply(project));
@@ -592,18 +507,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (config.isModeSkipTests()) {
                 timings.start(Timings.PHASE_APPLY_SKIP_TESTS);
                 try {
-                    applySkipTests(
-                            session,
-                            allProjects,
-                            trimResult,
-                            config,
-                            oldEffectiveModels,
-                            newEffectiveModels,
-                            includeMatchers,
-                            normalizedRoot,
-                            collectCache,
-                            oldCollectCache,
-                            timings);
+                    skipTestsApplier.applySkipTests(allProjects, trimResult, config, models, includeMatchers, rctx);
                 } finally {
                     timings.stop(Timings.PHASE_APPLY_SKIP_TESTS);
                 }
@@ -614,25 +518,22 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 // trim mode: remove unaffected projects from reactor
                 List<MavenProject> buildSet = trimResult.getBuildSet();
                 if (!includeMatchers.isEmpty()) {
-                    // Filter downstream modules outside includePaths scope while keeping
-                    // upstream build prerequisites and directly/transitively affected modules
                     Set<MavenProject> finalAllAffected = allAffected;
                     buildSet = new ArrayList<>(buildSet);
                     buildSet.removeIf(p -> !finalAllAffected.contains(p)
                             && !trimResult.getUpstreamOnly().contains(p)
-                            && !matchesIncludePaths(p, includeMatchers, normalizedRoot));
+                            && !ChangedFileClassifier.matchesIncludePaths(p, includeMatchers, normalizedRoot));
                 }
                 logger.info(
                         "Scalpel: Building {} of {} modules: {}", buildSet.size(), allProjects.size(), keys(buildSet));
                 session.setProjects(buildSet);
                 // Apply per-category args in trim mode
-                applyPerCategoryArgs(trimResult, config);
+                skipTestsApplier.applyPerCategoryArgs(trimResult, config);
                 if (config.isExplain()) {
                     logExplainDecisions(allProjects, new LinkedHashSet<>(buildSet), evidence);
                 }
-                // Write the same JSON report as report mode, so the skipped set (allProjects
-                // minus buildSet) is reviewable alongside the green trimmed build (#91)
-                writeReport(
+                // Write the same JSON report as report mode
+                reportAssembler.writeReport(
                         config,
                         normalizedRoot,
                         allProjects,
@@ -657,10 +558,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 logger.warn("Scalpel: {}, building all modules", e.getMessage());
                 logger.debug("ScalpelException details", e);
                 if (config.isModeShadow()) {
-                    // The monitor is the last thing the passive branch installs, so an
-                    // exception reaching here means nothing was measured; a previous run's
-                    // shadow document must not survive the bail-out.
-                    writeShadowStatus(reactorRoot, "failed", e.getMessage());
+                    reportAssembler.writeShadowStatus(reactorRoot, "failed", e.getMessage());
                 }
                 return;
             }
@@ -670,7 +568,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 logger.warn("Scalpel: Unexpected error, building all modules: {}", e.getMessage());
                 logger.debug("Unexpected error details", e);
                 if (config.isPassiveMode()) {
-                    writeFailedStatusReport(config, reactorRoot, "unexpected error: " + e.getMessage());
+                    reportAssembler.writeFailedStatusReport(config, reactorRoot, "unexpected error: " + e.getMessage());
                 }
                 return;
             }
@@ -681,12 +579,58 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     }
 
     /**
-     * One greppable INFO line answering "how long did Scalpel take and where did it go":
-     * total wall-clock millis, the per-phase breakdown, and the operation counters (#99).
+     * Bundles the changeset-level context needed by {@link #handleNoAffectedModules}.
+     */
+    record ChangesetContext(
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            List<MavenProject> allProjects,
+            Set<String> changedFiles,
+            Set<String> changedProperties,
+            Set<String> changedManagedDepGAs,
+            Set<String> changedManagedPluginGAs,
+            Set<String> unmatchedPomPaths,
+            Timings timings,
+            long analysisStartNano) {}
+
+    /**
+     * Handles the triplicated 'no affected modules' pattern. Returns {@code true} if the
+     * condition was met and the caller should return early.
+     */
+    private boolean handleNoAffectedModules(boolean noAffectedCondition, String reason, ChangesetContext cctx)
+            throws MavenExecutionException {
+        if (!noAffectedCondition) {
+            return false;
+        }
+        logger.info("Scalpel: No modules affected by changes");
+        if (cctx.config().isPassiveMode()) {
+            if (cctx.config().isModeShadow()) {
+                reportAssembler.writeShadowStatus(cctx.reactorRoot(), "skipped", reason);
+            }
+            reportAssembler.writeReport(
+                    cctx.config(),
+                    cctx.reactorRoot(),
+                    cctx.allProjects(),
+                    AnalysisContext.empty(
+                            cctx.changedFiles(),
+                            cctx.changedProperties(),
+                            cctx.changedManagedDepGAs(),
+                            cctx.changedManagedPluginGAs(),
+                            cctx.unmatchedPomPaths()),
+                    cctx.timings(),
+                    cctx.analysisStartNano());
+        } else if (cctx.config().isModeSkipTests()) {
+            skipTestsApplier.skipTestsOnAll(cctx.allProjects());
+        }
+        return true;
+    }
+
+    /**
+     * One greppable INFO line answering "how long did Scalpel take and where did it go".
      */
     private void logAnalysisSummary(Timings timings, long analysisStartNano) {
         StringBuilder line = new StringBuilder("Scalpel: analysis took ")
-                .append(millisSince(analysisStartNano))
+                .append(ReportAssembler.millisSince(analysisStartNano))
                 .append("ms");
         String phases = timings.toString();
         if (!phases.isEmpty()) {
@@ -699,1271 +643,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         logger.info("{}", line);
     }
 
-    private static long millisSince(long startNano) {
-        return (System.nanoTime() - startNano) / 1_000_000;
-    }
-
-    private boolean matchesDisableTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
-        for (String pattern : config.getDisableTriggers()) {
-            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
-            for (String changedFile : changedFiles) {
-                if (matcher.matches(Path.of(changedFile))) {
-                    logger.info(
-                            "Scalpel: Disabled due to change in {} (matches disable trigger {})", changedFile, pattern);
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private static List<PathMatcher> compileGlobMatchers(List<String> patterns) {
-        if (patterns.isEmpty()) {
-            return List.of();
-        }
-        List<PathMatcher> matchers = new ArrayList<>(patterns.size());
-        for (String pattern : patterns) {
-            matchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern)));
-        }
-        return matchers;
-    }
-
     /**
-     * Normalizes a user-supplied glob pattern so that bare patterns (those containing no path
-     * separator) match files at any depth in the repository tree. For example, {@code *.md} is
-     * rewritten to {@code {*.md,**&#47;*.md}} so that it matches both {@code README.md} (root)
-     * and {@code docs/guide.md} (nested). A plain {@code **&#47;} prefix alone would not match
-     * root-level files on the default {@link java.nio.file.FileSystem} because the path separator
-     * in the pattern is required to be present in the matched path. Patterns that already contain
-     * a {@code /} are returned unchanged because the user explicitly specified the directory
-     * structure.
-     */
-    static String normalizeGlobPattern(String pattern) {
-        if (pattern.contains("/")) {
-            return pattern;
-        }
-        return "{" + pattern + ",**/" + pattern + "}";
-    }
-
-    private Set<String> filterExcludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
-        List<PathMatcher> excludeMatchers = compileGlobMatchers(config.getExcludePaths());
-        if (excludeMatchers.isEmpty()) {
-            return changedFiles;
-        }
-        Set<String> filtered = new LinkedHashSet<>();
-        for (String file : changedFiles) {
-            boolean excluded = false;
-            for (PathMatcher matcher : excludeMatchers) {
-                if (matcher.matches(Path.of(file))) {
-                    excluded = true;
-                    break;
-                }
-            }
-            if (!excluded) {
-                filtered.add(file);
-            }
-        }
-        int excludedCount = changedFiles.size() - filtered.size();
-        if (excludedCount > 0) {
-            logger.info("Scalpel: {} files excluded by path filters", excludedCount);
-        }
-        return filtered;
-    }
-
-    private boolean matchesIncludePaths(MavenProject project, List<PathMatcher> matchers, Path reactorRoot) {
-        String relPath = relativePath(reactorRoot, project);
-        Path modulePath = Path.of(relPath);
-        for (PathMatcher matcher : matchers) {
-            // Match the module path directly (e.g., "module-a" matches pattern "module-a")
-            // or match a file within the module (e.g., "module-a/pom.xml" matches pattern "module-a/**")
-            if (matcher.matches(modulePath) || matcher.matches(modulePath.resolve("pom.xml"))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private String findFullBuildTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
-        for (String pattern : config.getFullBuildTriggers()) {
-            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
-            for (String changedFile : changedFiles) {
-                if (matcher.matches(Path.of(changedFile))) {
-                    logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
-                    return changedFile;
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Determine which non-directly-affected modules are <em>transitively</em> affected
-     * by changes in the reactor.  Uses a two-pass algorithm:
-     *
-     * <h4>Pass 1 — Effective model and dependency tree comparison</h4>
-     * For each non-directly-affected module, compare old vs new effective models:
-     * <ul>
-     *   <li><b>Effective plugins:</b> diff plugin versions from the fully-interpolated
-     *       models.  A managed plugin version bump that flows into this module's effective
-     *       plugin list triggers {@code MANAGED_PLUGIN}.</li>
-     *   <li><b>Resolved dependency tree:</b> resolve the module's dependency tree twice —
-     *       once from the old effective model, once from the current project — and diff the
-     *       (GA → version) maps.  A version difference triggers {@code TRANSITIVE_DEPENDENCY}
-     *       or {@code TRANSITIVE_DEPENDENCY_TEST} depending on scope.</li>
-     * </ul>
-     *
-     * <h4>Pass 2 — Reactor dependency propagation</h4>
-     * Pass 1 misses modules whose dependency tree changed only <em>transitively through
-     * reactor siblings</em>.  When resolving "old" dependency trees, Maven's reactor always
-     * provides the current (new) version of reactor siblings, so a module that depends on an
-     * affected reactor module will have identical old/new trees.
-     * <p>
-     * To catch this, pass 2 collects the GAs of all affected modules (directly + from pass 1)
-     * and checks each remaining module's dependency tree for those GAs.  If found, the module
-     * is transitively affected because rebuilding the upstream reactor module will change its
-     * output artifacts.  This propagates iteratively to a fixed point to handle chains
-     * (A → B → C where only A's POM changed).
-     */
-    private Map<MavenProject, List<String>> computeTransitivelyAffected(
-            List<MavenProject> allProjects,
-            Set<MavenProject> directlyAffected,
-            Map<String, Model> oldEffectiveModels,
-            Map<String, Model> newEffectiveModels,
-            Path reactorRoot,
-            MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
-            Timings timings,
-            boolean explain,
-            Map<MavenProject, List<String>> returnEvidence) {
-        Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
-        Map<MavenProject, List<String>> transitiveEvidence = new LinkedHashMap<>();
-        if (oldEffectiveModels.isEmpty()) {
-            logger.debug("Skipping transitive analysis: no effective models available");
-            return transitivelyAffected;
-        }
-        Path absRoot = reactorRoot.toAbsolutePath().normalize();
-        logger.debug(
-                "Computing transitively affected modules: comparing old vs new dependency trees for {} non-direct modules",
-                allProjects.size() - directlyAffected.size());
-        // First pass: compare effective models and dependency trees directly
-        for (MavenProject project : allProjects) {
-            if (directlyAffected.contains(project)) {
-                continue;
-            }
-            TransitiveMatch match = computeTransitiveMatch(
-                    project,
-                    oldEffectiveModels,
-                    newEffectiveModels,
-                    absRoot,
-                    session,
-                    collectCache,
-                    oldCollectCache,
-                    timings,
-                    explain);
-            if (!match.reasons.isEmpty()) {
-                transitivelyAffected.put(project, match.reasons);
-                if (explain) {
-                    transitiveEvidence.put(project, match.evidence);
-                }
-            }
-        }
-
-        // Second pass: propagate through reactor dependencies.
-        // When resolving "old" dependency trees, Maven's reactor always provides the current
-        // (new) version of reactor siblings.  So a module whose POM didn't change but depends
-        // on an affected reactor module will have identical old/new trees — the first pass
-        // misses it.  Fix: if a module's dependency tree contains the GA of any affected
-        // reactor module, it is transitively affected because rebuilding that upstream module
-        // will change its output artifacts.
-        Set<String> affectedGAs = new LinkedHashSet<>();
-        for (MavenProject p : directlyAffected) {
-            affectedGAs.add(p.getGroupId() + ":" + p.getArtifactId());
-        }
-        for (MavenProject p : transitivelyAffected.keySet()) {
-            affectedGAs.add(p.getGroupId() + ":" + p.getArtifactId());
-        }
-        boolean propagated = true;
-        while (propagated) {
-            propagated = false;
-            for (MavenProject project : allProjects) {
-                if (directlyAffected.contains(project) || transitivelyAffected.containsKey(project)) {
-                    continue;
-                }
-                DependencyResolutionResult depResult =
-                        resolveProjectDependencies(project, session, collectCache, timings);
-                if (depResult == null || depResult.getDependencyGraph() == null) {
-                    if (!affectedGAs.isEmpty()) {
-                        // Conservative: dependency resolution failed while there are
-                        // affected reactor modules whose impact could reach this one
-                        // through the unresolvable graph. Treat the module as affected
-                        // instead of silently dropping it. When nothing is affected
-                        // there is no impact the failure could hide, so skipping is
-                        // correct.
-                        logger.warn(
-                                "Cannot resolve dependencies of {} while propagating changes, conservatively marking as affected",
-                                key(project));
-                        List<String> reasons = new ArrayList<>();
-                        reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED);
-                        transitivelyAffected.put(project, reasons);
-                        affectedGAs.add(project.getGroupId() + ":" + project.getArtifactId());
-                        if (explain) {
-                            transitiveEvidence.put(
-                                    project,
-                                    List.of("dependency resolution failed; conservatively treated as affected"));
-                        }
-                        propagated = true;
-                    }
-                    continue;
-                }
-                Map<String, String> depScopes = collectDependencyScopes(depResult.getDependencyGraph());
-                for (Map.Entry<String, String> dep : depScopes.entrySet()) {
-                    if (affectedGAs.contains(dep.getKey())) {
-                        List<String> reasons = new ArrayList<>();
-                        if ("test".equals(dep.getValue())) {
-                            reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
-                        } else {
-                            reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
-                        }
-                        transitivelyAffected.put(project, reasons);
-                        affectedGAs.add(project.getGroupId() + ":" + project.getArtifactId());
-                        if (explain) {
-                            transitiveEvidence.put(
-                                    project, List.of("depends on affected reactor module " + dep.getKey()));
-                        }
-                        propagated = true;
-                        break;
-                    }
-                }
-            }
-        }
-        if (!transitivelyAffected.isEmpty()) {
-            logger.info(
-                    "Scalpel: {} modules transitively affected: {}",
-                    transitivelyAffected.size(),
-                    keys(transitivelyAffected.keySet()));
-        }
-        returnEvidence.putAll(transitiveEvidence);
-        return transitivelyAffected;
-    }
-
-    private static final class TransitiveMatch {
-        final List<String> reasons;
-        final List<String> evidence;
-
-        TransitiveMatch(List<String> reasons, List<String> evidence) {
-            this.reasons = reasons;
-            this.evidence = evidence;
-        }
-    }
-
-    /**
-     * Compare old vs new effective models and dependency trees for a single module.
-     * Effective plugin comparison uses the fully-interpolated models directly.
-     * Dependency tree comparison resolves both old and new trees and diffs them.
-     */
-    private TransitiveMatch computeTransitiveMatch(
-            MavenProject project,
-            Map<String, Model> oldEffectiveModels,
-            Map<String, Model> newEffectiveModels,
-            Path absRoot,
-            MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
-            Timings timings,
-            boolean explain) {
-        List<String> reasons = new ArrayList<>();
-        List<String> evidence = explain ? new ArrayList<>() : List.of();
-
-        String relPath = absRoot.relativize(
-                        project.getFile().toPath().toAbsolutePath().normalize())
-                .toString()
-                .replace('\\', '/');
-        Model oldModel = oldEffectiveModels.get(relPath);
-        Model newModel = newEffectiveModels.get(relPath);
-        if (oldModel == null || newModel == null) {
-            return new TransitiveMatch(reasons, evidence);
-        }
-
-        // Compare effective plugins directly from the fully-interpolated models
-        Set<String> changedPlugins = pomChangeAnalyzer.diffManagedPluginVersions(
-                pomChangeAnalyzer.getEffectivePlugins(oldModel), pomChangeAnalyzer.getEffectivePlugins(newModel));
-        if (!changedPlugins.isEmpty()) {
-            reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
-            if (explain) {
-                evidence.add("effective plugin " + changedPlugins.iterator().next());
-            }
-        }
-
-        // Compare resolved dependency trees: old effective model vs current project
-        ChangedDependencyMatch depMatch =
-                findChangedDependencyInTree(project, oldModel, session, collectCache, oldCollectCache, timings);
-        if (depMatch != null) {
-            if (UNRESOLVED_GA.equals(depMatch.ga)) {
-                reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED);
-            } else if ("test".equals(depMatch.scope)) {
-                reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
-            } else {
-                reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
-            }
-            if (explain) {
-                evidence.add("dependency tree diff " + depMatch.ga);
-            }
-        }
-
-        return new TransitiveMatch(reasons, evidence);
-    }
-
-    private void applySkipTests(
-            MavenSession session,
-            List<MavenProject> allProjects,
-            TrimResult trimResult,
-            ScalpelConfiguration config,
-            Map<String, Model> oldEffectiveModels,
-            Map<String, Model> newEffectiveModels,
-            List<PathMatcher> includeMatchers,
-            Path reactorRoot,
-            Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
-            Timings timings) {
-
-        Path absRoot = reactorRoot.toAbsolutePath().normalize();
-        Set<MavenProject> buildSetLookup = new LinkedHashSet<>(trimResult.getBuildSet());
-        List<MavenProject> testProjects = new ArrayList<>();
-        List<MavenProject> skippedProjects = new ArrayList<>();
-
-        // Directly affected modules always run tests
-        for (MavenProject project : trimResult.getBuildSet()) {
-            if (trimResult.getDirectlyAffected().contains(project)) {
-                testProjects.add(project);
-            } else if (config.isSkipTestsForUpstream()
-                    && trimResult.getUpstreamOnly().contains(project)) {
-                // Skip tests on upstream-only modules if configured
-                project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
-                skippedProjects.add(project);
-            } else if (shouldSkipTestsForExcludedDownstream(
-                    project,
-                    trimResult,
-                    config,
-                    oldEffectiveModels,
-                    newEffectiveModels,
-                    absRoot,
-                    session,
-                    collectCache,
-                    oldCollectCache,
-                    timings)) {
-                // Skip tests on excluded downstream modules (unless they also have plugin/dep changes)
-                project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
-                skippedProjects.add(project);
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Scalpel: Skipping tests on excluded downstream module {}", key(project));
-                }
-            } else {
-                // Downstream modules run tests by default
-                testProjects.add(project);
-            }
-        }
-
-        for (MavenProject project : allProjects) {
-            if (buildSetLookup.contains(project)) {
-                continue; // Already handled above
-            }
-
-            // Skip tests on modules outside includePaths scope — managed dep/plugin
-            // re-enabling should not override the user's includePaths restriction
-            if (!includeMatchers.isEmpty() && !matchesIncludePaths(project, includeMatchers, reactorRoot)) {
-                project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
-                skippedProjects.add(project);
-                continue;
-            }
-
-            // Check if this module's effective plugins or dependency tree changed
-            if (hasEffectiveModelChanges(
-                    project,
-                    oldEffectiveModels,
-                    newEffectiveModels,
-                    absRoot,
-                    session,
-                    collectCache,
-                    oldCollectCache,
-                    timings)) {
-                testProjects.add(project);
-                continue;
-            }
-
-            // Skip tests on this project
-            project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
-            skippedProjects.add(project);
-        }
-
-        // Apply per-category args
-        applyPerCategoryArgs(trimResult, config);
-
-        // Softening must have the last word on maven.test.skip/skipTests: it runs after
-        // applyPerCategoryArgs so user-configured upstreamArgs/downstreamArgs cannot
-        // reintroduce the #47 failure on a consumed test-jar producer.
-        Set<MavenProject> softenedProjects = softenTestJarProducers(testProjects, skippedProjects);
-
-        logger.info(
-                "Scalpel: Testing {}, {} compile-only (test-jar producers), skipping tests on {} of {} modules: {}",
-                testProjects.size(),
-                softenedProjects.size(),
-                skippedProjects.size(),
-                allProjects.size(),
-                keys(skippedProjects));
-    }
-
-    /**
-     * Modules slated for a full test skip (maven.test.skip=true) also skip test-compile, which
-     * suppresses their test-jar. If some other module that will still run tests (directly, or
-     * because it was already softened by a previous pass) depends on that test-jar
-     * (&lt;type&gt;test-jar&lt;/type&gt;), its test-compile would fail looking for classes that
-     * were never built. Soften those producers: drop maven.test.skip and use skipTests=true
-     * instead, which only disables the surefire/failsafe execution while leaving test-compile
-     * (and jar:test-jar) intact. Softening a producer can itself depend on another skipped
-     * producer's test-jar (chained test-jar consumers), so the algorithm uses a worklist BFS
-     * to propagate transitively in O(M × D) total rather than a fixpoint restart loop.
-     */
-    private Set<MavenProject> softenTestJarProducers(
-            List<MavenProject> testProjects, List<MavenProject> skippedProjects) {
-
-        // Index skipped projects by coordinates so we can look up producers in O(1).
-        Map<String, MavenProject> skippedByGa = new LinkedHashMap<>(skippedProjects.size());
-        for (MavenProject sp : skippedProjects) {
-            skippedByGa.put(sp.getGroupId() + ":" + sp.getArtifactId(), sp);
-        }
-
-        Set<MavenProject> softenedProjects = new LinkedHashSet<>();
-
-        // Worklist BFS: seed with the projects that will compile tests.  For each consumer,
-        // find skipped producers whose test-jar it requires, soften them, and enqueue them
-        // (a softened producer compiles its own tests, so its own test-jar deps must be
-        // checked in turn).  Each project is enqueued at most once, giving O(M × D) total.
-        ArrayDeque<MavenProject> worklist = new ArrayDeque<>(testProjects);
-        while (!worklist.isEmpty()) {
-            MavenProject consumer = worklist.poll();
-            for (org.apache.maven.model.Dependency dep : consumer.getDependencies()) {
-                if (!"test-jar".equals(dep.getType())) {
-                    continue;
-                }
-                String ga = dep.getGroupId() + ":" + dep.getArtifactId();
-                MavenProject producer = skippedByGa.get(ga);
-                if (producer == null || softenedProjects.contains(producer)) {
-                    continue;
-                }
-                // Soften: keep test-compile but skip surefire/failsafe execution.
-                producer.getProperties().remove(MAVEN_TEST_SKIP);
-                producer.getProperties().setProperty(SKIP_TESTS, "true");
-                softenedProjects.add(producer);
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                            "Scalpel: Keeping test-compile for {} because its test-jar is consumed"
-                                    + " in-reactor by {} (softened: skipTests=true instead of"
-                                    + " maven.test.skip=true)",
-                            key(producer),
-                            key(consumer));
-                }
-                // Enqueue the newly softened producer so its own test-jar deps are checked.
-                // No re-enqueue guard needed: testProjects and skippedProjects are disjoint
-                // by construction, and softenedProjects.contains() above prevents re-processing.
-                worklist.add(producer);
-            }
-        }
-
-        skippedProjects.removeAll(softenedProjects);
-        if (!softenedProjects.isEmpty()) {
-            logger.info(
-                    "Scalpel: {} modules had test-compile restored for in-reactor test-jar consumers: {}",
-                    softenedProjects.size(),
-                    keys(softenedProjects));
-        }
-        return softenedProjects;
-    }
-
-    private boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
-        for (String pattern : patterns) {
-            if (pattern.contains(":")) {
-                if (key(project).equals(pattern)) {
-                    return true;
-                }
-            } else {
-                if (project.getArtifactId().equals(pattern)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private boolean shouldSkipTestsForExcludedDownstream(
-            MavenProject project,
-            TrimResult trimResult,
-            ScalpelConfiguration config,
-            Map<String, Model> oldEffectiveModels,
-            Map<String, Model> newEffectiveModels,
-            Path absRoot,
-            MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
-            Timings timings) {
-        if (config.getSkipTestsForDownstreamModules().isEmpty()) {
-            return false;
-        }
-        if (!trimResult.getDownstreamOnly().contains(project)
-                && !trimResult.getDownstreamTestOnly().contains(project)) {
-            return false;
-        }
-        if (!matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
-            return false;
-        }
-        // Safety guard: don't skip tests if the module has effective model changes
-        return !hasEffectiveModelChanges(
-                project,
-                oldEffectiveModels,
-                newEffectiveModels,
-                absRoot,
-                session,
-                collectCache,
-                oldCollectCache,
-                timings);
-    }
-
-    /**
-     * A DependencyFilter that rejects all nodes, preventing artifact downloads
-     * while still allowing the dependency graph to be collected.
-     */
-    private static final DependencyFilter COLLECT_ONLY_FILTER = new DependencyFilter() {
-        @Override
-        public boolean accept(DependencyNode node, List<DependencyNode> parents) {
-            return false;
-        }
-    };
-
-    /**
-     * Checks whether a module's effective plugins or resolved dependency tree changed
-     * between old and new effective models.
-     */
-    private boolean hasEffectiveModelChanges(
-            MavenProject project,
-            Map<String, Model> oldEffectiveModels,
-            Map<String, Model> newEffectiveModels,
-            Path absRoot,
-            MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
-            Timings timings) {
-        String relPath = absRoot.relativize(
-                        project.getFile().toPath().toAbsolutePath().normalize())
-                .toString()
-                .replace('\\', '/');
-        Model oldModel = oldEffectiveModels.get(relPath);
-        Model newModel = newEffectiveModels.get(relPath);
-        if (oldModel == null || newModel == null) {
-            return false;
-        }
-
-        // Check effective plugins
-        Set<String> changedPlugins = pomChangeAnalyzer.diffManagedPluginVersions(
-                pomChangeAnalyzer.getEffectivePlugins(oldModel), pomChangeAnalyzer.getEffectivePlugins(newModel));
-        if (!changedPlugins.isEmpty()) {
-            return true;
-        }
-
-        // Check dependency tree
-        return findChangedDependencyInTree(project, oldModel, session, collectCache, oldCollectCache, timings) != null;
-    }
-
-    private static final class ChangedDependencyMatch {
-        final String ga;
-        final String scope;
-
-        ChangedDependencyMatch(String ga, String scope) {
-            this.ga = ga;
-            this.scope = scope;
-        }
-    }
-
-    /**
-     * Resolve dependency trees from both old effective model and current project,
-     * then diff them.  Returns the first changed dependency (with scope), or null if trees match.
-     * <p>
-     * Uses a reject-all DependencyFilter so only the dependency graph is collected
-     * without downloading any artifact files — we only need GA coordinates, versions, and scopes.
-     */
-    private ChangedDependencyMatch findChangedDependencyInTree(
-            MavenProject project,
-            Model oldEffectiveModel,
-            MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> collectCache,
-            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
-            Timings timings) {
-
-        // Resolve new (current) dependency tree
-        DependencyResolutionResult newResult = resolveProjectDependencies(project, session, collectCache, timings);
-        if (newResult == null || newResult.getDependencyGraph() == null) {
-            // Conservative: when the current tree cannot be resolved at all, assume it
-            // changed so the module is treated as affected (and its tests are not
-            // skipped downstream). A redundant rebuild is safer than a green build
-            // on untested code.
-            return new ChangedDependencyMatch(UNRESOLVED_GA, "compile");
-        }
-
-        // Resolve old dependency tree from old effective model
-        DependencyResolutionResult oldResult =
-                resolveModelDependencies(oldEffectiveModel, project, session, oldCollectCache, timings);
-        if (oldResult == null || oldResult.getDependencyGraph() == null) {
-            // Conservative: same posture when the old tree cannot be resolved.
-            return new ChangedDependencyMatch(UNRESOLVED_GA, "compile");
-        }
-
-        // Collect (GA → version) from both trees and diff
-        Map<String, String> oldVersions = collectDependencyVersions(oldResult.getDependencyGraph());
-        Map<String, String> newVersions = collectDependencyVersions(newResult.getDependencyGraph());
-
-        // Find changed GAs and determine scope from the new tree
-        Map<String, String> newScopes = collectDependencyScopes(newResult.getDependencyGraph());
-
-        String narrowestGa = null;
-        String narrowestScope = null;
-
-        for (Map.Entry<String, String> e : oldVersions.entrySet()) {
-            if (!Objects.equals(e.getValue(), newVersions.get(e.getKey()))) {
-                String ga = e.getKey();
-                String scope = newScopes.getOrDefault(ga, "compile");
-                logger.debug("Module {} has changed dependency {} (scope={})", key(project), ga, scope);
-                if (!"test".equals(scope)) {
-                    return new ChangedDependencyMatch(ga, scope);
-                }
-                if (narrowestScope == null) {
-                    narrowestScope = "test";
-                    narrowestGa = ga;
-                }
-            }
-        }
-        // Check for newly added dependencies
-        for (String ga : newVersions.keySet()) {
-            if (!oldVersions.containsKey(ga)) {
-                String scope = newScopes.getOrDefault(ga, "compile");
-                logger.debug("Module {} has new dependency {} (scope={})", key(project), ga, scope);
-                if (!"test".equals(scope)) {
-                    return new ChangedDependencyMatch(ga, scope);
-                }
-                if (narrowestScope == null) {
-                    narrowestScope = "test";
-                    narrowestGa = ga;
-                }
-            }
-        }
-
-        return narrowestScope != null ? new ChangedDependencyMatch(narrowestGa, narrowestScope) : null;
-    }
-
-    /**
-     * Resolve the current project's dependency tree (cached).
-     */
-    private DependencyResolutionResult resolveProjectDependencies(
-            MavenProject project,
-            MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> cache,
-            Timings timings) {
-        DependencyResolutionResult result = cache.get(project);
-        if (result != null) {
-            timings.increment(Timings.OP_RESOLVE_CACHE_HITS);
-            return result;
-        }
-        try {
-            DefaultDependencyResolutionRequest request =
-                    new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
-            request.setResolutionFilter(COLLECT_ONLY_FILTER);
-            result = dependenciesResolver.resolve(request);
-        } catch (DependencyResolutionException e) {
-            // Conservative: even when the exception carries a partial result, its
-            // dependency graph may be incomplete — a missing subtree could silently
-            // omit the very dependency that changed, making the old/new diff conclude
-            // "no change" when the module IS affected.  Discard the partial result
-            // so callers take the conservative "changed" / UNRESOLVED path.
-            logger.warn(
-                    "Cannot collect dependencies for {}, conservatively treating module as affected: {}",
-                    key(project),
-                    e.getMessage());
-            return null;
-        }
-        timings.increment(Timings.OP_DEPENDENCY_RESOLVES);
-        cache.put(project, result);
-        return result;
-    }
-
-    /**
-     * Resolve the dependency tree from an old effective model.
-     * Creates a temporary MavenProject from the model and copies remote repositories
-     * from the current project so transitive resolution can reach the same repos.
-     */
-    private DependencyResolutionResult resolveModelDependencies(
-            Model oldModel,
-            MavenProject currentProject,
-            MavenSession session,
-            Map<MavenProject, DependencyResolutionResult> cache,
-            Timings timings) {
-        DependencyResolutionResult result = cache.get(currentProject);
-        if (result != null) {
-            timings.increment(Timings.OP_RESOLVE_CACHE_HITS);
-            return result;
-        }
-        try {
-            MavenProject tempProject = new MavenProject(currentProject);
-            tempProject.setModel(oldModel);
-            tempProject.setDependencies(oldModel.getDependencies());
-            DefaultDependencyResolutionRequest request =
-                    new DefaultDependencyResolutionRequest(tempProject, session.getRepositorySession());
-            request.setResolutionFilter(COLLECT_ONLY_FILTER);
-            result = dependenciesResolver.resolve(request);
-        } catch (DependencyResolutionException e) {
-            // Conservative: same posture as resolveProjectDependencies — discard
-            // partial results to avoid silently missing changes in an incomplete graph.
-            logger.warn(
-                    "Cannot collect old dependencies for {}, conservatively treating module as affected: {}",
-                    key(currentProject),
-                    e.getMessage());
-            return null;
-        }
-        timings.increment(Timings.OP_DEPENDENCY_RESOLVES);
-        cache.put(currentProject, result);
-        return result;
-    }
-
-    /**
-     * Walk the dependency graph and collect (GA → version) for all nodes.
-     */
-    private static Map<String, String> collectDependencyVersions(DependencyNode root) {
-        Map<String, String> versions = new LinkedHashMap<>();
-        List<DependencyNode> stack = new ArrayList<>(root.getChildren());
-        Set<String> visited = new HashSet<>();
-        while (!stack.isEmpty()) {
-            DependencyNode node = stack.remove(stack.size() - 1);
-            Dependency dep = node.getDependency();
-            if (dep == null) {
-                continue;
-            }
-            String ga = dep.getArtifact().getGroupId() + ":" + dep.getArtifact().getArtifactId();
-            if (!visited.add(ga)) {
-                continue;
-            }
-            versions.put(ga, dep.getArtifact().getVersion());
-            stack.addAll(node.getChildren());
-        }
-        return versions;
-    }
-
-    /**
-     * Walk the dependency graph and collect (GA → scope) for all nodes.
-     */
-    private static Map<String, String> collectDependencyScopes(DependencyNode root) {
-        Map<String, String> scopes = new LinkedHashMap<>();
-        List<DependencyNode> stack = new ArrayList<>(root.getChildren());
-        Set<String> visited = new HashSet<>();
-        while (!stack.isEmpty()) {
-            DependencyNode node = stack.remove(stack.size() - 1);
-            Dependency dep = node.getDependency();
-            if (dep == null) {
-                continue;
-            }
-            String ga = dep.getArtifact().getGroupId() + ":" + dep.getArtifact().getArtifactId();
-            if (!visited.add(ga)) {
-                continue;
-            }
-            scopes.put(ga, dep.getScope() != null ? dep.getScope() : "compile");
-            stack.addAll(node.getChildren());
-        }
-        return scopes;
-    }
-
-    /**
-     * Derive changed managed dependency GAs from effective models (for report purposes only).
-     */
-    private Set<String> deriveChangedManagedDeps(
-            Map<String, Model> oldEffectiveModels, Map<String, Model> newEffectiveModels) {
-        Set<String> changed = new LinkedHashSet<>();
-        for (Map.Entry<String, Model> entry : oldEffectiveModels.entrySet()) {
-            Model newModel = newEffectiveModels.get(entry.getKey());
-            if (newModel != null) {
-                changed.addAll(pomChangeAnalyzer.diffDependencies(
-                        pomChangeAnalyzer.getManagedDependencies(entry.getValue()),
-                        pomChangeAnalyzer.getManagedDependencies(newModel)));
-            }
-        }
-        return changed;
-    }
-
-    /**
-     * Derive changed managed plugin GAs from effective models (for report purposes only).
-     */
-    private Set<String> deriveChangedManagedPlugins(
-            Map<String, Model> oldEffectiveModels, Map<String, Model> newEffectiveModels) {
-        Set<String> changed = new LinkedHashSet<>();
-        for (Map.Entry<String, Model> entry : oldEffectiveModels.entrySet()) {
-            Model newModel = newEffectiveModels.get(entry.getKey());
-            if (newModel != null) {
-                changed.addAll(pomChangeAnalyzer.diffManagedPluginVersions(
-                        pomChangeAnalyzer.getManagedPlugins(entry.getValue()),
-                        pomChangeAnalyzer.getManagedPlugins(newModel)));
-            }
-        }
-        return changed;
-    }
-
-    private void writeImpactedLog(ScalpelConfiguration config, Path reactorRoot, Set<MavenProject> affectedModules)
-            throws MavenExecutionException {
-        String impactedLog = config.getImpactedLog();
-        if (impactedLog == null || impactedLog.trim().isEmpty()) {
-            return;
-        }
-        Path logPath;
-        try {
-            // The path is PR-controllable through .mvn/maven.config; neither write may
-            // land outside the reactor root (#97).
-            logPath = ScalpelReport.resolveContained(reactorRoot, impactedLog, ScalpelConfiguration.IMPACTED_LOG);
-        } catch (IOException e) {
-            handleWriteFailure(config, "Rejected impacted log path", e);
-            return;
-        }
-        try {
-            Files.createDirectories(logPath.getParent());
-            List<String> lines = new ArrayList<>();
-            for (MavenProject project : affectedModules) {
-                String relPath = relativePath(reactorRoot, project);
-                if (relPath.isEmpty()) {
-                    // The reactor root's relative path is the empty string; represent it as
-                    // "." so an affected root stays visible to CI consumers instead of
-                    // disappearing as a blank (or skipped) line (#84).
-                    relPath = ".";
-                }
-                if (!isSafeImpactedLogPath(relPath)) {
-                    // The log is one path per line, consumed by CI shell scripts ($(cat ...),
-                    // xargs); a module directory name is PR-author-controlled, so a path outside
-                    // the documented safe set is skipped rather than escaped (#84).
-                    logger.warn(
-                            "Scalpel: Skipping module {} in impacted log: path '{}' uses characters outside the"
-                                    + " safe set (letters, digits, '-', '_', '.', '/'; see README)",
-                            key(project),
-                            escapeControlChars(relPath));
-                    continue;
-                }
-                lines.add(relPath);
-            }
-            Files.write(logPath, lines, StandardCharsets.UTF_8);
-            logger.info("Scalpel: Impacted modules written to {}", config.getImpactedLog());
-        } catch (IOException e) {
-            handleWriteFailure(config, "Failed to write impacted log", e);
-        }
-    }
-
-    /**
-     * Safe character set for impacted-log lines. The log holds one relative module path per line
-     * and is consumed by CI shell scripts, so a PR author controlling a module directory name must
-     * not be able to inject shell metacharacters, spaces, quotes, glob characters or
-     * line/control characters into it. Only {@code [A-Za-z0-9._-/]} is accepted; a leading dash
-     * (option injection) and the empty string are rejected too. Control characters and newlines
-     * are rejected by construction: nothing outside this set passes. Backslashes never occur
-     * ({@link #relativePath} normalizes separators to '/') and would be rejected like any other
-     * character.
-     */
-    static boolean isSafeImpactedLogPath(String path) {
-        if (path == null || path.isEmpty() || path.charAt(0) == '-') {
-            return false;
-        }
-        for (int i = 0; i < path.length(); i++) {
-            char c = path.charAt(i);
-            boolean allowed = (c >= 'a' && c <= 'z')
-                    || (c >= 'A' && c <= 'Z')
-                    || (c >= '0' && c <= '9')
-                    || c == '-'
-                    || c == '_'
-                    || c == '.'
-                    || c == '/';
-            if (!allowed) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Escapes control characters (newlines included) so a rejected path cannot forge extra
-     * lines in the skip warning itself.
-     */
-    private static String escapeControlChars(String value) {
-        StringBuilder escaped = new StringBuilder(value.length() + 8);
-        for (int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            if (Character.isISOControl(c)) {
-                escaped.append("\\u%04x".formatted((int) c));
-            } else {
-                escaped.append(c);
-            }
-        }
-        return escaped.toString();
-    }
-
-    /**
-     * Honours failSafe on report/log write failures: with failSafe=true the build continues with a
-     * warning, otherwise the write failure fails the build as before.
-     */
-    private void handleWriteFailure(ScalpelConfiguration config, String message, IOException e)
-            throws MavenExecutionException {
-        if (config.isFailSafe()) {
-            logger.warn("Scalpel: {} (failSafe=true, continuing build): {}", message, e.toString());
-        } else {
-            throw new MavenExecutionException("Scalpel: " + message, e);
-        }
-    }
-
-    /**
-     * Overwrites the configured reportFile with a minimal failed-status document so a previous
-     * run's report cannot be mistaken for current results by CI. Only called on failSafe bail-out
-     * paths; write failures here are logged and swallowed (the build continues by design).
-     */
-    private void writeFailedStatusReport(ScalpelConfiguration config, Path reactorRoot, String reason) {
-        writeStatusReport(config, reactorRoot, "failed", reason);
-    }
-
-    /**
-     * Overwrites the configured reportFile with a minimal status-only document ("failed" for
-     * bail-outs, "skipped" for deliberate non-analysis paths) so a previous run's report cannot
-     * be mistaken for current results by CI. Write failures are logged and swallowed (the build
-     * continues by design).
-     */
-    private void writeStatusReport(ScalpelConfiguration config, Path reactorRoot, String status, String reason) {
-        String baseBranch = config.getBaseBranch();
-        try {
-            // Written first and independently: a failure of the report write below must
-            // not leave a previous run's shadow measurement in place.
-            if (config.isModeShadow()) {
-                writeShadowStatus(reactorRoot, status, reason);
-            }
-            ScalpelReport report = ScalpelReport.builder()
-                    .baseBranch(baseBranch != null ? baseBranch : "(unconfigured)")
-                    .status(status)
-                    .reason(reason)
-                    .fullBuildTriggered(true)
-                    .build();
-            report.writeToFile(reactorRoot, config.getReportFile());
-            logger.warn(
-                    "Scalpel: Analysis did not complete (status={}, reason={}), report at {} overwritten",
-                    status,
-                    reason,
-                    config.getReportFile());
-        } catch (Exception e) {
-            // Status reports must never fail the build; that is their entire job.
-            logger.warn("Scalpel: Could not overwrite report with {} status: {}", status, e.toString());
-        }
-    }
-
-    /**
-     * Shadow mode must uphold the same invariant as the JSON report (#89): when a run bails
-     * out before any measurement, the previous run's shadow document is overwritten with a
-     * status-only document rather than surviving as if current. Write failures are logged
-     * and swallowed like the report's.
-     */
-    private void writeShadowStatus(Path reactorRoot, String status, String reason) {
-        try {
-            Files.createDirectories(
-                    reactorRoot.resolve(ShadowBuildMonitor.SHADOW_FILE).getParent());
-            Files.write(
-                    reactorRoot.resolve(ShadowBuildMonitor.SHADOW_FILE),
-                    ShadowBuildMonitor.statusDocument(status, reason).getBytes(StandardCharsets.UTF_8));
-            logger.warn(
-                    "Scalpel: Shadow document at {} overwritten with {} status",
-                    ShadowBuildMonitor.SHADOW_FILE,
-                    status);
-        } catch (Exception e) {
-            logger.warn("Scalpel: Could not overwrite shadow document with {} status: {}", status, e.toString());
-        }
-    }
-
-    private void writeFullBuildReport(
-            ScalpelConfiguration config, Path reactorRoot, String triggerFile, Set<String> changedFiles)
-            throws MavenExecutionException {
-        ScalpelReport report = ScalpelReport.builder()
-                .baseBranch(config.getBaseBranch())
-                .fullBuildTriggered(true)
-                .triggerFile(triggerFile)
-                .changedFiles(changedFiles)
-                .build();
-        try {
-            // Written first and independently: a failure of the report write below must
-            // not leave a previous run's shadow measurement in place.
-            if (config.isModeShadow()) {
-                writeShadowStatus(reactorRoot, "skipped", "full build triggered by " + triggerFile);
-            }
-            report.writeToFile(reactorRoot, config.getReportFile());
-            logger.info("Scalpel: Report written to {}", config.getReportFile());
-        } catch (IOException e) {
-            handleWriteFailure(config, "Failed to write report", e);
-        }
-    }
-
-    private void writeReport(
-            ScalpelConfiguration config,
-            Path reactorRoot,
-            List<MavenProject> allProjects,
-            AnalysisContext ctx,
-            Timings timings,
-            long analysisStartNano)
-            throws MavenExecutionException {
-        ScalpelReport.Builder builder = ScalpelReport.builder()
-                .baseBranch(config.getBaseBranch())
-                .fullBuildTriggered(false)
-                .changedFiles(ctx.changedFiles)
-                .changedProperties(ctx.changedProperties)
-                .changedManagedDependencies(ctx.changedManagedDepGAs)
-                .changedManagedPlugins(ctx.changedManagedPluginGAs)
-                .unmatchedPomPaths(ctx.unmatchedPomPaths)
-                .timings(timings, millisSince(analysisStartNano));
-
-        logger.debug(
-                "Building report: {} directly affected, {} transitively affected, trim result has {} upstream / {} downstream / {} downstream-test",
-                ctx.directlyAffected.size(),
-                ctx.transitivelyAffected.size(),
-                ctx.trimResult != null ? ctx.trimResult.getUpstreamOnly().size() : 0,
-                ctx.trimResult != null ? ctx.trimResult.getDownstreamOnly().size() : 0,
-                ctx.trimResult != null ? ctx.trimResult.getDownstreamTestOnly().size() : 0);
-
-        addDirectlyAffectedModules(builder, ctx, reactorRoot);
-        addTransitivelyAffectedModules(builder, ctx, config, reactorRoot);
-        int excludedUpstream = addTrimResultModules(builder, ctx, config, reactorRoot);
-        builder.excludedUpstreamCount(excludedUpstream);
-        addSkippedModules(builder, allProjects, ctx, reactorRoot);
-
-        try {
-            ScalpelReport report = builder.build();
-            report.writeToFile(reactorRoot, config.getReportFile());
-            logger.info("Scalpel: Report written to {}", config.getReportFile());
-        } catch (IOException e) {
-            handleWriteFailure(config, "Failed to write report", e);
-        }
-    }
-
-    /**
-     * Enumerates reactor modules that were left out of the build set, so a reviewer of a
-     * green trimmed build can see exactly what was skipped and why. A module is skipped
-     * when it is neither directly nor transitively affected, and not part of the trim
-     * build set (upstream prerequisites and downstream dependents are built, not skipped).
-     */
-    private void addSkippedModules(
-            ScalpelReport.Builder builder, List<MavenProject> allProjects, AnalysisContext ctx, Path reactorRoot) {
-        Set<MavenProject> included = new LinkedHashSet<>(ctx.directlyAffected);
-        included.addAll(ctx.transitivelyAffected.keySet());
-        if (ctx.trimResult != null) {
-            // Use the filtered build set when available (trim mode with includePaths),
-            // so modules removed by the includePaths scope check appear in skippedModules.
-            if (ctx.filteredBuildSet != null) {
-                included.addAll(ctx.filteredBuildSet);
-            } else {
-                included.addAll(ctx.trimResult.getBuildSet());
-            }
-        }
-        for (MavenProject project : allProjects) {
-            if (!included.contains(project)) {
-                String path = relativePath(reactorRoot, project);
-                builder.addSkippedModule(new ScalpelReport.SkippedModule(
-                        project.getGroupId(), project.getArtifactId(), path, ScalpelReport.SKIP_REASON_NOT_AFFECTED));
-            }
-        }
-    }
-
-    private void addDirectlyAffectedModules(ScalpelReport.Builder builder, AnalysisContext ctx, Path reactorRoot) {
-        for (MavenProject project : ctx.directlyAffected) {
-            String path = relativePath(reactorRoot, project);
-            List<String> reasons = new ArrayList<>();
-            String sourceSet = null;
-            if (ctx.affectedBySource.contains(project)) {
-                if (ctx.testOnlyBySource.contains(project)) {
-                    reasons.add(ScalpelReport.REASON_TEST_CHANGE);
-                    sourceSet = "test";
-                } else {
-                    reasons.add(ScalpelReport.REASON_SOURCE_CHANGE);
-                    sourceSet = "main";
-                }
-            }
-            if (ctx.affectedByPom.contains(project)) {
-                reasons.add(ScalpelReport.REASON_POM_CHANGE);
-            }
-            if (ctx.forceIncluded.contains(project)) {
-                reasons.add(ScalpelReport.REASON_FORCE_BUILD);
-            }
-            if (logger.isDebugEnabled()) {
-                logger.debug("Report: {} -> category=DIRECT, reasons={}", key(project), reasons);
-            }
-            builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                            project.getGroupId(), project.getArtifactId(), path, reasons)
-                    .category(ScalpelReport.CATEGORY_DIRECT)
-                    .sourceSet(sourceSet)
-                    .evidence(ctx.evidence.get(project))
-                    .build());
-        }
-    }
-
-    private void addTransitivelyAffectedModules(
-            ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
-        for (Map.Entry<MavenProject, List<String>> entry : ctx.transitivelyAffected.entrySet()) {
-            MavenProject project = entry.getKey();
-            String path = relativePath(reactorRoot, project);
-            String category = null;
-            String testsSkippedReason = null;
-            if (ctx.trimResult != null) {
-                if (ctx.trimResult.getUpstreamOnly().contains(project)) {
-                    category = ScalpelReport.CATEGORY_UPSTREAM;
-                } else if (ctx.trimResult.getDownstreamOnly().contains(project)
-                        || ctx.trimResult.getDownstreamTestOnly().contains(project)) {
-                    category = ScalpelReport.CATEGORY_DOWNSTREAM;
-                    if (matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
-                        testsSkippedReason = ScalpelReport.REASON_EXCLUDED_DOWNSTREAM;
-                    }
-                }
-            }
-            if (category == null) {
-                category = ScalpelReport.CATEGORY_TRANSITIVE;
-            }
-            logger.debug("Report: {} -> category={}, reasons={}", key(project), category, entry.getValue());
-            builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                            project.getGroupId(), project.getArtifactId(), path, entry.getValue())
-                    .category(category)
-                    .testsSkippedReason(testsSkippedReason)
-                    .evidence(ctx.evidence.get(project))
-                    .build());
-        }
-    }
-
-    /**
-     * Adds downstream modules from the trim result to the report and returns the number of
-     * upstream build-prerequisite modules that were excluded.
-     */
-    private int addTrimResultModules(
-            ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
-        if (ctx.trimResult == null) {
-            return 0;
-        }
-        // Upstream modules are build-order prerequisites, not genuinely affected by the change.
-        // Including them in affectedModules inflates the report (e.g. a sync-point module like
-        // camel-allcomponents that depends on everything pulls the entire reactor as UPSTREAM).
-        // Log the count for transparency but don't include them in the report.
-        int upstreamCount = 0;
-        for (MavenProject project : ctx.trimResult.getUpstreamOnly()) {
-            if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
-                upstreamCount++;
-                if (logger.isDebugEnabled()) {
-                    logger.debug(
-                            "Excluding upstream build-prerequisite {} from report (not genuinely affected)",
-                            key(project));
-                }
-            }
-        }
-        if (upstreamCount > 0) {
-            logger.info(
-                    "Scalpel: {} upstream build-prerequisite modules excluded from report (use trim/skip-tests mode for full build set)",
-                    upstreamCount);
-        }
-        addDownstreamModules(
-                builder,
-                ctx,
-                config,
-                reactorRoot,
-                ctx.trimResult.getDownstreamOnly(),
-                ScalpelReport.REASON_DOWNSTREAM_DEPENDENT);
-        addDownstreamModules(
-                builder,
-                ctx,
-                config,
-                reactorRoot,
-                ctx.trimResult.getDownstreamTestOnly(),
-                ScalpelReport.REASON_DOWNSTREAM_TEST);
-        return upstreamCount;
-    }
-
-    private void addDownstreamModules(
-            ScalpelReport.Builder builder,
-            AnalysisContext ctx,
-            ScalpelConfiguration config,
-            Path reactorRoot,
-            Set<MavenProject> downstreamProjects,
-            String reason) {
-        List<PathMatcher> includeMatchers = compileGlobMatchers(config.getIncludePaths());
-        for (MavenProject project : downstreamProjects) {
-            if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
-                // Skip downstream modules outside includePaths scope
-                if (!includeMatchers.isEmpty() && !matchesIncludePaths(project, includeMatchers, reactorRoot)) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug("Excluding downstream module {} from report (outside includePaths)", key(project));
-                    }
-                    continue;
-                }
-                String path = relativePath(reactorRoot, project);
-                String testsSkippedReason =
-                        matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())
-                                ? ScalpelReport.REASON_EXCLUDED_DOWNSTREAM
-                                : null;
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Report: {} -> category=DOWNSTREAM, reason={}", key(project), reason);
-                }
-                builder.addAffectedModule(ScalpelReport.AffectedModule.moduleBuilder(
-                                project.getGroupId(), project.getArtifactId(), path, List.of(reason))
-                        .category(ScalpelReport.CATEGORY_DOWNSTREAM)
-                        .testsSkippedReason(testsSkippedReason)
-                        .evidence(ctx.evidence.get(project))
-                        .build());
-            }
-        }
-    }
-
-    private static String relativePath(Path normalizedRoot, MavenProject project) {
-        return normalizedRoot
-                .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
-                .toString()
-                .replace('\\', '/');
-    }
-
-    private void applyPerCategoryArgs(TrimResult trimResult, ScalpelConfiguration config) {
-        for (String arg : config.getUpstreamArgs()) {
-            String[] parts = arg.split("=", 2);
-            if (parts.length == 2) {
-                for (MavenProject project : trimResult.getUpstreamOnly()) {
-                    project.getProperties().setProperty(parts[0], parts[1]);
-                }
-            } else {
-                logger.warn("Scalpel: Malformed upstreamArgs entry '{}', expected key=value format", arg);
-            }
-        }
-        for (String arg : config.getDownstreamArgs()) {
-            String[] parts = arg.split("=", 2);
-            if (parts.length == 2) {
-                for (MavenProject project : trimResult.getDownstreamOnly()) {
-                    project.getProperties().setProperty(parts[0], parts[1]);
-                }
-                for (MavenProject project : trimResult.getDownstreamTestOnly()) {
-                    project.getProperties().setProperty(parts[0], parts[1]);
-                }
-            } else {
-                logger.warn("Scalpel: Malformed downstreamArgs entry '{}', expected key=value format", arg);
-            }
-        }
-    }
-
-    private String matchesForceBuild(MavenProject project, List<String> patterns) {
-        for (String pattern : patterns) {
-            // artifactId is PR-author-controlled input (including length): match through the
-            // cached, input-bounded matcher, never String.matches()
-            if (regexMatcher.matches(project.getArtifactId(), pattern, "forceBuildModules", logger)) {
-                logger.debug("Scalpel: Force-including module {} (matches {})", key(project), pattern);
-                return pattern;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Assembles explain-mode evidence per module: the specific input (changed file, property,
-     * managed dep/plugin GA, force pattern, upstream/downstream relationship) that put each
-     * module into the affected/build set.
+     * Assembles explain-mode evidence per module.
      */
     private static Map<MavenProject, List<String>> buildEvidence(
             Map<MavenProject, Set<String>> triggeringFiles,
@@ -2014,9 +695,13 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private void skipTestsOnAll(List<MavenProject> projects) {
-        for (MavenProject project : projects) {
-            project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
-        }
+    // ---- Static forwarders for backward compatibility with existing tests ----
+
+    static String normalizeGlobPattern(String pattern) {
+        return ChangedFileClassifier.normalizeGlobPattern(pattern);
+    }
+
+    static boolean isSafeImpactedLogPath(String path) {
+        return ImpactedLogWriter.isSafeImpactedLogPath(path);
     }
 }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplier.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplier.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies skip-tests logic: determines which modules should have their tests skipped
+ * in skip-tests mode, handles test-jar producer softening, and applies per-category args.
+ */
+class SkipTestsApplier {
+
+    private static final String MAVEN_TEST_SKIP = "maven.test.skip";
+    private static final String SKIP_TESTS = "skipTests";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ReactorTrimmer reactorTrimmer;
+    private final TransitiveImpactAnalyzer transitiveImpactAnalyzer;
+
+    SkipTestsApplier(ReactorTrimmer reactorTrimmer, TransitiveImpactAnalyzer transitiveImpactAnalyzer) {
+        this.reactorTrimmer = reactorTrimmer;
+        this.transitiveImpactAnalyzer = transitiveImpactAnalyzer;
+    }
+
+    void applySkipTests(
+            List<MavenProject> allProjects,
+            TrimResult trimResult,
+            ScalpelConfiguration config,
+            TransitiveImpactAnalyzer.EffectiveModels models,
+            List<PathMatcher> includeMatchers,
+            TransitiveImpactAnalyzer.ResolutionContext rctx) {
+
+        List<MavenProject> testProjects = new ArrayList<>();
+        List<MavenProject> skippedProjects = new ArrayList<>();
+
+        // Directly affected modules always run tests
+        classifyBuildSetProjects(trimResult, config, models, rctx, testProjects, skippedProjects);
+
+        // Modules outside the build set
+        classifyRemainingProjects(
+                allProjects, trimResult, models, includeMatchers, rctx, testProjects, skippedProjects);
+
+        // Apply per-category args
+        applyPerCategoryArgs(trimResult, config);
+
+        // Softening must have the last word on maven.test.skip/skipTests
+        Set<MavenProject> softenedProjects = softenTestJarProducers(testProjects, skippedProjects);
+
+        logger.info(
+                "Scalpel: Testing {}, {} compile-only (test-jar producers), skipping tests on {} of {} modules: {}",
+                testProjects.size(),
+                softenedProjects.size(),
+                skippedProjects.size(),
+                allProjects.size(),
+                keys(skippedProjects));
+    }
+
+    private void classifyBuildSetProjects(
+            TrimResult trimResult,
+            ScalpelConfiguration config,
+            TransitiveImpactAnalyzer.EffectiveModels models,
+            TransitiveImpactAnalyzer.ResolutionContext rctx,
+            List<MavenProject> testProjects,
+            List<MavenProject> skippedProjects) {
+        for (MavenProject project : trimResult.getBuildSet()) {
+            if (trimResult.getDirectlyAffected().contains(project)) {
+                testProjects.add(project);
+            } else if (config.isSkipTestsForUpstream()
+                    && trimResult.getUpstreamOnly().contains(project)) {
+                project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
+                skippedProjects.add(project);
+            } else if (shouldSkipTestsForExcludedDownstream(project, trimResult, config, models, rctx)) {
+                project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
+                skippedProjects.add(project);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Scalpel: Skipping tests on excluded downstream module {}", key(project));
+                }
+            } else {
+                testProjects.add(project);
+            }
+        }
+    }
+
+    private void classifyRemainingProjects(
+            List<MavenProject> allProjects,
+            TrimResult trimResult,
+            TransitiveImpactAnalyzer.EffectiveModels models,
+            List<PathMatcher> includeMatchers,
+            TransitiveImpactAnalyzer.ResolutionContext rctx,
+            List<MavenProject> testProjects,
+            List<MavenProject> skippedProjects) {
+        Set<MavenProject> buildSetLookup = new LinkedHashSet<>(trimResult.getBuildSet());
+        for (MavenProject project : allProjects) {
+            if (buildSetLookup.contains(project)) {
+                continue;
+            }
+            classifySingleRemainingProject(project, models, includeMatchers, rctx, testProjects, skippedProjects);
+        }
+    }
+
+    private void classifySingleRemainingProject(
+            MavenProject project,
+            TransitiveImpactAnalyzer.EffectiveModels models,
+            List<PathMatcher> includeMatchers,
+            TransitiveImpactAnalyzer.ResolutionContext rctx,
+            List<MavenProject> testProjects,
+            List<MavenProject> skippedProjects) {
+        // Skip tests on modules outside includePaths scope
+        if (!includeMatchers.isEmpty()
+                && !ChangedFileClassifier.matchesIncludePaths(project, includeMatchers, rctx.normalizedRoot())) {
+            project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
+            skippedProjects.add(project);
+            return;
+        }
+
+        // Check if this module's effective plugins or dependency tree changed
+        if (transitiveImpactAnalyzer.hasEffectiveModelChanges(project, models, rctx)) {
+            testProjects.add(project);
+            return;
+        }
+
+        // Skip tests on this project
+        project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
+        skippedProjects.add(project);
+    }
+
+    /**
+     * Modules slated for a full test skip also skip test-compile, which suppresses their
+     * test-jar. If some other module depends on that test-jar, soften the producer:
+     * drop maven.test.skip and use skipTests=true instead.
+     */
+    Set<MavenProject> softenTestJarProducers(List<MavenProject> testProjects, List<MavenProject> skippedProjects) {
+        Set<MavenProject> compilingTests = new LinkedHashSet<>(testProjects);
+        Set<MavenProject> softenedProjects = new LinkedHashSet<>();
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            for (MavenProject candidate : skippedProjects) {
+                if (softenedProjects.contains(candidate)) {
+                    continue;
+                }
+                if (trySoftenCandidate(candidate, compilingTests, softenedProjects)) {
+                    changed = true;
+                }
+            }
+        }
+        skippedProjects.removeAll(softenedProjects);
+        if (!softenedProjects.isEmpty()) {
+            logger.info(
+                    "Scalpel: {} modules had test-compile restored for in-reactor test-jar consumers: {}",
+                    softenedProjects.size(),
+                    keys(softenedProjects));
+        }
+        return softenedProjects;
+    }
+
+    private boolean trySoftenCandidate(
+            MavenProject candidate, Set<MavenProject> compilingTests, Set<MavenProject> softenedProjects) {
+        for (MavenProject consumer : new ArrayList<>(compilingTests)) {
+            if (reactorTrimmer.hasTestJarDependency(consumer, candidate)) {
+                candidate.getProperties().remove(MAVEN_TEST_SKIP);
+                candidate.getProperties().setProperty(SKIP_TESTS, "true");
+                softenedProjects.add(candidate);
+                compilingTests.add(candidate);
+                if (logger.isDebugEnabled()) {
+                    logger.debug(
+                            "Scalpel: Keeping test-compile for {} because its test-jar is consumed"
+                                    + " in-reactor by {} (softened: skipTests=true instead of"
+                                    + " maven.test.skip=true)",
+                            key(candidate),
+                            key(consumer));
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    boolean shouldSkipTestsForExcludedDownstream(
+            MavenProject project,
+            TrimResult trimResult,
+            ScalpelConfiguration config,
+            TransitiveImpactAnalyzer.EffectiveModels models,
+            TransitiveImpactAnalyzer.ResolutionContext rctx) {
+        if (config.getSkipTestsForDownstreamModules().isEmpty()) {
+            return false;
+        }
+        if (!trimResult.getDownstreamOnly().contains(project)
+                && !trimResult.getDownstreamTestOnly().contains(project)) {
+            return false;
+        }
+        if (!matchesDownstreamExclusion(project, config.getSkipTestsForDownstreamModules())) {
+            return false;
+        }
+        // Safety guard: don't skip tests if the module has effective model changes
+        return !transitiveImpactAnalyzer.hasEffectiveModelChanges(project, models, rctx);
+    }
+
+    boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
+        for (String pattern : patterns) {
+            if (pattern.contains(":")) {
+                if (key(project).equals(pattern)) {
+                    return true;
+                }
+            } else {
+                if (project.getArtifactId().equals(pattern)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    void applyPerCategoryArgs(TrimResult trimResult, ScalpelConfiguration config) {
+        applyArgsToProjects(config.getUpstreamArgs(), trimResult.getUpstreamOnly());
+        applyDownstreamArgs(config.getDownstreamArgs(), trimResult);
+    }
+
+    private void applyArgsToProjects(List<String> args, Set<MavenProject> projects) {
+        for (String arg : args) {
+            String[] parts = arg.split("=", 2);
+            if (parts.length == 2) {
+                for (MavenProject project : projects) {
+                    project.getProperties().setProperty(parts[0], parts[1]);
+                }
+            } else {
+                logger.warn("Scalpel: Malformed upstreamArgs entry '{}', expected key=value format", arg);
+            }
+        }
+    }
+
+    private void applyDownstreamArgs(List<String> args, TrimResult trimResult) {
+        for (String arg : args) {
+            String[] parts = arg.split("=", 2);
+            if (parts.length == 2) {
+                for (MavenProject project : trimResult.getDownstreamOnly()) {
+                    project.getProperties().setProperty(parts[0], parts[1]);
+                }
+                for (MavenProject project : trimResult.getDownstreamTestOnly()) {
+                    project.getProperties().setProperty(parts[0], parts[1]);
+                }
+            } else {
+                logger.warn("Scalpel: Malformed downstreamArgs entry '{}', expected key=value format", arg);
+            }
+        }
+    }
+
+    void skipTestsOnAll(List<MavenProject> projects) {
+        for (MavenProject project : projects) {
+            project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
+        }
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplier.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplier.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.matchesDownstreamExclusion;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.nio.file.PathMatcher;
@@ -210,21 +211,6 @@ class SkipTestsApplier {
         }
         // Safety guard: don't skip tests if the module has effective model changes
         return !transitiveImpactAnalyzer.hasEffectiveModelChanges(project, models, rctx);
-    }
-
-    boolean matchesDownstreamExclusion(MavenProject project, List<String> patterns) {
-        for (String pattern : patterns) {
-            if (pattern.contains(":")) {
-                if (key(project).equals(pattern)) {
-                    return true;
-                }
-            } else {
-                if (project.getArtifactId().equals(pattern)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     void applyPerCategoryArgs(TrimResult trimResult, ScalpelConfiguration config) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TransitiveImpactAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/TransitiveImpactAnalyzer.java
@@ -1,0 +1,565 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.key;
+import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelReport;
+import eu.maveniverse.maven.scalpel.core.Timings;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.DefaultDependencyResolutionRequest;
+import org.apache.maven.project.DependencyResolutionException;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectDependenciesResolver;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Performs transitive impact analysis: compares old vs new effective models and dependency
+ * trees to find modules indirectly affected by changes in the reactor.
+ */
+class TransitiveImpactAnalyzer {
+
+    static final String UNRESOLVED_GA = "(unresolved)";
+    private static final String SCOPE_COMPILE = "compile";
+
+    /**
+     * A DependencyFilter that rejects all nodes, preventing artifact downloads
+     * while still allowing the dependency graph to be collected.
+     */
+    static final DependencyFilter COLLECT_ONLY_FILTER = (node, parents) -> false;
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ProjectDependenciesResolver dependenciesResolver;
+    private final PomChangeAnalyzer pomChangeAnalyzer;
+
+    TransitiveImpactAnalyzer(ProjectDependenciesResolver dependenciesResolver, PomChangeAnalyzer pomChangeAnalyzer) {
+        this.dependenciesResolver = dependenciesResolver;
+        this.pomChangeAnalyzer = pomChangeAnalyzer;
+    }
+
+    /**
+     * Bundles the resolution-related parameters shared across transitive analysis methods.
+     */
+    record ResolutionContext(
+            Path normalizedRoot,
+            MavenSession session,
+            Map<MavenProject, DependencyResolutionResult> collectCache,
+            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
+            Timings timings) {}
+
+    /**
+     * Bundles effective model maps for old-vs-new comparison.
+     */
+    record EffectiveModels(Map<String, Model> oldModels, Map<String, Model> newModels) {}
+
+    static final class TransitiveMatch {
+        final List<String> reasons;
+        final List<String> evidence;
+
+        TransitiveMatch(List<String> reasons, List<String> evidence) {
+            this.reasons = reasons;
+            this.evidence = evidence;
+        }
+    }
+
+    static final class ChangedDependencyMatch {
+        final String ga;
+        final String scope;
+
+        ChangedDependencyMatch(String ga, String scope) {
+            this.ga = ga;
+            this.scope = scope;
+        }
+    }
+
+    /**
+     * Determine which non-directly-affected modules are <em>transitively</em> affected
+     * by changes in the reactor. Uses a two-pass algorithm:
+     *
+     * <h4>Pass 1 — Effective model and dependency tree comparison</h4>
+     * For each non-directly-affected module, compare old vs new effective models.
+     *
+     * <h4>Pass 2 — Reactor dependency propagation</h4>
+     * Propagates through reactor dependencies to a fixed point.
+     */
+    Map<MavenProject, List<String>> computeTransitivelyAffected(
+            List<MavenProject> allProjects,
+            Set<MavenProject> directlyAffected,
+            EffectiveModels models,
+            ResolutionContext rctx,
+            boolean explain,
+            Map<MavenProject, List<String>> returnEvidence) {
+        Map<MavenProject, List<String>> transitivelyAffected = new LinkedHashMap<>();
+        Map<MavenProject, List<String>> transitiveEvidence = new LinkedHashMap<>();
+        if (models.oldModels().isEmpty()) {
+            logger.debug("Skipping transitive analysis: no effective models available");
+            return transitivelyAffected;
+        }
+        logger.debug(
+                "Computing transitively affected modules: comparing old vs new dependency trees for {} non-direct modules",
+                allProjects.size() - directlyAffected.size());
+
+        // First pass: compare effective models and dependency trees directly
+        firstPassModelComparison(
+                allProjects, directlyAffected, models, rctx, explain, transitivelyAffected, transitiveEvidence);
+
+        // Second pass: propagate through reactor dependencies.
+        secondPassReactorPropagation(
+                allProjects, directlyAffected, rctx, explain, transitivelyAffected, transitiveEvidence);
+
+        if (!transitivelyAffected.isEmpty()) {
+            logger.info(
+                    "Scalpel: {} modules transitively affected: {}",
+                    transitivelyAffected.size(),
+                    keys(transitivelyAffected.keySet()));
+        }
+        returnEvidence.putAll(transitiveEvidence);
+        return transitivelyAffected;
+    }
+
+    private void firstPassModelComparison(
+            List<MavenProject> allProjects,
+            Set<MavenProject> directlyAffected,
+            EffectiveModels models,
+            ResolutionContext rctx,
+            boolean explain,
+            Map<MavenProject, List<String>> transitivelyAffected,
+            Map<MavenProject, List<String>> transitiveEvidence) {
+        for (MavenProject project : allProjects) {
+            if (directlyAffected.contains(project)) {
+                continue;
+            }
+            TransitiveMatch match = computeTransitiveMatch(project, models, rctx, explain);
+            if (!match.reasons.isEmpty()) {
+                transitivelyAffected.put(project, match.reasons);
+                if (explain) {
+                    transitiveEvidence.put(project, match.evidence);
+                }
+            }
+        }
+    }
+
+    private void secondPassReactorPropagation(
+            List<MavenProject> allProjects,
+            Set<MavenProject> directlyAffected,
+            ResolutionContext rctx,
+            boolean explain,
+            Map<MavenProject, List<String>> transitivelyAffected,
+            Map<MavenProject, List<String>> transitiveEvidence) {
+        Set<String> affectedGAs = new LinkedHashSet<>();
+        for (MavenProject p : directlyAffected) {
+            affectedGAs.add(p.getGroupId() + ":" + p.getArtifactId());
+        }
+        for (MavenProject p : transitivelyAffected.keySet()) {
+            affectedGAs.add(p.getGroupId() + ":" + p.getArtifactId());
+        }
+        boolean propagated = true;
+        while (propagated) {
+            propagated = false;
+            for (MavenProject project : allProjects) {
+                if (directlyAffected.contains(project) || transitivelyAffected.containsKey(project)) {
+                    continue;
+                }
+                propagated |= propagateToProject(
+                        project, rctx, affectedGAs, explain, transitivelyAffected, transitiveEvidence);
+            }
+        }
+    }
+
+    /**
+     * Attempts to propagate the affected status to a single project during the
+     * reactor-dependency propagation pass. Returns {@code true} if the project
+     * was newly marked as affected.
+     */
+    private boolean propagateToProject(
+            MavenProject project,
+            ResolutionContext rctx,
+            Set<String> affectedGAs,
+            boolean explain,
+            Map<MavenProject, List<String>> transitivelyAffected,
+            Map<MavenProject, List<String>> transitiveEvidence) {
+        DependencyResolutionResult depResult =
+                resolveProjectDependencies(project, rctx.session(), rctx.collectCache(), rctx.timings());
+        if (depResult == null || depResult.getDependencyGraph() == null) {
+            return handleUnresolvableProject(project, affectedGAs, explain, transitivelyAffected, transitiveEvidence);
+        }
+        return matchAffectedDependency(
+                project, depResult, affectedGAs, explain, transitivelyAffected, transitiveEvidence);
+    }
+
+    private boolean handleUnresolvableProject(
+            MavenProject project,
+            Set<String> affectedGAs,
+            boolean explain,
+            Map<MavenProject, List<String>> transitivelyAffected,
+            Map<MavenProject, List<String>> transitiveEvidence) {
+        if (affectedGAs.isEmpty()) {
+            return false;
+        }
+        if (logger.isWarnEnabled()) {
+            logger.warn(
+                    "Cannot resolve dependencies of {} while propagating changes, conservatively marking as affected",
+                    key(project));
+        }
+        transitivelyAffected.put(
+                project, new ArrayList<>(List.of(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED)));
+        affectedGAs.add(project.getGroupId() + ":" + project.getArtifactId());
+        if (explain) {
+            transitiveEvidence.put(
+                    project, List.of("dependency resolution failed; conservatively treated as affected"));
+        }
+        return true;
+    }
+
+    private boolean matchAffectedDependency(
+            MavenProject project,
+            DependencyResolutionResult depResult,
+            Set<String> affectedGAs,
+            boolean explain,
+            Map<MavenProject, List<String>> transitivelyAffected,
+            Map<MavenProject, List<String>> transitiveEvidence) {
+        Map<String, String> depScopes = collectDependencyScopes(depResult.getDependencyGraph());
+        for (Map.Entry<String, String> dep : depScopes.entrySet()) {
+            if (affectedGAs.contains(dep.getKey())) {
+                List<String> reasons = new ArrayList<>();
+                reasons.add(
+                        "test".equals(dep.getValue())
+                                ? ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST
+                                : ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+                transitivelyAffected.put(project, reasons);
+                affectedGAs.add(project.getGroupId() + ":" + project.getArtifactId());
+                if (explain) {
+                    transitiveEvidence.put(project, List.of("depends on affected reactor module " + dep.getKey()));
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Compare old vs new effective models and dependency trees for a single module.
+     */
+    TransitiveMatch computeTransitiveMatch(
+            MavenProject project, EffectiveModels models, ResolutionContext rctx, boolean explain) {
+        List<String> reasons = new ArrayList<>();
+        List<String> evidence = explain ? new ArrayList<>() : List.of();
+
+        String relPath = rctx.normalizedRoot()
+                .relativize(project.getFile().toPath().toAbsolutePath().normalize())
+                .toString()
+                .replace('\\', '/');
+        Model oldModel = models.oldModels().get(relPath);
+        Model newModel = models.newModels().get(relPath);
+        if (oldModel == null || newModel == null) {
+            return new TransitiveMatch(reasons, evidence);
+        }
+
+        // Compare effective plugins directly from the fully-interpolated models
+        Set<String> changedPlugins = pomChangeAnalyzer.diffManagedPluginVersions(
+                pomChangeAnalyzer.getEffectivePlugins(oldModel), pomChangeAnalyzer.getEffectivePlugins(newModel));
+        if (!changedPlugins.isEmpty()) {
+            reasons.add(ScalpelReport.REASON_MANAGED_PLUGIN);
+            if (explain) {
+                evidence.add("effective plugin " + changedPlugins.iterator().next());
+            }
+        }
+
+        // Compare resolved dependency trees: old effective model vs current project
+        ChangedDependencyMatch depMatch = findChangedDependencyInTree(
+                project, oldModel, rctx.session(), rctx.collectCache(), rctx.oldCollectCache(), rctx.timings());
+        if (depMatch != null) {
+            if (UNRESOLVED_GA.equals(depMatch.ga)) {
+                reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_UNRESOLVED);
+            } else if ("test".equals(depMatch.scope)) {
+                reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY_TEST);
+            } else {
+                reasons.add(ScalpelReport.REASON_TRANSITIVE_DEPENDENCY);
+            }
+            if (explain) {
+                evidence.add("dependency tree diff " + depMatch.ga);
+            }
+        }
+
+        return new TransitiveMatch(reasons, evidence);
+    }
+
+    /**
+     * Checks whether a module's effective plugins or resolved dependency tree changed
+     * between old and new effective models.
+     */
+    boolean hasEffectiveModelChanges(MavenProject project, EffectiveModels models, ResolutionContext rctx) {
+        String relPath = rctx.normalizedRoot()
+                .relativize(project.getFile().toPath().toAbsolutePath().normalize())
+                .toString()
+                .replace('\\', '/');
+        Model oldModel = models.oldModels().get(relPath);
+        Model newModel = models.newModels().get(relPath);
+        if (oldModel == null || newModel == null) {
+            return false;
+        }
+
+        // Check effective plugins
+        Set<String> changedPlugins = pomChangeAnalyzer.diffManagedPluginVersions(
+                pomChangeAnalyzer.getEffectivePlugins(oldModel), pomChangeAnalyzer.getEffectivePlugins(newModel));
+        if (!changedPlugins.isEmpty()) {
+            return true;
+        }
+
+        // Check dependency tree
+        return findChangedDependencyInTree(
+                        project, oldModel, rctx.session(), rctx.collectCache(), rctx.oldCollectCache(), rctx.timings())
+                != null;
+    }
+
+    /**
+     * Resolve dependency trees from both old effective model and current project,
+     * then diff them.
+     */
+    ChangedDependencyMatch findChangedDependencyInTree(
+            MavenProject project,
+            Model oldEffectiveModel,
+            MavenSession session,
+            Map<MavenProject, DependencyResolutionResult> collectCache,
+            Map<MavenProject, DependencyResolutionResult> oldCollectCache,
+            Timings timings) {
+
+        // Resolve new (current) dependency tree
+        DependencyResolutionResult newResult = resolveProjectDependencies(project, session, collectCache, timings);
+        if (newResult == null || newResult.getDependencyGraph() == null) {
+            return new ChangedDependencyMatch(UNRESOLVED_GA, SCOPE_COMPILE);
+        }
+
+        // Resolve old dependency tree from old effective model
+        DependencyResolutionResult oldResult =
+                resolveModelDependencies(oldEffectiveModel, project, session, oldCollectCache, timings);
+        if (oldResult == null || oldResult.getDependencyGraph() == null) {
+            return new ChangedDependencyMatch(UNRESOLVED_GA, SCOPE_COMPILE);
+        }
+
+        // Collect (GA → version) from both trees and diff
+        Map<String, String> oldVersions = collectDependencyVersions(oldResult.getDependencyGraph());
+        Map<String, String> newVersions = collectDependencyVersions(newResult.getDependencyGraph());
+
+        // Find changed GAs and determine scope from the new tree
+        Map<String, String> newScopes = collectDependencyScopes(newResult.getDependencyGraph());
+
+        ChangedDependencyMatch changed = findChangedVersions(project, oldVersions, newVersions, newScopes);
+        if (changed != null) {
+            return changed;
+        }
+        return findNewDependencies(project, oldVersions, newVersions, newScopes);
+    }
+
+    private ChangedDependencyMatch findChangedVersions(
+            MavenProject project,
+            Map<String, String> oldVersions,
+            Map<String, String> newVersions,
+            Map<String, String> newScopes) {
+        String narrowestGa = null;
+        String narrowestScope = null;
+
+        for (Map.Entry<String, String> e : oldVersions.entrySet()) {
+            if (!Objects.equals(e.getValue(), newVersions.get(e.getKey()))) {
+                String ga = e.getKey();
+                String scope = newScopes.getOrDefault(ga, SCOPE_COMPILE);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Module {} has changed dependency {} (scope={})", key(project), ga, scope);
+                }
+                if (!"test".equals(scope)) {
+                    return new ChangedDependencyMatch(ga, scope);
+                }
+                if (narrowestScope == null) {
+                    narrowestScope = "test";
+                    narrowestGa = ga;
+                }
+            }
+        }
+        return narrowestScope != null ? new ChangedDependencyMatch(narrowestGa, narrowestScope) : null;
+    }
+
+    private ChangedDependencyMatch findNewDependencies(
+            MavenProject project,
+            Map<String, String> oldVersions,
+            Map<String, String> newVersions,
+            Map<String, String> newScopes) {
+        String narrowestGa = null;
+        String narrowestScope = null;
+
+        for (String ga : newVersions.keySet()) {
+            if (!oldVersions.containsKey(ga)) {
+                String scope = newScopes.getOrDefault(ga, SCOPE_COMPILE);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Module {} has new dependency {} (scope={})", key(project), ga, scope);
+                }
+                if (!"test".equals(scope)) {
+                    return new ChangedDependencyMatch(ga, scope);
+                }
+                if (narrowestScope == null) {
+                    narrowestScope = "test";
+                    narrowestGa = ga;
+                }
+            }
+        }
+        return narrowestScope != null ? new ChangedDependencyMatch(narrowestGa, narrowestScope) : null;
+    }
+
+    /**
+     * Resolve the current project's dependency tree (cached).
+     */
+    DependencyResolutionResult resolveProjectDependencies(
+            MavenProject project,
+            MavenSession session,
+            Map<MavenProject, DependencyResolutionResult> cache,
+            Timings timings) {
+        DependencyResolutionResult result = cache.get(project);
+        if (result != null) {
+            timings.increment(Timings.OP_RESOLVE_CACHE_HITS);
+            return result;
+        }
+        try {
+            DefaultDependencyResolutionRequest request =
+                    new DefaultDependencyResolutionRequest(project, session.getRepositorySession());
+            request.setResolutionFilter(COLLECT_ONLY_FILTER);
+            result = dependenciesResolver.resolve(request);
+        } catch (DependencyResolutionException e) {
+            logger.warn(
+                    "Cannot collect dependencies for {}, conservatively treating module as affected: {}",
+                    key(project),
+                    e.getMessage());
+            return null;
+        }
+        timings.increment(Timings.OP_DEPENDENCY_RESOLVES);
+        cache.put(project, result);
+        return result;
+    }
+
+    /**
+     * Resolve the dependency tree from an old effective model.
+     */
+    DependencyResolutionResult resolveModelDependencies(
+            Model oldModel,
+            MavenProject currentProject,
+            MavenSession session,
+            Map<MavenProject, DependencyResolutionResult> cache,
+            Timings timings) {
+        DependencyResolutionResult result = cache.get(currentProject);
+        if (result != null) {
+            timings.increment(Timings.OP_RESOLVE_CACHE_HITS);
+            return result;
+        }
+        try {
+            MavenProject tempProject = new MavenProject(currentProject);
+            tempProject.setModel(oldModel);
+            tempProject.setDependencies(oldModel.getDependencies());
+            DefaultDependencyResolutionRequest request =
+                    new DefaultDependencyResolutionRequest(tempProject, session.getRepositorySession());
+            request.setResolutionFilter(COLLECT_ONLY_FILTER);
+            result = dependenciesResolver.resolve(request);
+        } catch (DependencyResolutionException e) {
+            logger.warn(
+                    "Cannot collect old dependencies for {}, conservatively treating module as affected: {}",
+                    key(currentProject),
+                    e.getMessage());
+            return null;
+        }
+        timings.increment(Timings.OP_DEPENDENCY_RESOLVES);
+        cache.put(currentProject, result);
+        return result;
+    }
+
+    /**
+     * Walk the dependency graph and collect (GA → version) for all nodes.
+     */
+    static Map<String, String> collectDependencyVersions(DependencyNode root) {
+        Map<String, String> versions = new LinkedHashMap<>();
+        walkDependencyGraph(
+                root, (ga, dep) -> versions.put(ga, dep.getArtifact().getVersion()));
+        return versions;
+    }
+
+    /**
+     * Walk the dependency graph and collect (GA → scope) for all nodes.
+     */
+    static Map<String, String> collectDependencyScopes(DependencyNode root) {
+        Map<String, String> scopes = new LinkedHashMap<>();
+        walkDependencyGraph(root, (ga, dep) -> scopes.put(ga, dep.getScope() != null ? dep.getScope() : SCOPE_COMPILE));
+        return scopes;
+    }
+
+    /**
+     * Generic depth-first walk over a dependency graph, invoking the consumer for each
+     * unique GA encountered.
+     */
+    private static void walkDependencyGraph(
+            DependencyNode root, java.util.function.BiConsumer<String, Dependency> consumer) {
+        List<DependencyNode> stack = new ArrayList<>(root.getChildren());
+        Set<String> visited = new HashSet<>();
+        while (!stack.isEmpty()) {
+            DependencyNode node = stack.remove(stack.size() - 1);
+            Dependency dep = node.getDependency();
+            if (dep == null) {
+                continue;
+            }
+            String ga = dep.getArtifact().getGroupId() + ":" + dep.getArtifact().getArtifactId();
+            if (visited.add(ga)) {
+                consumer.accept(ga, dep);
+                stack.addAll(node.getChildren());
+            }
+        }
+    }
+
+    /**
+     * Derive changed managed dependency GAs from effective models (for report purposes only).
+     */
+    Set<String> deriveChangedManagedDeps(Map<String, Model> oldEffectiveModels, Map<String, Model> newEffectiveModels) {
+        Set<String> changed = new LinkedHashSet<>();
+        for (Map.Entry<String, Model> entry : oldEffectiveModels.entrySet()) {
+            Model newModel = newEffectiveModels.get(entry.getKey());
+            if (newModel != null) {
+                changed.addAll(pomChangeAnalyzer.diffDependencies(
+                        pomChangeAnalyzer.getManagedDependencies(entry.getValue()),
+                        pomChangeAnalyzer.getManagedDependencies(newModel)));
+            }
+        }
+        return changed;
+    }
+
+    /**
+     * Derive changed managed plugin GAs from effective models (for report purposes only).
+     */
+    Set<String> deriveChangedManagedPlugins(
+            Map<String, Model> oldEffectiveModels, Map<String, Model> newEffectiveModels) {
+        Set<String> changed = new LinkedHashSet<>();
+        for (Map.Entry<String, Model> entry : oldEffectiveModels.entrySet()) {
+            Model newModel = newEffectiveModels.get(entry.getKey());
+            if (newModel != null) {
+                changed.addAll(pomChangeAnalyzer.diffManagedPluginVersions(
+                        pomChangeAnalyzer.getManagedPlugins(entry.getValue()),
+                        pomChangeAnalyzer.getManagedPlugins(newModel)));
+            }
+        }
+        return changed;
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifierTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifierTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ChangedFileClassifierTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ChangedFileClassifier classifier;
+
+    @BeforeEach
+    void setUp() {
+        classifier = new ChangedFileClassifier();
+    }
+
+    @Test
+    void classifyChanges_separatesPomAndSourceFiles() {
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("pom.xml");
+        changedFiles.add("module-a/pom.xml");
+        changedFiles.add("module-a/src/main/java/Foo.java");
+        changedFiles.add("module-b/src/test/java/FooTest.java");
+        changedFiles.add(".mvn/extensions.xml");
+
+        ChangedFileClassifier.ClassificationResult result = classifier.classifyChanges(changedFiles);
+
+        assertEquals(Set.of("pom.xml", "module-a/pom.xml"), result.pomChanges);
+        assertEquals(
+                Set.of("module-a/src/main/java/Foo.java", "module-b/src/test/java/FooTest.java"), result.sourceChanges);
+    }
+
+    @Test
+    void classifyChanges_ignoresMvnFiles() {
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add(".mvn/extensions.xml");
+        changedFiles.add(".mvn/maven.config");
+        changedFiles.add(".mvn/jvm.config");
+
+        ChangedFileClassifier.ClassificationResult result = classifier.classifyChanges(changedFiles);
+
+        assertTrue(result.pomChanges.isEmpty());
+        assertTrue(result.sourceChanges.isEmpty());
+    }
+
+    @Test
+    void classifyChanges_emptyInput() {
+        ChangedFileClassifier.ClassificationResult result = classifier.classifyChanges(Set.of());
+
+        assertTrue(result.pomChanges.isEmpty());
+        assertTrue(result.sourceChanges.isEmpty());
+    }
+
+    @Test
+    void normalizeGlobPattern_barePatternIsPrefixed() {
+        assertEquals("{*.md,**/*.md}", ChangedFileClassifier.normalizeGlobPattern("*.md"));
+        assertEquals("{LICENSE,**/LICENSE}", ChangedFileClassifier.normalizeGlobPattern("LICENSE"));
+    }
+
+    @Test
+    void normalizeGlobPattern_patternWithSlashIsUnchanged() {
+        assertEquals("docs/*.md", ChangedFileClassifier.normalizeGlobPattern("docs/*.md"));
+        assertEquals("**/*.md", ChangedFileClassifier.normalizeGlobPattern("**/*.md"));
+    }
+
+    @Test
+    void compileGlobMatchers_emptyPatterns() {
+        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of());
+        assertTrue(matchers.isEmpty());
+    }
+
+    @Test
+    void compileGlobMatchers_compilesPatterns() {
+        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of("*.md", "docs/**"));
+        assertEquals(2, matchers.size());
+    }
+
+    @Test
+    void matchesIncludePaths_matchesDirectModulePath() {
+        Path root = tempDir;
+        MavenProject project = createProject(root, "module-a", "com.example", "module-a");
+
+        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of("module-a"));
+        assertTrue(ChangedFileClassifier.matchesIncludePaths(project, matchers, root));
+    }
+
+    @Test
+    void matchesIncludePaths_noMatch() {
+        Path root = tempDir;
+        MavenProject project = createProject(root, "module-b", "com.example", "module-b");
+
+        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of("module-a"));
+        assertFalse(ChangedFileClassifier.matchesIncludePaths(project, matchers, root));
+    }
+
+    @Test
+    void matchesIncludePaths_matchesPomXmlPattern() {
+        Path root = tempDir;
+        MavenProject project = createProject(root, "module-a", "com.example", "module-a");
+
+        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of("module-a/**"));
+        assertTrue(ChangedFileClassifier.matchesIncludePaths(project, matchers, root));
+    }
+
+    @Test
+    void matchesDisableTrigger_matchesPattern() {
+        ScalpelConfiguration config = configWith("scalpel.disableTriggers", "*.lock");
+
+        // The lock file won't match *.lock, but let's test with a matching one
+        Set<String> files2 = Set.of("deps.lock");
+        assertTrue(classifier.matchesDisableTrigger(files2, config));
+    }
+
+    @Test
+    void matchesDisableTrigger_noMatch() {
+        ScalpelConfiguration config = configWith("scalpel.disableTriggers", "*.lock");
+        Set<String> changedFiles = Set.of("src/main/java/Foo.java");
+
+        assertFalse(classifier.matchesDisableTrigger(changedFiles, config));
+    }
+
+    @Test
+    void filterExcludedPaths_excludesMatchingFiles() {
+        ScalpelConfiguration config = configWith("scalpel.excludePaths", "docs/**");
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("docs/guide.md");
+        changedFiles.add("src/main/java/Foo.java");
+
+        Set<String> filtered = classifier.filterExcludedPaths(changedFiles, config);
+        assertEquals(Set.of("src/main/java/Foo.java"), filtered);
+    }
+
+    @Test
+    void filterExcludedPaths_noExclusions() {
+        ScalpelConfiguration config = configWith("scalpel.mode", "trim");
+        Set<String> changedFiles = Set.of("src/main/java/Foo.java");
+
+        Set<String> filtered = classifier.filterExcludedPaths(changedFiles, config);
+        assertEquals(changedFiles, filtered);
+    }
+
+    @Test
+    void findFullBuildTrigger_findsMatch() {
+        ScalpelConfiguration config = configWith("scalpel.fullBuildTriggers", ".github/workflows/**");
+        Set<String> changedFiles = Set.of(".github/workflows/ci.yml", "src/main/java/Foo.java");
+
+        String trigger = classifier.findFullBuildTrigger(changedFiles, config);
+        assertEquals(".github/workflows/ci.yml", trigger);
+    }
+
+    @Test
+    void findFullBuildTrigger_noMatch() {
+        ScalpelConfiguration config = configWith("scalpel.fullBuildTriggers", ".github/workflows/**");
+        Set<String> changedFiles = Set.of("src/main/java/Foo.java");
+
+        String trigger = classifier.findFullBuildTrigger(changedFiles, config);
+        assertNull(trigger);
+    }
+
+    @Test
+    void relativePath_computesCorrectly() {
+        Path root = tempDir;
+        MavenProject project = createProject(root, "module-a", "com.example", "module-a");
+        assertEquals("module-a", ChangedFileClassifier.relativePath(root, project));
+    }
+
+    private MavenProject createProject(Path root, String module, String groupId, String artifactId) {
+        Path moduleDir = root.resolve(module);
+        moduleDir.toFile().mkdirs();
+        MavenProject project = mock(MavenProject.class);
+        when(project.getGroupId()).thenReturn(groupId);
+        when(project.getArtifactId()).thenReturn(artifactId);
+        when(project.getBasedir()).thenReturn(moduleDir.toFile());
+        when(project.getFile()).thenReturn(moduleDir.resolve("pom.xml").toFile());
+        when(project.getProperties()).thenReturn(new Properties());
+        return project;
+    }
+
+    private ScalpelConfiguration configWith(String key, String value) {
+        Properties sysProps = new Properties();
+        Properties userProps = new Properties();
+        userProps.setProperty("scalpel.enabled", "true");
+        userProps.setProperty("scalpel.mode", "trim");
+        userProps.setProperty("scalpel.baseBranch", "main");
+        userProps.setProperty(key, value);
+        return ScalpelConfiguration.fromProperties(sysProps, userProps);
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ForceBuildMatcherTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ForceBuildMatcherTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Properties;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ForceBuildMatcherTest {
+
+    private ForceBuildMatcher matcher;
+
+    @BeforeEach
+    void setUp() {
+        matcher = new ForceBuildMatcher();
+    }
+
+    @Test
+    void matchesForceBuild_matchesExactArtifactId() {
+        MavenProject project = createProject("module-a");
+        String result = matcher.matchesForceBuild(project, List.of("module-a"));
+        assertEquals("module-a", result);
+    }
+
+    @Test
+    void matchesForceBuild_matchesRegexPattern() {
+        MavenProject project = createProject("module-integration-tests");
+        String result = matcher.matchesForceBuild(project, List.of(".*-integration-tests"));
+        assertEquals(".*-integration-tests", result);
+    }
+
+    @Test
+    void matchesForceBuild_noMatch() {
+        MavenProject project = createProject("module-a");
+        String result = matcher.matchesForceBuild(project, List.of("module-b"));
+        assertNull(result);
+    }
+
+    @Test
+    void matchesForceBuild_emptyPatterns() {
+        MavenProject project = createProject("module-a");
+        String result = matcher.matchesForceBuild(project, List.of());
+        assertNull(result);
+    }
+
+    @Test
+    void matchesForceBuild_multiplePatterns_returnsFirstMatch() {
+        MavenProject project = createProject("module-a");
+        String result = matcher.matchesForceBuild(project, List.of("module-b", "module-a", "module-.*"));
+        assertEquals("module-a", result);
+    }
+
+    @Test
+    void matchesForceBuild_partialMatch_doesNotMatch() {
+        // Regex matching is full-string match by default in BoundedRegexMatcher
+        MavenProject project = createProject("module-a-extra");
+        String result = matcher.matchesForceBuild(project, List.of("module-a"));
+        assertNull(result);
+    }
+
+    @Test
+    void matchesForceBuild_wildcardPattern() {
+        MavenProject project = createProject("any-module");
+        String result = matcher.matchesForceBuild(project, List.of(".*"));
+        assertEquals(".*", result);
+    }
+
+    private MavenProject createProject(String artifactId) {
+        MavenProject project = mock(MavenProject.class);
+        when(project.getGroupId()).thenReturn("com.example");
+        when(project.getArtifactId()).thenReturn(artifactId);
+        when(project.getProperties()).thenReturn(new Properties());
+        return project;
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ImpactedLogWriterTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ImpactedLogWriterTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ImpactedLogWriterTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ImpactedLogWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        writer = new ImpactedLogWriter(new ReportAssembler());
+    }
+
+    @Test
+    void isSafeImpactedLogPath_acceptsSafePaths() {
+        assertTrue(ImpactedLogWriter.isSafeImpactedLogPath("module-a"));
+        assertTrue(ImpactedLogWriter.isSafeImpactedLogPath("module-a/sub-module"));
+        assertTrue(ImpactedLogWriter.isSafeImpactedLogPath("Module_1.v2/dir"));
+        assertTrue(ImpactedLogWriter.isSafeImpactedLogPath("m"));
+        assertTrue(ImpactedLogWriter.isSafeImpactedLogPath("a-b_c.d/e"));
+        assertTrue(ImpactedLogWriter.isSafeImpactedLogPath("."));
+    }
+
+    @Test
+    void isSafeImpactedLogPath_rejectsUnsafePaths() {
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath(null));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath(""));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("-module"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("module;rm"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("module$(id)"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("module rm"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("module`id`"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("mo'dule"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("mo\"dule"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("mo\\dule"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("module*"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("mo?dule"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("mo[du]le"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("module|rm"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("module&rm"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("evil\nforge"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("evil\rforge"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("evil\tforge"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("evil\0forge"));
+        assertFalse(ImpactedLogWriter.isSafeImpactedLogPath("evil\u007Fforge"));
+    }
+
+    @Test
+    void escapeControlChars_escapesControlCharacters() {
+        assertEquals("evil\\u000aforge", ImpactedLogWriter.escapeControlChars("evil\nforge"));
+        assertEquals("evil\\u000dforge", ImpactedLogWriter.escapeControlChars("evil\rforge"));
+        assertEquals("evil\\u0009forge", ImpactedLogWriter.escapeControlChars("evil\tforge"));
+        assertEquals("evil\\u0000forge", ImpactedLogWriter.escapeControlChars("evil\0forge"));
+    }
+
+    @Test
+    void escapeControlChars_leavesNormalCharsAlone() {
+        assertEquals("module-a", ImpactedLogWriter.escapeControlChars("module-a"));
+        assertEquals("path/to/module", ImpactedLogWriter.escapeControlChars("path/to/module"));
+    }
+
+    @Test
+    void writeImpactedLog_writesModulePaths() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        MavenProject p1 = createProject(root, "module-a");
+        MavenProject p2 = createProject(root, "module-b");
+
+        Set<MavenProject> affected = new LinkedHashSet<>();
+        affected.add(p1);
+        affected.add(p2);
+
+        ScalpelConfiguration config = configWithImpactedLog("target/impacted.log");
+
+        writer.writeImpactedLog(config, root, affected);
+
+        Path logPath = root.resolve("target/impacted.log");
+        assertTrue(Files.exists(logPath));
+        List<String> lines = Files.readAllLines(logPath, StandardCharsets.UTF_8);
+        assertEquals(2, lines.size());
+        assertEquals("module-a", lines.get(0));
+        assertEquals("module-b", lines.get(1));
+    }
+
+    @Test
+    void writeImpactedLog_rootModuleRepresentedAsDot() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        // Root module: basedir == reactorRoot
+        MavenProject rootProject = mock(MavenProject.class);
+        when(rootProject.getGroupId()).thenReturn("com.example");
+        when(rootProject.getArtifactId()).thenReturn("parent");
+        when(rootProject.getBasedir()).thenReturn(root.toFile());
+        when(rootProject.getFile()).thenReturn(root.resolve("pom.xml").toFile());
+        when(rootProject.getProperties()).thenReturn(new Properties());
+
+        Set<MavenProject> affected = new LinkedHashSet<>();
+        affected.add(rootProject);
+
+        ScalpelConfiguration config = configWithImpactedLog("target/impacted.log");
+
+        writer.writeImpactedLog(config, root, affected);
+
+        Path logPath = root.resolve("target/impacted.log");
+        List<String> lines = Files.readAllLines(logPath, StandardCharsets.UTF_8);
+        assertEquals(1, lines.size());
+        assertEquals(".", lines.get(0));
+    }
+
+    @Test
+    void writeImpactedLog_skipsWhenNull() throws Exception {
+        ScalpelConfiguration config = configWith("scalpel.mode", "trim");
+
+        // null impactedLog means no-op — verify no exception is thrown
+        assertDoesNotThrow(() -> writer.writeImpactedLog(config, tempDir, Set.of()));
+    }
+
+    private MavenProject createProject(Path root, String module) {
+        Path moduleDir = root.resolve(module);
+        moduleDir.toFile().mkdirs();
+        MavenProject project = mock(MavenProject.class);
+        when(project.getGroupId()).thenReturn("com.example");
+        when(project.getArtifactId()).thenReturn(module);
+        when(project.getBasedir()).thenReturn(moduleDir.toFile());
+        when(project.getFile()).thenReturn(moduleDir.resolve("pom.xml").toFile());
+        when(project.getProperties()).thenReturn(new Properties());
+        return project;
+    }
+
+    private ScalpelConfiguration configWithImpactedLog(String logPath) {
+        Properties sysProps = new Properties();
+        Properties userProps = new Properties();
+        userProps.setProperty("scalpel.enabled", "true");
+        userProps.setProperty("scalpel.mode", "trim");
+        userProps.setProperty("scalpel.baseBranch", "main");
+        userProps.setProperty("scalpel.impactedLog", logPath);
+        return ScalpelConfiguration.fromProperties(sysProps, userProps);
+    }
+
+    private ScalpelConfiguration configWith(String key, String value) {
+        Properties sysProps = new Properties();
+        Properties userProps = new Properties();
+        userProps.setProperty("scalpel.enabled", "true");
+        userProps.setProperty("scalpel.mode", "trim");
+        userProps.setProperty("scalpel.baseBranch", "main");
+        userProps.setProperty(key, value);
+        return ScalpelConfiguration.fromProperties(sysProps, userProps);
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplierTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplierTest.java
@@ -54,25 +54,25 @@ class SkipTestsApplierTest {
     @Test
     void matchesDownstreamExclusion_matchesByArtifactId() {
         MavenProject project = createProject("module-a");
-        assertTrue(applier.matchesDownstreamExclusion(project, List.of("module-a")));
+        assertTrue(Projects.matchesDownstreamExclusion(project, List.of("module-a")));
     }
 
     @Test
     void matchesDownstreamExclusion_matchesByGA() {
         MavenProject project = createProject("module-a");
-        assertTrue(applier.matchesDownstreamExclusion(project, List.of("com.example:module-a")));
+        assertTrue(Projects.matchesDownstreamExclusion(project, List.of("com.example:module-a")));
     }
 
     @Test
     void matchesDownstreamExclusion_noMatch() {
         MavenProject project = createProject("module-a");
-        assertFalse(applier.matchesDownstreamExclusion(project, List.of("module-b")));
+        assertFalse(Projects.matchesDownstreamExclusion(project, List.of("module-b")));
     }
 
     @Test
     void matchesDownstreamExclusion_emptyPatterns() {
         MavenProject project = createProject("module-a");
-        assertFalse(applier.matchesDownstreamExclusion(project, List.of()));
+        assertFalse(Projects.matchesDownstreamExclusion(project, List.of()));
     }
 
     @Test
@@ -190,6 +190,29 @@ class SkipTestsApplierTest {
                         new java.util.LinkedHashMap<>(),
                         new java.util.LinkedHashMap<>(),
                         new eu.maveniverse.maven.scalpel.core.Timings())));
+    }
+
+    @Test
+    void shouldSkipTestsForExcludedDownstream_returnsTrue_whenMatchingDownstreamWithNoModelChanges() {
+        MavenProject project = createProject("module-a");
+        ScalpelConfiguration config = configWith("scalpel.skipTestsForDownstreamModules", "module-a");
+        // project IS in downstream set, pattern matches, and no effective model changes
+        TrimResult trimResult = new TrimResult(List.of(project), Set.of(), Set.of(), Set.of(project));
+
+        TransitiveImpactAnalyzer.EffectiveModels models =
+                new TransitiveImpactAnalyzer.EffectiveModels(java.util.Map.of(), java.util.Map.of());
+        TransitiveImpactAnalyzer.ResolutionContext rctx = new TransitiveImpactAnalyzer.ResolutionContext(
+                tempDir,
+                mock(org.apache.maven.execution.MavenSession.class),
+                new java.util.LinkedHashMap<>(),
+                new java.util.LinkedHashMap<>(),
+                new eu.maveniverse.maven.scalpel.core.Timings());
+
+        // hasEffectiveModelChanges returns false (no changes) → should skip tests
+        when(transitiveImpactAnalyzer.hasEffectiveModelChanges(project, models, rctx))
+                .thenReturn(false);
+
+        assertTrue(applier.shouldSkipTestsForExcludedDownstream(project, trimResult, config, models, rctx));
     }
 
     private MavenProject createProject(String artifactId) {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplierTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplierTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkipTestsApplierTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ReactorTrimmer reactorTrimmer;
+    private TransitiveImpactAnalyzer transitiveImpactAnalyzer;
+    private SkipTestsApplier applier;
+
+    @BeforeEach
+    void setUp() {
+        reactorTrimmer = mock(ReactorTrimmer.class);
+        transitiveImpactAnalyzer = mock(TransitiveImpactAnalyzer.class);
+        applier = new SkipTestsApplier(reactorTrimmer, transitiveImpactAnalyzer);
+    }
+
+    @Test
+    void skipTestsOnAll_setsPropertyOnAllProjects() {
+        MavenProject p1 = createProject("module-a");
+        MavenProject p2 = createProject("module-b");
+
+        applier.skipTestsOnAll(List.of(p1, p2));
+
+        assertEquals("true", p1.getProperties().getProperty("maven.test.skip"));
+        assertEquals("true", p2.getProperties().getProperty("maven.test.skip"));
+    }
+
+    @Test
+    void matchesDownstreamExclusion_matchesByArtifactId() {
+        MavenProject project = createProject("module-a");
+        assertTrue(applier.matchesDownstreamExclusion(project, List.of("module-a")));
+    }
+
+    @Test
+    void matchesDownstreamExclusion_matchesByGA() {
+        MavenProject project = createProject("module-a");
+        assertTrue(applier.matchesDownstreamExclusion(project, List.of("com.example:module-a")));
+    }
+
+    @Test
+    void matchesDownstreamExclusion_noMatch() {
+        MavenProject project = createProject("module-a");
+        assertFalse(applier.matchesDownstreamExclusion(project, List.of("module-b")));
+    }
+
+    @Test
+    void matchesDownstreamExclusion_emptyPatterns() {
+        MavenProject project = createProject("module-a");
+        assertFalse(applier.matchesDownstreamExclusion(project, List.of()));
+    }
+
+    @Test
+    void applyPerCategoryArgs_setsUpstreamArgs() {
+        MavenProject upstream = createProject("upstream");
+        MavenProject downstream = createProject("downstream");
+        MavenProject downstreamTest = createProject("downstream-test");
+
+        TrimResult trimResult = new TrimResult(
+                List.of(upstream, downstream, downstreamTest),
+                Set.of(),
+                Set.of(upstream),
+                Set.of(downstream),
+                Set.of(downstreamTest));
+
+        ScalpelConfiguration config = configWith("scalpel.upstreamArgs", "maven.javadoc.skip=true");
+        applier.applyPerCategoryArgs(trimResult, config);
+
+        assertEquals("true", upstream.getProperties().getProperty("maven.javadoc.skip"));
+        assertFalse(downstream.getProperties().containsKey("maven.javadoc.skip"));
+    }
+
+    @Test
+    void applyPerCategoryArgs_setsDownstreamArgs() {
+        MavenProject upstream = createProject("upstream");
+        MavenProject downstream = createProject("downstream");
+        MavenProject downstreamTest = createProject("downstream-test");
+
+        TrimResult trimResult = new TrimResult(
+                List.of(upstream, downstream, downstreamTest),
+                Set.of(),
+                Set.of(upstream),
+                Set.of(downstream),
+                Set.of(downstreamTest));
+
+        ScalpelConfiguration config = configWith("scalpel.downstreamArgs", "skipITs=true");
+        applier.applyPerCategoryArgs(trimResult, config);
+
+        assertFalse(upstream.getProperties().containsKey("skipITs"));
+        assertEquals("true", downstream.getProperties().getProperty("skipITs"));
+        assertEquals("true", downstreamTest.getProperties().getProperty("skipITs"));
+    }
+
+    @Test
+    void softenTestJarProducers_softensWhenConsumerExists() {
+        MavenProject consumer = createProject("consumer");
+        MavenProject producer = createProject("producer");
+        producer.getProperties().setProperty("maven.test.skip", "true");
+
+        List<MavenProject> testProjects = new ArrayList<>(List.of(consumer));
+        List<MavenProject> skippedProjects = new ArrayList<>(List.of(producer));
+
+        when(reactorTrimmer.hasTestJarDependency(consumer, producer)).thenReturn(true);
+
+        Set<MavenProject> softened = applier.softenTestJarProducers(testProjects, skippedProjects);
+
+        assertEquals(1, softened.size());
+        assertTrue(softened.contains(producer));
+        assertFalse(producer.getProperties().containsKey("maven.test.skip"));
+        assertEquals("true", producer.getProperties().getProperty("skipTests"));
+        assertTrue(skippedProjects.isEmpty()); // Producer removed from skipped list
+    }
+
+    @Test
+    void softenTestJarProducers_noSofteningWhenNoConsumer() {
+        MavenProject consumer = createProject("consumer");
+        MavenProject producer = createProject("producer");
+        producer.getProperties().setProperty("maven.test.skip", "true");
+
+        List<MavenProject> testProjects = new ArrayList<>(List.of(consumer));
+        List<MavenProject> skippedProjects = new ArrayList<>(List.of(producer));
+
+        when(reactorTrimmer.hasTestJarDependency(consumer, producer)).thenReturn(false);
+
+        Set<MavenProject> softened = applier.softenTestJarProducers(testProjects, skippedProjects);
+
+        assertTrue(softened.isEmpty());
+        assertEquals("true", producer.getProperties().getProperty("maven.test.skip"));
+    }
+
+    @Test
+    void shouldSkipTestsForExcludedDownstream_returnsFalse_whenNoPatternsConfigured() {
+        MavenProject project = createProject("module-a");
+        ScalpelConfiguration config = configWith("scalpel.mode", "skip-tests");
+        TrimResult trimResult = new TrimResult(List.of(project), Set.of(), Set.of(), Set.of(project));
+
+        assertFalse(applier.shouldSkipTestsForExcludedDownstream(
+                project,
+                trimResult,
+                config,
+                new TransitiveImpactAnalyzer.EffectiveModels(java.util.Map.of(), java.util.Map.of()),
+                new TransitiveImpactAnalyzer.ResolutionContext(
+                        tempDir,
+                        mock(org.apache.maven.execution.MavenSession.class),
+                        new java.util.LinkedHashMap<>(),
+                        new java.util.LinkedHashMap<>(),
+                        new eu.maveniverse.maven.scalpel.core.Timings())));
+    }
+
+    @Test
+    void shouldSkipTestsForExcludedDownstream_returnsFalse_whenNotDownstream() {
+        MavenProject project = createProject("module-a");
+        ScalpelConfiguration config = configWith("scalpel.skipTestsForDownstreamModules", "module-a");
+        // project is NOT in downstream sets
+        TrimResult trimResult = new TrimResult(List.of(project), Set.of(project), Set.of(), Set.of());
+
+        assertFalse(applier.shouldSkipTestsForExcludedDownstream(
+                project,
+                trimResult,
+                config,
+                new TransitiveImpactAnalyzer.EffectiveModels(java.util.Map.of(), java.util.Map.of()),
+                new TransitiveImpactAnalyzer.ResolutionContext(
+                        tempDir,
+                        mock(org.apache.maven.execution.MavenSession.class),
+                        new java.util.LinkedHashMap<>(),
+                        new java.util.LinkedHashMap<>(),
+                        new eu.maveniverse.maven.scalpel.core.Timings())));
+    }
+
+    private MavenProject createProject(String artifactId) {
+        MavenProject project = mock(MavenProject.class);
+        when(project.getGroupId()).thenReturn("com.example");
+        when(project.getArtifactId()).thenReturn(artifactId);
+        when(project.getBasedir()).thenReturn(tempDir.resolve(artifactId).toFile());
+        when(project.getFile())
+                .thenReturn(tempDir.resolve(artifactId + "/pom.xml").toFile());
+        Properties props = new Properties();
+        when(project.getProperties()).thenReturn(props);
+        return project;
+    }
+
+    private ScalpelConfiguration configWith(String key, String value) {
+        Properties sysProps = new Properties();
+        Properties userProps = new Properties();
+        userProps.setProperty("scalpel.enabled", "true");
+        userProps.setProperty("scalpel.mode", "skip-tests");
+        userProps.setProperty("scalpel.baseBranch", "main");
+        userProps.setProperty(key, value);
+        return ScalpelConfiguration.fromProperties(sysProps, userProps);
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/TransitiveImpactAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/TransitiveImpactAnalyzerTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.maveniverse.maven.scalpel.core.Timings;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.DependencyResolutionException;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectDependenciesResolver;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TransitiveImpactAnalyzerTest {
+
+    @TempDir
+    Path tempDir;
+
+    private ProjectDependenciesResolver resolver;
+    private PomChangeAnalyzer pomChangeAnalyzer;
+    private TransitiveImpactAnalyzer analyzer;
+
+    @BeforeEach
+    void setUp() {
+        resolver = mock(ProjectDependenciesResolver.class);
+        pomChangeAnalyzer = mock(PomChangeAnalyzer.class);
+        analyzer = new TransitiveImpactAnalyzer(resolver, pomChangeAnalyzer);
+    }
+
+    @Test
+    void collectDependencyVersions_collectsFromTree() {
+        DependencyNode root = new DefaultDependencyNode((Dependency) null);
+        DependencyNode child1 = createDependencyNode("com.example", "dep-a", "1.0", "compile");
+        DependencyNode child2 = createDependencyNode("com.example", "dep-b", "2.0", "test");
+        root.setChildren(List.of(child1, child2));
+
+        Map<String, String> versions = TransitiveImpactAnalyzer.collectDependencyVersions(root);
+
+        assertEquals(2, versions.size());
+        assertEquals("1.0", versions.get("com.example:dep-a"));
+        assertEquals("2.0", versions.get("com.example:dep-b"));
+    }
+
+    @Test
+    void collectDependencyVersions_handlesNestedNodes() {
+        DependencyNode root = new DefaultDependencyNode((Dependency) null);
+        DependencyNode child = createDependencyNode("com.example", "dep-a", "1.0", "compile");
+        DependencyNode grandchild = createDependencyNode("org.other", "lib", "3.0", "compile");
+        child.setChildren(List.of(grandchild));
+        root.setChildren(List.of(child));
+
+        Map<String, String> versions = TransitiveImpactAnalyzer.collectDependencyVersions(root);
+
+        assertEquals(2, versions.size());
+        assertEquals("1.0", versions.get("com.example:dep-a"));
+        assertEquals("3.0", versions.get("org.other:lib"));
+    }
+
+    @Test
+    void collectDependencyVersions_deduplicatesByGA() {
+        DependencyNode root = new DefaultDependencyNode((Dependency) null);
+        DependencyNode child1 = createDependencyNode("com.example", "dep-a", "1.0", "compile");
+        DependencyNode child2 = createDependencyNode("com.example", "dep-a", "2.0", "compile");
+        root.setChildren(List.of(child1, child2));
+
+        Map<String, String> versions = TransitiveImpactAnalyzer.collectDependencyVersions(root);
+
+        assertEquals(1, versions.size());
+        // First encountered wins
+        assertNotNull(versions.get("com.example:dep-a"));
+    }
+
+    @Test
+    void collectDependencyScopes_collectsFromTree() {
+        DependencyNode root = new DefaultDependencyNode((Dependency) null);
+        DependencyNode child1 = createDependencyNode("com.example", "dep-a", "1.0", "compile");
+        DependencyNode child2 = createDependencyNode("com.example", "dep-b", "2.0", "test");
+        root.setChildren(List.of(child1, child2));
+
+        Map<String, String> scopes = TransitiveImpactAnalyzer.collectDependencyScopes(root);
+
+        assertEquals(2, scopes.size());
+        assertEquals("compile", scopes.get("com.example:dep-a"));
+        assertEquals("test", scopes.get("com.example:dep-b"));
+    }
+
+    @Test
+    void collectDependencyScopes_emptyScopeFallsThrough() {
+        // Aether's Dependency normalizes null scope to ""; verify the code handles
+        // that case gracefully (the getOrDefault("compile") path in the caller
+        // handles any missing entries, not this method).
+        DependencyNode root = new DefaultDependencyNode((Dependency) null);
+        DependencyNode child = createDependencyNode("com.example", "dep-a", "1.0", null);
+        root.setChildren(List.of(child));
+
+        Map<String, String> scopes = TransitiveImpactAnalyzer.collectDependencyScopes(root);
+
+        // Aether's Dependency constructor normalizes null -> ""; the method preserves that.
+        assertEquals("", scopes.get("com.example:dep-a"));
+    }
+
+    @Test
+    void collectDependencyVersions_emptyTree() {
+        DependencyNode root = new DefaultDependencyNode((Dependency) null);
+        root.setChildren(List.of());
+
+        Map<String, String> versions = TransitiveImpactAnalyzer.collectDependencyVersions(root);
+
+        assertTrue(versions.isEmpty());
+    }
+
+    @Test
+    void deriveChangedManagedDeps_detectsChanges() {
+        Map<String, Model> oldModels = Map.of("pom.xml", new Model());
+        Map<String, Model> newModels = Map.of("pom.xml", new Model());
+
+        List<org.apache.maven.model.Dependency> oldDeps = List.of();
+        List<org.apache.maven.model.Dependency> newDeps = List.of();
+        when(pomChangeAnalyzer.getManagedDependencies(any())).thenReturn(oldDeps, newDeps);
+        when(pomChangeAnalyzer.diffDependencies(oldDeps, newDeps)).thenReturn(Set.of("com.example:changed-dep"));
+
+        Set<String> changed = analyzer.deriveChangedManagedDeps(oldModels, newModels);
+
+        assertEquals(Set.of("com.example:changed-dep"), changed);
+    }
+
+    @Test
+    void deriveChangedManagedDeps_emptyModels() {
+        Set<String> changed = analyzer.deriveChangedManagedDeps(Map.of(), Map.of());
+        assertTrue(changed.isEmpty());
+    }
+
+    @Test
+    void deriveChangedManagedPlugins_detectsChanges() {
+        Map<String, Model> oldModels = Map.of("pom.xml", new Model());
+        Map<String, Model> newModels = Map.of("pom.xml", new Model());
+
+        List<org.apache.maven.model.Plugin> oldPlugins = List.of();
+        List<org.apache.maven.model.Plugin> newPlugins = List.of();
+        when(pomChangeAnalyzer.getManagedPlugins(any())).thenReturn(oldPlugins, newPlugins);
+        when(pomChangeAnalyzer.diffManagedPluginVersions(oldPlugins, newPlugins))
+                .thenReturn(Set.of("org.apache.maven.plugins:maven-compiler-plugin"));
+
+        Set<String> changed = analyzer.deriveChangedManagedPlugins(oldModels, newModels);
+
+        assertEquals(Set.of("org.apache.maven.plugins:maven-compiler-plugin"), changed);
+    }
+
+    @Test
+    void computeTransitivelyAffected_skipsWhenNoEffectiveModels() {
+        MavenSession session = mock(MavenSession.class);
+        List<MavenProject> allProjects = List.of();
+        Set<MavenProject> directlyAffected = Set.of();
+        Map<MavenProject, List<String>> returnEvidence = new LinkedHashMap<>();
+
+        Map<MavenProject, List<String>> result = analyzer.computeTransitivelyAffected(
+                allProjects,
+                directlyAffected,
+                new TransitiveImpactAnalyzer.EffectiveModels(Map.of(), Map.of()),
+                new TransitiveImpactAnalyzer.ResolutionContext(
+                        tempDir, session, new LinkedHashMap<>(), new LinkedHashMap<>(), new Timings()),
+                false,
+                returnEvidence);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void resolveProjectDependencies_returnsCachedResult() {
+        MavenProject project = mock(MavenProject.class);
+        when(project.getGroupId()).thenReturn("com.example");
+        when(project.getArtifactId()).thenReturn("module-a");
+        MavenSession session = mock(MavenSession.class);
+        DependencyResolutionResult cachedResult = mock(DependencyResolutionResult.class);
+        Map<MavenProject, DependencyResolutionResult> cache = new LinkedHashMap<>();
+        cache.put(project, cachedResult);
+        Timings timings = new Timings();
+
+        DependencyResolutionResult result = analyzer.resolveProjectDependencies(project, session, cache, timings);
+
+        assertEquals(cachedResult, result);
+    }
+
+    @Test
+    void resolveProjectDependencies_returnsNullOnException() throws Exception {
+        MavenProject project = mock(MavenProject.class);
+        when(project.getGroupId()).thenReturn("com.example");
+        when(project.getArtifactId()).thenReturn("module-a");
+        MavenSession session = mock(MavenSession.class);
+        RepositorySystemSession repoSession = mock(RepositorySystemSession.class);
+        when(session.getRepositorySession()).thenReturn(repoSession);
+        DependencyResolutionResult partialResult = mock(DependencyResolutionResult.class);
+        when(partialResult.getUnresolvedDependencies()).thenReturn(List.of());
+        // Build the exception eagerly, outside the when() chain, so the mock
+        // interaction in DependencyResolutionException's constructor doesn't
+        // interfere with Mockito's stubbing state.
+        DependencyResolutionException ex = new DependencyResolutionException(partialResult, "test failure", null);
+        when(resolver.resolve(any())).thenThrow(ex);
+        Timings timings = new Timings();
+
+        DependencyResolutionResult result =
+                analyzer.resolveProjectDependencies(project, session, new LinkedHashMap<>(), timings);
+
+        assertNull(result);
+    }
+
+    private DependencyNode createDependencyNode(String groupId, String artifactId, String version, String scope) {
+        DefaultArtifact artifact = new DefaultArtifact(groupId, artifactId, "jar", version);
+        Dependency dep = new Dependency(artifact, scope);
+        DefaultDependencyNode node = new DefaultDependencyNode(dep);
+        node.setChildren(new ArrayList<>());
+        return node;
+    }
+}

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/TransitiveImpactAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/TransitiveImpactAnalyzerTest.java
@@ -8,7 +8,6 @@
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -92,8 +91,8 @@ class TransitiveImpactAnalyzerTest {
         Map<String, String> versions = TransitiveImpactAnalyzer.collectDependencyVersions(root);
 
         assertEquals(1, versions.size());
-        // First encountered wins
-        assertNotNull(versions.get("com.example:dep-a"));
+        // LIFO traversal: child2 (dep-a:2.0) is popped first, first-encountered wins
+        assertEquals("2.0", versions.get("com.example:dep-a"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Extracts six single-responsibility collaborator classes from the 2008-line `ScalpelLifecycleParticipant`, reducing it to a 736-line orchestrator:

| Class | Responsibility | Lines |
|-------|---------------|-------|
| `ChangedFileClassifier` | Glob compilation, path filtering, disable/full-build triggers, POM/source classification, includePaths | 174 |
| `TransitiveImpactAnalyzer` | Two-pass transitive impact analysis, resolver cache, dependency tree diff, effective model comparison | 504 |
| `SkipTestsApplier` | Skip-tests mode, test-jar softening, per-category args, downstream exclusion | 268 |
| `ReportAssembler` | JSON report assembly, status/shadow/full-build report writing | 330 |
| `ImpactedLogWriter` | Impacted-log file writing with path safety validation | 122 |
| `ForceBuildMatcher` | Regex-based forceBuildModules pattern matching | 40 |

### Design

- All extracted classes are **package-private** with **constructor-injected** collaborators
- Each class is **independently unit-testable** without a full `MavenSession` mock
- The participant's DI constructor signature is **unchanged** — internal collaborators are constructed from existing injected dependencies
- The triplicated "no affected modules" block is **deduplicated** into `handleNoAffectedModules()`
- Static forwarders `isSafeImpactedLogPath()` and `normalizeGlobPattern()` preserve backward compatibility with existing tests

### Tests

- All **95 existing `ScalpelLifecycleParticipantTest`** tests pass unchanged
- **54 new tests** across 5 test classes cover the extracted logic:
  - `ChangedFileClassifierTest` (17 tests)
  - `TransitiveImpactAnalyzerTest` (12 tests)
  - `SkipTestsApplierTest` (11 tests)
  - `ImpactedLogWriterTest` (7 tests)
  - `ForceBuildMatcherTest` (7 tests)
- Build: **244 tests, 0 failures, 0 errors** ✅

### Notes

The participant is 736 lines rather than the aspirational ~150 from the issue. The remaining bulk is pure orchestration: the 530-line `afterProjectsRead` method sequences config bootstrap → change detection → classification → POM analysis → transitive resolution → includePaths filtering → shadow mode → trim/skip-tests dispatch. All domain **logic** has been extracted; what remains is glue code that wires collaborator outputs together and handles the mode-dependent branching. Further decomposition would require splitting the method into smaller orchestration phases, which would benefit from landing the shadow-mode extraction first (separate concern).

Fixes #125

_AI agent (Hermes on behalf of gnodet)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Selective builds now account for source, POM, dependency, plugin, and transitive changes.
  - Modules can be force-built using configured patterns.
  - Test skipping preserves test-jar outputs required by other modules.
  - Impacted-module logs include validated paths and relative module names.
  - Build reports include affected, skipped, excluded, and timing details.
- **Bug Fixes**
  - Improved handling of excluded paths, include patterns, unresolved dependencies, and full-build triggers.
  - Added safer handling for invalid report and log paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->