### PR TITLE
Fix #148: include/exclude glob patterns for effective model comparison

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -184,6 +184,44 @@ public final class ScalpelConfiguration {
      */
     public static final String MAX_RESOURCE_FILE_SIZE = PREFIX + "maxResourceFileSize";
 
+    /**
+     * System property {@code scalpel.excludeChanges}: comma-separated glob patterns over change
+     * paths that should be excluded from the effective model comparison. Excluded changes are
+     * treated as if they did not happen — a module is not marked as affected by them.
+     *
+     * <p>Change paths follow a normalized scheme:
+     * <ul>
+     *   <li>{@code properties/<name>} — e.g. {@code properties/build.timestamp}</li>
+     *   <li>{@code dependencies/<groupId>:<artifactId>} — e.g. {@code dependencies/com.foo:bar}</li>
+     *   <li>{@code plugins/<groupId>:<artifactId>}</li>
+     *   <li>{@code managedDependencies/<groupId>:<artifactId>}</li>
+     *   <li>{@code managedPlugins/<groupId>:<artifactId>}</li>
+     *   <li>{@code resources/<path>} — filtered resource files referencing changed properties</li>
+     * </ul>
+     *
+     * <p>Default: {@code properties/build.timestamp,properties/project.build.outputTimestamp}
+     * (volatile properties that change on every build and don't affect compilation).
+     *
+     * @see #INCLUDE_CHANGES
+     */
+    public static final String EXCLUDE_CHANGES = PREFIX + "excludeChanges";
+
+    /**
+     * System property {@code scalpel.includeChanges}: comma-separated glob patterns over change
+     * paths that force inclusion in the effective model comparison, even if the change would
+     * normally be ignored (e.g. because the property is inherited but not in the child's raw model).
+     *
+     * <p>Include patterns are applied after exclude patterns and override them: a change matching
+     * both an exclude and an include pattern is included.
+     *
+     * <p>Uses the same change path scheme as {@link #EXCLUDE_CHANGES}.
+     *
+     * <p>Default: none.
+     *
+     * @see #EXCLUDE_CHANGES
+     */
+    public static final String INCLUDE_CHANGES = PREFIX + "includeChanges";
+
     /** Mode value selecting {@code trim}: drop unaffected modules from the reactor. */
     public static final String MODE_TRIM = "trim";
 
@@ -205,6 +243,13 @@ public final class ScalpelConfiguration {
 
     /** Default value for {@link #REPORT_FILE}: {@code target/scalpel-report.json}. */
     private static final String DEFAULT_REPORT_FILE = "target/scalpel-report.json";
+
+    /**
+     * Default value for {@link #EXCLUDE_CHANGES}: volatile timestamp properties that change on
+     * every build and do not affect compilation output.
+     */
+    private static final String DEFAULT_EXCLUDE_CHANGES =
+            "properties/build.timestamp,properties/project.build.outputTimestamp";
 
     /** Default value for {@link #MAX_RESOURCE_FILE_SIZE}: ten mebibytes ({@code 10 * 1024 * 1024}). */
     public static final long DEFAULT_MAX_RESOURCE_FILE_SIZE = 10L * 1024 * 1024; // 10 MB
@@ -236,7 +281,9 @@ public final class ScalpelConfiguration {
             BUILD_ALL_IF_NO_CHANGES,
             IMPACTED_LOG,
             REPORT_FILE,
-            MAX_RESOURCE_FILE_SIZE)));
+            MAX_RESOURCE_FILE_SIZE,
+            EXCLUDE_CHANGES,
+            INCLUDE_CHANGES)));
 
     private final boolean enabled;
     private final String baseBranch;
@@ -265,6 +312,8 @@ public final class ScalpelConfiguration {
     private final boolean explain;
     private final String reportFile;
     private final long maxResourceFileSize;
+    private final List<String> excludeChanges;
+    private final List<String> includeChanges;
     private final List<String> warnings;
 
     private ScalpelConfiguration(
@@ -295,6 +344,8 @@ public final class ScalpelConfiguration {
             boolean explain,
             String reportFile,
             long maxResourceFileSize,
+            List<String> excludeChanges,
+            List<String> includeChanges,
             List<String> warnings) {
         this.enabled = enabled;
         this.baseBranch = baseBranch;
@@ -323,6 +374,8 @@ public final class ScalpelConfiguration {
         this.explain = explain;
         this.reportFile = reportFile;
         this.maxResourceFileSize = maxResourceFileSize;
+        this.excludeChanges = excludeChanges;
+        this.includeChanges = includeChanges;
         this.warnings = warnings;
     }
 
@@ -398,6 +451,9 @@ public final class ScalpelConfiguration {
             }
         }
 
+        List<String> excludeChanges = parseList(resolve(system, user, EXCLUDE_CHANGES, DEFAULT_EXCLUDE_CHANGES));
+        List<String> includeChanges = parseList(resolve(system, user, INCLUDE_CHANGES, null));
+
         List<String> warnings = detectUnknownKeys(system, user);
 
         return new ScalpelConfiguration(
@@ -428,6 +484,8 @@ public final class ScalpelConfiguration {
                 explain,
                 reportFile,
                 maxResourceFileSize,
+                excludeChanges,
+                includeChanges,
                 warnings);
     }
 
@@ -721,6 +779,26 @@ public final class ScalpelConfiguration {
     }
 
     /**
+     * Returns the glob patterns over change paths that are excluded from effective model comparison.
+     * Default: {@code properties/build.timestamp,properties/project.build.outputTimestamp}.
+     *
+     * @see #EXCLUDE_CHANGES
+     */
+    public List<String> getExcludeChanges() {
+        return excludeChanges;
+    }
+
+    /**
+     * Returns the glob patterns over change paths that force inclusion in effective model comparison.
+     * Default: none.
+     *
+     * @see #INCLUDE_CHANGES
+     */
+    public List<String> getIncludeChanges() {
+        return includeChanges;
+    }
+
+    /**
      * Returns configuration warnings collected during parsing (e.g. unknown {@code scalpel.*} keys
      * with a "did you mean" suggestion). Empty when the configuration is clean.
      */
@@ -758,6 +836,8 @@ public final class ScalpelConfiguration {
                 + ", failSafe=" + failSafe
                 + ", reportFile='" + reportFile + '\''
                 + ", maxResourceFileSize=" + maxResourceFileSize
+                + ", excludeChanges=" + excludeChanges
+                + ", includeChanges=" + includeChanges
                 + ", warnings=" + warnings
                 + '}';
     }

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -196,7 +196,6 @@ public final class ScalpelConfiguration {
      *   <li>{@code plugins/<groupId>:<artifactId>}</li>
      *   <li>{@code managedDependencies/<groupId>:<artifactId>}</li>
      *   <li>{@code managedPlugins/<groupId>:<artifactId>}</li>
-     *   <li>{@code resources/<path>} — filtered resource files referencing changed properties</li>
      * </ul>
      *
      * <p>Default: {@code properties/build.timestamp,properties/project.build.outputTimestamp}

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -643,4 +643,59 @@ class ScalpelConfigurationTest {
         ScalpelConfiguration config = ScalpelConfiguration.fromProperties(sys, new Properties());
         assertTrue(config.getWarnings().isEmpty(), "non-scalpel keys should be ignored");
     }
+
+    // ---------------------------------------------------------------
+    // Change filter configuration (excludeChanges / includeChanges)
+    // ---------------------------------------------------------------
+
+    @Test
+    void defaultExcludeChanges_containsVolatileTimestamps() {
+        ScalpelConfiguration config = defaultConfig();
+        List<String> excludes = config.getExcludeChanges();
+        assertTrue(
+                excludes.contains("properties/build.timestamp"),
+                "default excludeChanges should contain build.timestamp");
+        assertTrue(
+                excludes.contains("properties/project.build.outputTimestamp"),
+                "default excludeChanges should contain project.build.outputTimestamp");
+    }
+
+    @Test
+    void defaultIncludeChanges_isEmpty() {
+        ScalpelConfiguration config = defaultConfig();
+        assertTrue(config.getIncludeChanges().isEmpty(), "default includeChanges should be empty");
+    }
+
+    @Test
+    void excludeChanges_customValue() {
+        Properties user = new Properties();
+        user.setProperty("scalpel.excludeChanges", "properties/git.*,managedDependencies/**");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(new Properties(), user);
+        assertEquals(List.of("properties/git.*", "managedDependencies/**"), config.getExcludeChanges());
+    }
+
+    @Test
+    void includeChanges_customValue() {
+        Properties user = new Properties();
+        user.setProperty("scalpel.includeChanges", "properties/maven.compiler.*");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(new Properties(), user);
+        assertEquals(List.of("properties/maven.compiler.*"), config.getIncludeChanges());
+    }
+
+    @Test
+    void excludeChanges_emptyString_clearsDefaults() {
+        Properties user = new Properties();
+        user.setProperty("scalpel.excludeChanges", "");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(new Properties(), user);
+        assertTrue(config.getExcludeChanges().isEmpty(), "empty excludeChanges should clear defaults");
+    }
+
+    @Test
+    void excludeChanges_noWarningForKnownKey() {
+        Properties user = new Properties();
+        user.setProperty("scalpel.excludeChanges", "properties/foo");
+        user.setProperty("scalpel.includeChanges", "properties/bar");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(new Properties(), user);
+        assertTrue(config.getWarnings().isEmpty(), "excludeChanges and includeChanges are known keys");
+    }
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -39,6 +39,8 @@ Properties defined in a project POM are deliberately not read. Scalpel is config
 | `scalpel.failSafe` | `true` | On error, fall back to a full build instead of failing |
 | `scalpel.maxResourceFileSize` | `10 MB` | Maximum size in bytes for a resource file (resources larger than this are skipped with a warning) |
 | `scalpel.explain` | `false` | Enable explain mode. This adds per-module decision evidence to the report |
+| `scalpel.excludeChanges` | `properties/build.timestamp,properties/project.build.outputTimestamp` | Comma-separated glob patterns over change paths. Matching changes are excluded from effective model comparison |
+| `scalpel.includeChanges` | none | Comma-separated glob patterns over change paths. Overrides exclude patterns — a change matching both is included |
 
 ## Local Developer Usage
 
@@ -231,3 +233,60 @@ mvn verify -Dscalpel.upstreamArgs=skipITs=true -Dscalpel.downstreamArgs=skipITs=
 ```
 
 In `report` mode, each affected module in the JSON report includes a `category` field (`DIRECT`, `UPSTREAM`, or `DOWNSTREAM`).
+
+## Change Filtering
+
+Scalpel lets you exclude or force-include specific types of POM changes from the effective model comparison using glob patterns over a normalized "change path" scheme.
+
+### Change Path Scheme
+
+| Category | Path format | Example |
+|----------|------------|---------|
+| Property | `properties/<name>` | `properties/lib.version` |
+| Dependency | `dependencies/<groupId>:<artifactId>` | `dependencies/com.foo:bar` |
+| Plugin | `plugins/<groupId>:<artifactId>` | `plugins/org.apache.maven.plugins:maven-compiler-plugin` |
+| Managed dependency | `managedDependencies/<groupId>:<artifactId>` | `managedDependencies/com.foo:bar` |
+| Managed plugin | `managedPlugins/<groupId>:<artifactId>` | `managedPlugins/org.apache.maven.plugins:maven-surefire-plugin` |
+
+### Excluding Volatile Properties
+
+Some properties change on every build (timestamps, git commit IDs) and do not affect compilation. By default, Scalpel excludes `build.timestamp` and `project.build.outputTimestamp`. To exclude additional volatile properties:
+
+```bash
+-Dscalpel.excludeChanges=properties/build.timestamp,properties/project.build.outputTimestamp,properties/git.*
+```
+
+### Excluding CI Flags
+
+Properties like `ci.deploy.skip` or `gpg.skip` are irrelevant to build output:
+
+```bash
+-Dscalpel.excludeChanges=properties/build.timestamp,properties/project.build.outputTimestamp,properties/ci.*,properties/gpg.skip
+```
+
+### Trusting the Parent BOM
+
+To exclude all managed dependency changes (trusting the parent BOM blindly):
+
+```bash
+-Dscalpel.excludeChanges=managedDependencies/**
+```
+
+### Force-Including Inherited Properties
+
+Properties that affect the build through indirect mechanisms (e.g. profile-activated plugin configuration) but are not in the child's raw model can be force-included:
+
+```bash
+-Dscalpel.includeChanges=properties/maven.compiler.*
+```
+
+Include patterns override exclude patterns: a change matching both is included.
+
+### Smart Defaults
+
+Scalpel is already smart by default about several POM sections:
+
+- **`<modules>`** — adding or removing a module in the parent does NOT trigger rebuilds of existing children
+- **`<scm>`, `<developers>`, `<licenses>`** — metadata sections do not affect compilation and are not compared
+- **`<distributionManagement>`** — does not affect compilation output and is not compared
+- **Properties** — only properties the child defines or uses in filtered resources are checked; inherited-but-unused properties are ignored

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -15,10 +15,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttribute;
@@ -302,6 +305,7 @@ class PomChangeAnalyzer {
         List<MavenProject> allProjects;
         Path reactorRoot;
         boolean explain;
+        ChangeFilter changeFilter;
 
         // Accumulators — populated during analysis
         final Set<MavenProject> affected = new LinkedHashSet<>();
@@ -310,6 +314,64 @@ class PomChangeAnalyzer {
         final List<String> unmatchedPomPaths = new ArrayList<>();
         /** Filesystem entries visited by filtered-resource scans (instrumentation, #99). */
         long resourcesVisited;
+    }
+
+    /**
+     * Filters change paths against user-configured include/exclude glob patterns.
+     * A change path is a normalized string like {@code properties/foo.version} or
+     * {@code dependencies/com.foo:bar}.
+     *
+     * <p>Evaluation order: a change path that matches any exclude pattern is excluded,
+     * UNLESS it also matches an include pattern (include overrides exclude).
+     *
+     * <p>When both lists are empty, all changes are accepted (the filter is a no-op).
+     */
+    static class ChangeFilter {
+        private static final String GLOB_PREFIX = "glob:";
+
+        private final List<PathMatcher> excludeMatchers;
+        private final List<PathMatcher> includeMatchers;
+
+        ChangeFilter(List<String> excludePatterns, List<String> includePatterns) {
+            FileSystem fs = FileSystems.getDefault();
+            this.excludeMatchers = compileMatchers(excludePatterns, fs);
+            this.includeMatchers = compileMatchers(includePatterns, fs);
+        }
+
+        /** Returns {@code true} if the change path should be considered (not excluded). */
+        boolean accepts(String changePath) {
+            if (excludeMatchers.isEmpty() && includeMatchers.isEmpty()) {
+                return true;
+            }
+            Path path = Path.of(changePath);
+            // Include overrides exclude
+            for (PathMatcher m : includeMatchers) {
+                if (m.matches(path)) {
+                    return true;
+                }
+            }
+            for (PathMatcher m : excludeMatchers) {
+                if (m.matches(path)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        boolean isActive() {
+            return !excludeMatchers.isEmpty() || !includeMatchers.isEmpty();
+        }
+
+        private static List<PathMatcher> compileMatchers(List<String> patterns, FileSystem fs) {
+            if (patterns == null || patterns.isEmpty()) {
+                return List.of();
+            }
+            List<PathMatcher> matchers = new ArrayList<>(patterns.size());
+            for (String pattern : patterns) {
+                matchers.add(fs.getPathMatcher(GLOB_PREFIX + pattern));
+            }
+            return matchers;
+        }
     }
 
     /**
@@ -340,6 +402,34 @@ class PomChangeAnalyzer {
             Path reactorRoot,
             boolean explain,
             ModelResolutionContext resolutionCtx) {
+        return analyzeChanges(
+                changedPomPaths,
+                oldPomContents,
+                allProjects,
+                reactorRoot,
+                explain,
+                resolutionCtx,
+                List.of(),
+                List.of());
+    }
+
+    /**
+     * Analyze POM changes with user-configured include/exclude change filters.
+     * <p>
+     * Change paths matching {@code excludeChangePatterns} are ignored unless they also
+     * match an {@code includeChangePatterns} pattern (include overrides exclude).
+     *
+     * @see #analyzeChanges(Set, Map, List, Path, boolean, ModelResolutionContext)
+     */
+    public Result analyzeChanges(
+            Set<String> changedPomPaths,
+            Map<String, byte[]> oldPomContents,
+            List<MavenProject> allProjects,
+            Path reactorRoot,
+            boolean explain,
+            ModelResolutionContext resolutionCtx,
+            List<String> excludeChangePatterns,
+            List<String> includeChangePatterns) {
 
         // Build a map of relative POM path -> MavenProject
         Map<String, MavenProject> projectByPomPath = new LinkedHashMap<>();
@@ -374,6 +464,7 @@ class PomChangeAnalyzer {
         ctx.allProjects = allProjects;
         ctx.reactorRoot = reactorRoot;
         ctx.explain = explain;
+        ctx.changeFilter = new ChangeFilter(excludeChangePatterns, includeChangePatterns);
 
         for (String changedPomPath : changedPomPaths) {
             analyzeChangedPom(changedPomPath, ctx);
@@ -569,8 +660,12 @@ class PomChangeAnalyzer {
         Set<String> activeProfileIds = getActiveProfileIds(parentProject);
         parentSelfAffected = parentSelfAffected || analyzeProfileChanges(oldModel, newModel, activeProfileIds);
 
-        // Collect all changed properties
-        ctx.allChangedProperties.addAll(changedProperties);
+        // Collect all changed properties (filtered by change filter)
+        for (String prop : changedProperties) {
+            if (ctx.changeFilter.accepts("properties/" + prop)) {
+                ctx.allChangedProperties.add(prop);
+            }
+        }
 
         if (parentSelfAffected) {
             ctx.affected.add(parentProject);
@@ -664,6 +759,10 @@ class PomChangeAnalyzer {
      * Both old and new effective models are built by the same {@link ModelBuilder}
      * so lifecycle default plugin versions are identical on both sides, making direct
      * comparison safe without GA filtering.
+     * <p>
+     * When a {@link ChangeFilter} is active, each detected change is translated to a
+     * normalized change path (e.g. {@code properties/foo.version}, {@code dependencies/g:a})
+     * and filtered before deciding whether the child is affected (issue #148).
      */
     private boolean hasEffectiveChanges(MavenProject child, Path absReactorRoot, AnalysisContext ctx) {
         Path childPomPath = child.getFile().toPath().toAbsolutePath().normalize();
@@ -684,6 +783,7 @@ class PomChangeAnalyzer {
         }
 
         boolean changed = false;
+        ChangeFilter filter = ctx.changeFilter;
 
         // Compare effective dependencies — dependencyManagement versions are injected
         // into <dependencies> during model building, so this catches managed dep version
@@ -691,15 +791,26 @@ class PomChangeAnalyzer {
         Set<String> changedDeps =
                 diffEffectiveDependencies(oldChildEffective.getDependencies(), newChildEffective.getDependencies());
         if (!changedDeps.isEmpty()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Child {} has changed effective dependencies: {}", key(child), changedDeps);
-            }
-            if (ctx.explain) {
-                for (String ga : changedDeps) {
-                    addEvidence(ctx.evidence, child, "effective dep " + ga);
+            // Apply change filter: generate change paths for each changed dep
+            Set<String> acceptedDeps = new LinkedHashSet<>();
+            for (String ga : changedDeps) {
+                if (filter.accepts("dependencies/" + ga)) {
+                    acceptedDeps.add(ga);
+                } else if (logger.isDebugEnabled()) {
+                    logger.debug("Child {} effective dep {} excluded by change filter", key(child), ga);
                 }
             }
-            changed = true;
+            if (!acceptedDeps.isEmpty()) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Child {} has changed effective dependencies: {}", key(child), acceptedDeps);
+                }
+                if (ctx.explain) {
+                    for (String ga : acceptedDeps) {
+                        addEvidence(ctx.evidence, child, "effective dep " + ga);
+                    }
+                }
+                changed = true;
+            }
         }
 
         // Compare effective plugin VERSIONS only (not configuration/executions).
@@ -710,15 +821,25 @@ class PomChangeAnalyzer {
         Set<String> changedPlugins = diffManagedPluginVersions(
                 getEffectivePlugins(oldChildEffective), getEffectivePlugins(newChildEffective));
         if (!changedPlugins.isEmpty()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Child {} has changed effective plugins: {}", key(child), changedPlugins);
-            }
-            if (ctx.explain) {
-                for (String ga : changedPlugins) {
-                    addEvidence(ctx.evidence, child, "effective plugin " + ga);
+            Set<String> acceptedPlugins = new LinkedHashSet<>();
+            for (String ga : changedPlugins) {
+                if (filter.accepts("plugins/" + ga)) {
+                    acceptedPlugins.add(ga);
+                } else if (logger.isDebugEnabled()) {
+                    logger.debug("Child {} effective plugin {} excluded by change filter", key(child), ga);
                 }
             }
-            changed = true;
+            if (!acceptedPlugins.isEmpty()) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Child {} has changed effective plugins: {}", key(child), acceptedPlugins);
+                }
+                if (ctx.explain) {
+                    for (String ga : acceptedPlugins) {
+                        addEvidence(ctx.evidence, child, "effective plugin " + ga);
+                    }
+                }
+                changed = true;
+            }
         }
 
         // Compare effective values of properties explicitly defined in the child's
@@ -736,6 +857,15 @@ class PomChangeAnalyzer {
                 String oldValue = oldEffectiveProps != null ? oldEffectiveProps.getProperty(propName) : null;
                 String newValue = newEffectiveProps != null ? newEffectiveProps.getProperty(propName) : null;
                 if (!Objects.equals(oldValue, newValue)) {
+                    if (!filter.accepts("properties/" + propName)) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Child {} property {} effective value changed but excluded by change filter",
+                                    key(child),
+                                    propName);
+                        }
+                        continue;
+                    }
                     if (logger.isDebugEnabled()) {
                         logger.debug(
                                 "Child {} property {} effective value changed: {} -> {}",
@@ -773,18 +903,28 @@ class PomChangeAnalyzer {
                         filterByGA(getManagedDependencies(oldChildEffective), rawManagedGAs),
                         filterByGA(getManagedDependencies(newChildEffective), rawManagedGAs));
                 if (!changedRawManagedDeps.isEmpty()) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
-                                "Child {} has changed effective managed deps (defined in raw model): {}",
-                                key(child),
-                                changedRawManagedDeps);
-                    }
-                    if (ctx.explain) {
-                        for (String ga : changedRawManagedDeps) {
-                            addEvidence(ctx.evidence, child, "effective managed dep " + ga);
+                    Set<String> acceptedManagedDeps = new LinkedHashSet<>();
+                    for (String ga : changedRawManagedDeps) {
+                        if (filter.accepts("managedDependencies/" + ga)) {
+                            acceptedManagedDeps.add(ga);
+                        } else if (logger.isDebugEnabled()) {
+                            logger.debug("Child {} effective managed dep {} excluded by change filter", key(child), ga);
                         }
                     }
-                    changed = true;
+                    if (!acceptedManagedDeps.isEmpty()) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Child {} has changed effective managed deps (defined in raw model): {}",
+                                    key(child),
+                                    acceptedManagedDeps);
+                        }
+                        if (ctx.explain) {
+                            for (String ga : acceptedManagedDeps) {
+                                addEvidence(ctx.evidence, child, "effective managed dep " + ga);
+                            }
+                        }
+                        changed = true;
+                    }
                 }
             }
         }
@@ -802,18 +942,29 @@ class PomChangeAnalyzer {
                         filterPluginsByGA(getManagedPlugins(oldChildEffective), rawPluginGAs),
                         filterPluginsByGA(getManagedPlugins(newChildEffective), rawPluginGAs));
                 if (!changedRawManagedPlugins.isEmpty()) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
-                                "Child {} has changed effective managed plugins (defined in raw model): {}",
-                                key(child),
-                                changedRawManagedPlugins);
-                    }
-                    if (ctx.explain) {
-                        for (String ga : changedRawManagedPlugins) {
-                            addEvidence(ctx.evidence, child, "effective managed plugin " + ga);
+                    Set<String> acceptedManagedPlugins = new LinkedHashSet<>();
+                    for (String ga : changedRawManagedPlugins) {
+                        if (filter.accepts("managedPlugins/" + ga)) {
+                            acceptedManagedPlugins.add(ga);
+                        } else if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Child {} effective managed plugin {} excluded by change filter", key(child), ga);
                         }
                     }
-                    changed = true;
+                    if (!acceptedManagedPlugins.isEmpty()) {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug(
+                                    "Child {} has changed effective managed plugins (defined in raw model): {}",
+                                    key(child),
+                                    acceptedManagedPlugins);
+                        }
+                        if (ctx.explain) {
+                            for (String ga : acceptedManagedPlugins) {
+                                addEvidence(ctx.evidence, child, "effective managed plugin " + ga);
+                            }
+                        }
+                        changed = true;
+                    }
                 }
             }
         }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -661,9 +661,11 @@ class PomChangeAnalyzer {
         parentSelfAffected = parentSelfAffected || analyzeProfileChanges(oldModel, newModel, activeProfileIds);
 
         // Collect all changed properties (filtered by change filter)
+        Set<String> filteredChangedProperties = new LinkedHashSet<>();
         for (String prop : changedProperties) {
             if (ctx.changeFilter.accepts("properties/" + prop)) {
                 ctx.allChangedProperties.add(prop);
+                filteredChangedProperties.add(prop);
             }
         }
 
@@ -714,8 +716,8 @@ class PomChangeAnalyzer {
             // Properties used in filtered resources are often inherited (defined in the
             // parent, not the child), so the raw-model property check above won't catch them.
             if (!childAffected
-                    && !changedProperties.isEmpty()
-                    && hasFilteredResourcesWithChangedProperty(child, changedProperties, ctx)) {
+                    && !filteredChangedProperties.isEmpty()
+                    && hasFilteredResourcesWithChangedProperty(child, filteredChangedProperties, ctx)) {
                 logger.debug("Child {} has filtered resources referencing changed properties", key(child));
                 if (ctx.explain) {
                     addEvidence(ctx.evidence, child, "filtered resources referencing changed properties");

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -252,7 +252,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                         session.getSystemProperties(),
                                         session.getUserProperties(),
                                         session.getRepositorySession(),
-                                        allProjects.get(0).getRemoteProjectRepositories()));
+                                        allProjects.get(0).getRemoteProjectRepositories()),
+                                config.getExcludeChanges(),
+                                config.getIncludeChanges());
                     } finally {
                         timings.stop(Timings.PHASE_POM_ANALYSIS);
                     }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -125,6 +125,25 @@ class PomChangeAnalyzerTest {
                 changedPomPaths, oldPomContents, allProjects, reactorRoot, true, defaultResolutionCtx);
     }
 
+    /** Convenience wrapper with change filter patterns. */
+    private PomChangeAnalyzer.Result analyzeChanges(
+            Set<String> changedPomPaths,
+            Map<String, byte[]> oldPomContents,
+            List<MavenProject> allProjects,
+            Path reactorRoot,
+            List<String> excludeChangePatterns,
+            List<String> includeChangePatterns) {
+        return analyzer.analyzeChanges(
+                changedPomPaths,
+                oldPomContents,
+                allProjects,
+                reactorRoot,
+                true,
+                defaultResolutionCtx,
+                excludeChangePatterns,
+                includeChangePatterns);
+    }
+
     /**
      * Derive changed managed dependency GAs from result's effective models.
      * Mirrors ScalpelLifecycleParticipant.deriveChangedManagedDeps for test assertions.
@@ -2701,6 +2720,335 @@ class PomChangeAnalyzerTest {
         projects.add(moduleA);
         projects.add(moduleB);
         return projects;
+    }
+
+    // --- Change filter (include/exclude) tests (#148) ---
+
+    @Test
+    void changeFilter_acceptsAll_whenEmpty() {
+        PomChangeAnalyzer.ChangeFilter filter = new PomChangeAnalyzer.ChangeFilter(List.of(), List.of());
+        assertTrue(filter.accepts("properties/foo.version"));
+        assertTrue(filter.accepts("dependencies/com.foo:bar"));
+        assertFalse(filter.isActive());
+    }
+
+    @Test
+    void changeFilter_excludesMatchingPattern() {
+        PomChangeAnalyzer.ChangeFilter filter =
+                new PomChangeAnalyzer.ChangeFilter(List.of("properties/build.*"), List.of());
+        assertFalse(filter.accepts("properties/build.timestamp"));
+        assertFalse(filter.accepts("properties/build.number"));
+        assertTrue(filter.accepts("properties/dep.version"));
+        assertTrue(filter.isActive());
+    }
+
+    @Test
+    void changeFilter_excludeGlobStar() {
+        PomChangeAnalyzer.ChangeFilter filter =
+                new PomChangeAnalyzer.ChangeFilter(List.of("managedDependencies/**"), List.of());
+        assertFalse(filter.accepts("managedDependencies/com.foo:bar"));
+        assertTrue(filter.accepts("dependencies/com.foo:bar"));
+    }
+
+    @Test
+    void changeFilter_includeOverridesExclude() {
+        PomChangeAnalyzer.ChangeFilter filter =
+                new PomChangeAnalyzer.ChangeFilter(List.of("properties/*"), List.of("properties/maven.compiler.*"));
+        assertFalse(filter.accepts("properties/foo.version"));
+        assertTrue(filter.accepts("properties/maven.compiler.source"));
+        assertTrue(filter.accepts("properties/maven.compiler.target"));
+    }
+
+    @Test
+    void changeFilter_multipleExcludePatterns() {
+        PomChangeAnalyzer.ChangeFilter filter = new PomChangeAnalyzer.ChangeFilter(
+                List.of("properties/build.timestamp", "properties/project.build.outputTimestamp", "properties/git.*"),
+                List.of());
+        assertFalse(filter.accepts("properties/build.timestamp"));
+        assertFalse(filter.accepts("properties/project.build.outputTimestamp"));
+        assertFalse(filter.accepts("properties/git.commit.id"));
+        assertTrue(filter.accepts("properties/dep.version"));
+    }
+
+    @Test
+    void analyzeChanges_excludeVolatileProperty() throws Exception {
+        // Parent has dep.version property that changes. Child's my.ref depends on it.
+        // With excludeChanges for properties/my.*, child should NOT be affected.
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root, "dep.version");
+
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <dep.version>1.0</dep.version>
+                  </properties>
+                </project>
+                """;
+
+        Set<String> changedPoms = Set.of("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        // Without filter: module-b is affected (my.dep.version.ref changes)
+        Set<MavenProject> affectedNoFilter =
+                analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+        MavenProject moduleB = projects.get(2);
+        assertTrue(affectedNoFilter.contains(moduleB), "Without filter, module-b should be affected");
+
+        // With excludeChanges for the child's property: module-b should NOT be affected
+        Set<MavenProject> affectedWithFilter = analyzeChanges(
+                        changedPoms, oldPoms, projects, root, List.of("properties/my.dep.version.ref"), List.of())
+                .getAffectedProjects();
+        assertFalse(
+                affectedWithFilter.contains(moduleB),
+                "With excludeChanges for properties/my.dep.version.ref, module-b should NOT be affected");
+    }
+
+    @Test
+    void analyzeChanges_excludeGitProperties() throws Exception {
+        // Parent has git.version property that changes. Child has my.git.version.ref that depends on it.
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root, "git.version");
+
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <git.version>abc123</git.version>
+                  </properties>
+                </project>
+                """;
+
+        Set<String> changedPoms = Set.of("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        Set<MavenProject> affected = analyzeChanges(
+                        changedPoms, oldPoms, projects, root, List.of("properties/my.git.version.ref"), List.of())
+                .getAffectedProjects();
+        MavenProject moduleB = projects.get(2);
+        assertFalse(affected.contains(moduleB), "my.git.version.ref excluded by explicit pattern");
+    }
+
+    @Test
+    void analyzeChanges_includeOverridesExclude() throws Exception {
+        // Exclude all child properties matching my.*, but include my.app.source.ref specifically
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root, "app.source");
+
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <app.source>11</app.source>
+                  </properties>
+                </project>
+                """;
+
+        Set<String> changedPoms = Set.of("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        // Exclude all 'my.*' properties, but include 'my.app.source.*' — child should still be affected
+        Set<MavenProject> affected = analyzeChanges(
+                        changedPoms,
+                        oldPoms,
+                        projects,
+                        root,
+                        List.of("properties/my.*"),
+                        List.of("properties/my.app.source.*"))
+                .getAffectedProjects();
+        MavenProject moduleB = projects.get(2);
+        assertTrue(
+                affected.contains(moduleB),
+                "my.app.source.ref should override the exclude pattern and affect module-b");
+    }
+
+    @Test
+    void analyzeChanges_excludeManagedDependency() throws Exception {
+        // Exclude all managed dependency changes
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithDepMgmtUsage(root);
+
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <dependencyManagement><dependencies>
+                    <dependency>
+                      <groupId>com.example</groupId>
+                      <artifactId>lib-x</artifactId>
+                      <version>1.0</version>
+                    </dependency>
+                  </dependencies></dependencyManagement>
+                </project>
+                """;
+
+        Set<String> changedPoms = Set.of("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        // Without filter: module-b is affected
+        Set<MavenProject> affectedNoFilter =
+                analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+        MavenProject moduleB = projects.get(2);
+        assertTrue(affectedNoFilter.contains(moduleB), "Without filter, module-b uses lib-x and should be affected");
+
+        // With excludeChanges for dependencies/com.example:lib-x
+        Set<MavenProject> affected = analyzeChanges(
+                        changedPoms, oldPoms, projects, root, List.of("dependencies/com.example:lib-x"), List.of())
+                .getAffectedProjects();
+        assertFalse(
+                affected.contains(moduleB),
+                "With dependencies/com.example:lib-x excluded, module-b should NOT be affected");
+    }
+
+    @Test
+    void analyzeChanges_excludePropertyAlsoExcludesFromFilteredResources() throws Exception {
+        // When a property is excluded by change filter, it should also be excluded
+        // from the filtered resource check
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createReactorWithPropertyUsage(root, "build.timestamp");
+
+        // Create a filtered resource that uses the property
+        Path resourceDir = root.resolve("module-b/src/main/resources");
+        Files.createDirectories(resourceDir);
+        Files.writeString(resourceDir.resolve("version.properties"), "built.at=${build.timestamp}");
+
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <build.timestamp>2024-01-01T00:00:00Z</build.timestamp>
+                  </properties>
+                </project>
+                """;
+
+        Set<String> changedPoms = Set.of("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        // The property is excluded: even though filtered resources reference it,
+        // the property should not be in changedProperties
+        PomChangeAnalyzer.Result result =
+                analyzeChanges(changedPoms, oldPoms, projects, root, List.of("properties/build.timestamp"), List.of());
+        assertFalse(
+                result.getChangedProperties().contains("build.timestamp"),
+                "Excluded property should not appear in changedProperties");
+    }
+
+    @Test
+    void analyzeChanges_modulesChangeDoesNotAffectChildren() throws Exception {
+        // Adding a new module to the parent should NOT affect existing children
+        Path root = setupReactorRoot();
+        List<MavenProject> projects = createSimpleReactor(root);
+
+        // Old POM had only module-a
+        String oldParentPom = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module></modules>
+                </project>
+                """;
+
+        Set<String> changedPoms = Set.of("pom.xml");
+        Map<String, byte[]> oldPoms = new HashMap<>();
+        oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
+
+        Set<MavenProject> affected =
+                analyzeChanges(changedPoms, oldPoms, projects, root).getAffectedProjects();
+
+        MavenProject moduleA = projects.get(1);
+        MavenProject moduleB = projects.get(2);
+        assertFalse(affected.contains(moduleA), "Adding a new module should NOT affect existing module-a");
+        assertFalse(affected.contains(moduleB), "Adding a new module should NOT affect existing module-b");
+    }
+
+    /**
+     * Create a reactor where module-b defines a property that the parent also defines.
+     * The parent's new value differs from the old value, causing the child's effective
+     * property value to change. Module-b redeclares the property so the effective model
+     * comparison finds the change under the exact property name.
+     */
+    private List<MavenProject> createReactorWithPropertyUsage(Path root, String propertyName) throws IOException {
+        // Current (new) parent has the property with a new value
+        String parentPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                  <modules><module>module-a</module><module>module-b</module></modules>
+                  <properties>
+                    <%s>new-value</%s>
+                  </properties>
+                </project>
+                """.formatted(propertyName, propertyName);
+        writePom(root.resolve("pom.xml"), parentPomXml);
+
+        String moduleAPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
+        writePom(root.resolve("module-a/pom.xml"), moduleAPomXml);
+
+        // module-b uses the property in a dependency version; the property is also
+        // declared in the child's properties so hasEffectiveChanges can detect it
+        String moduleBPomXml = """
+                <?xml version="1.0"?>
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>com.example</groupId><artifactId>parent</artifactId><version>1.0</version></parent>
+                  <artifactId>module-b</artifactId>
+                  <properties>
+                    <my.%s.ref>${%s}</my.%s.ref>
+                  </properties>
+                </project>
+                """.formatted(propertyName, propertyName, propertyName);
+        writePom(root.resolve("module-b/pom.xml"), moduleBPomXml);
+
+        return buildProjectList(root, parentPomXml, moduleAPomXml, moduleBPomXml);
     }
 
     private Path setupReactorRoot() throws IOException {

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -2939,6 +2939,15 @@ class PomChangeAnalyzerTest {
         Files.createDirectories(resourceDir);
         Files.writeString(resourceDir.resolve("version.properties"), "built.at=${build.timestamp}");
 
+        // Set up module-b with filtering enabled so hasFilteredResourcesWithChangedProperty scans it
+        MavenProject moduleB = projects.get(2);
+        Resource resource = new Resource();
+        resource.setDirectory(resourceDir.toString());
+        resource.setFiltering(true);
+        Build build = new Build();
+        build.addResource(resource);
+        moduleB.getModel().setBuild(build);
+
         String oldParentPom = """
                 <?xml version="1.0"?>
                 <project>
@@ -2959,12 +2968,15 @@ class PomChangeAnalyzerTest {
         oldPoms.put("pom.xml", oldParentPom.getBytes(StandardCharsets.UTF_8));
 
         // The property is excluded: even though filtered resources reference it,
-        // the property should not be in changedProperties
+        // the property should not be in changedProperties and the module should not be affected
         PomChangeAnalyzer.Result result =
                 analyzeChanges(changedPoms, oldPoms, projects, root, List.of("properties/build.timestamp"), List.of());
         assertFalse(
                 result.getChangedProperties().contains("build.timestamp"),
                 "Excluded property should not appear in changedProperties");
+        assertFalse(
+                result.getAffectedProjects().contains(moduleB),
+                "Excluded property must not trigger filtered-resource scan");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #148: Allow users to include/exclude specific properties from effective model comparison.

## Changes

Adds two new configuration properties:

- **`scalpel.excludeChanges`** — comma-separated glob patterns over change paths to exclude from comparison
- **`scalpel.includeChanges`** — comma-separated glob patterns that override exclusions (escape hatch)

### Change Path Scheme

| Category | Path format | Example |
|----------|------------|---------|
| Property | `properties/<name>` | `properties/build.timestamp` |
| Dependency | `dependencies/<GA>` | `dependencies/com.foo:bar` |
| Plugin | `plugins/<GA>` | `plugins/o.a.m.p:maven-compiler-plugin` |
| Managed dependency | `managedDependencies/<GA>` | `managedDependencies/com.foo:bar` |
| Managed plugin | `managedPlugins/<GA>` | `managedPlugins/o.a.m.p:maven-surefire-plugin` |

### Smart Defaults

- **Default excludes:** `properties/build.timestamp,properties/project.build.outputTimestamp` (volatile properties that change on every build)
- **`<modules>` changes** already don't trigger child rebuilds (documented)
- **Metadata sections** (scm, developers, licenses) already not compared

### Usage Examples

```bash
# Exclude git properties and CI flags
-Dscalpel.excludeChanges=properties/build.timestamp,properties/project.build.outputTimestamp,properties/git.*

# Trust parent BOM blindly
-Dscalpel.excludeChanges=managedDependencies/**

# Force-check compiler settings even when all properties are excluded
-Dscalpel.includeChanges=properties/maven.compiler.*
```

## Implementation

- `ChangeFilter` inner class in `PomChangeAnalyzer` — compiles glob patterns into `PathMatcher` instances
- Filter applied in `hasEffectiveChanges()` to each detected change path before marking a child as affected
- Filter applied to `changedProperties` at the parent level (feeds filtered resource checks)
- Reuses existing `parseList()` comma-separated pattern for configuration

## Tests

- 5 `ChangeFilter` unit tests (empty, exclude, glob, include-override, multiple patterns)
- 5 integration tests (property exclusion, git properties, include override, dependency exclusion, filtered resources, modules changes)
- 7 `ScalpelConfiguration` tests (defaults, custom values, empty override, known keys)

_AI agent (Hermes on behalf of gnodet)_