### PR TITLE
Fix #124: centralise path filtering into a single PathFilters type

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifier.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifier.java
@@ -7,25 +7,18 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
-import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
-import java.nio.file.FileSystems;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import org.apache.maven.project.MavenProject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Classifies changed files into POM changes vs source changes, applies exclusion/inclusion
- * filters, and detects disable/full-build triggers.
+ * Classifies changed files into POM changes vs source changes, and provides
+ * shared utility methods for glob-pattern normalisation and relative-path computation.
  */
 class ChangedFileClassifier {
-
-    private static final String GLOB_PREFIX = "glob:";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -59,97 +52,6 @@ class ChangedFileClassifier {
             }
         }
         return new ClassificationResult(pomChanges, sourceChanges);
-    }
-
-    /**
-     * Returns {@code true} if any changed file matches one of the configured disable triggers.
-     */
-    boolean matchesDisableTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
-        for (String pattern : config.getDisableTriggers()) {
-            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
-            for (String changedFile : changedFiles) {
-                if (matcher.matches(Path.of(changedFile))) {
-                    logger.info(
-                            "Scalpel: Disabled due to change in {} (matches disable trigger {})", changedFile, pattern);
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Removes files matching exclusion path patterns from the changed file set.
-     */
-    Set<String> filterExcludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
-        List<PathMatcher> excludeMatchers = compileGlobMatchers(config.getExcludePaths());
-        if (excludeMatchers.isEmpty()) {
-            return changedFiles;
-        }
-        Set<String> filtered = new LinkedHashSet<>();
-        for (String file : changedFiles) {
-            boolean excluded = false;
-            for (PathMatcher matcher : excludeMatchers) {
-                if (matcher.matches(Path.of(file))) {
-                    excluded = true;
-                    break;
-                }
-            }
-            if (!excluded) {
-                filtered.add(file);
-            }
-        }
-        int excludedCount = changedFiles.size() - filtered.size();
-        if (excludedCount > 0) {
-            logger.info("Scalpel: {} files excluded by path filters", excludedCount);
-        }
-        return filtered;
-    }
-
-    /**
-     * Returns the first changed file matching a full-build trigger pattern, or {@code null}
-     * if no trigger matches.
-     */
-    String findFullBuildTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
-        for (String pattern : config.getFullBuildTriggers()) {
-            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
-            for (String changedFile : changedFiles) {
-                if (matcher.matches(Path.of(changedFile))) {
-                    logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
-                    return changedFile;
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Returns {@code true} if the project's module path matches at least one of the
-     * given include-paths matchers.
-     */
-    static boolean matchesIncludePaths(MavenProject project, List<PathMatcher> matchers, Path normalizedRoot) {
-        String relPath = relativePath(normalizedRoot, project);
-        Path modulePath = Path.of(relPath);
-        for (PathMatcher matcher : matchers) {
-            if (matcher.matches(modulePath) || matcher.matches(modulePath.resolve("pom.xml"))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Compiles a list of glob patterns into PathMatcher instances.
-     */
-    static List<PathMatcher> compileGlobMatchers(List<String> patterns) {
-        if (patterns.isEmpty()) {
-            return List.of();
-        }
-        List<PathMatcher> matchers = new ArrayList<>(patterns.size());
-        for (String pattern : patterns) {
-            matchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern)));
-        }
-        return matchers;
     }
 
     /**

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PathFilters.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PathFilters.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Centralises all glob-based path filtering for Scalpel: exclude paths, include paths,
+ * disable triggers, and full-build triggers. All glob patterns are compiled once in the
+ * constructor and reused across every evaluation site, replacing the previous approach of
+ * recompiling matchers independently at each call site.
+ *
+ * <h3>Trim mode vs skip-tests mode</h3>
+ * <p>There is one <em>intentional</em> semantic difference between how include-path filtering
+ * is applied in <strong>trim mode</strong> and <strong>skip-tests mode</strong>:</p>
+ * <ul>
+ *   <li><strong>Trim mode</strong> ({@link #filterBuildSet}): upstream build prerequisites
+ *       survive the include filter even when their path falls outside {@code includePaths},
+ *       because removing them would break the build (missing compile-time dependencies).
+ *       Downstream modules outside the scope <em>are</em> dropped.</li>
+ *   <li><strong>Skip-tests mode</strong> ({@link #matchesIncludePaths}): every module outside
+ *       {@code includePaths} has its tests skipped, with <em>no</em> exception for upstream
+ *       prerequisites. The upstream module is still built (skip-tests mode never removes
+ *       modules from the reactor), but its tests are not run.</li>
+ * </ul>
+ */
+class PathFilters {
+
+    private static final String GLOB_PREFIX = "glob:";
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final List<PathMatcher> excludeMatchers;
+    private final List<PathMatcher> includeMatchers;
+    private final List<String> disableTriggerPatterns;
+    private final List<PathMatcher> disableTriggerMatchers;
+    private final List<String> fullBuildTriggerPatterns;
+    private final List<PathMatcher> fullBuildTriggerMatchers;
+
+    PathFilters(ScalpelConfiguration config) {
+        requireNonNull(config, "config");
+        this.excludeMatchers = compileGlobMatchers(config.getExcludePaths());
+        this.includeMatchers = compileGlobMatchers(config.getIncludePaths());
+        this.disableTriggerPatterns = List.copyOf(config.getDisableTriggers());
+        this.disableTriggerMatchers = compileGlobMatchers(config.getDisableTriggers());
+        this.fullBuildTriggerPatterns = List.copyOf(config.getFullBuildTriggers());
+        this.fullBuildTriggerMatchers = compileGlobMatchers(config.getFullBuildTriggers());
+    }
+
+    /**
+     * Filters out changed files matching any {@code excludePaths} glob pattern.
+     *
+     * @param changedFiles the original set of changed file paths (forward-slash separated)
+     * @return a new set with excluded files removed; the original set when no excludes are
+     *     configured
+     */
+    Set<String> filterExcludedPaths(Set<String> changedFiles) {
+        if (excludeMatchers.isEmpty()) {
+            return changedFiles;
+        }
+        Set<String> filtered = new LinkedHashSet<>();
+        for (String file : changedFiles) {
+            Path p = Path.of(file);
+            boolean excluded = false;
+            for (PathMatcher matcher : excludeMatchers) {
+                if (matcher.matches(p)) {
+                    excluded = true;
+                    break;
+                }
+            }
+            if (!excluded) {
+                filtered.add(file);
+            }
+        }
+        int excludedCount = changedFiles.size() - filtered.size();
+        if (excludedCount > 0) {
+            logger.info("Scalpel: {} files excluded by path filters", excludedCount);
+        }
+        return filtered;
+    }
+
+    /**
+     * Returns {@code true} if any changed file matches a {@code disableTriggers} glob pattern.
+     */
+    boolean matchesDisableTrigger(Set<String> changedFiles) {
+        if (disableTriggerMatchers.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < disableTriggerMatchers.size(); i++) {
+            PathMatcher matcher = disableTriggerMatchers.get(i);
+            String pattern = disableTriggerPatterns.get(i);
+            for (String changedFile : changedFiles) {
+                Path p = Path.of(changedFile);
+                if (matcher.matches(p)) {
+                    logger.info(
+                            "Scalpel: Disabled due to change in {} (matches disable trigger {})", changedFile, pattern);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the first changed file matching a {@code fullBuildTriggers} glob pattern, or
+     * {@code null} if none match.
+     */
+    String findFullBuildTrigger(Set<String> changedFiles) {
+        if (fullBuildTriggerMatchers.isEmpty()) {
+            return null;
+        }
+        for (int i = 0; i < fullBuildTriggerMatchers.size(); i++) {
+            PathMatcher matcher = fullBuildTriggerMatchers.get(i);
+            String pattern = fullBuildTriggerPatterns.get(i);
+            for (String changedFile : changedFiles) {
+                Path p = Path.of(changedFile);
+                if (matcher.matches(p)) {
+                    logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
+                    return changedFile;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns whether any {@code includePaths} patterns are configured.
+     */
+    boolean hasIncludeFilters() {
+        return !includeMatchers.isEmpty();
+    }
+
+    /**
+     * Returns whether the given project's module path matches any {@code includePaths} glob
+     * pattern. This is the <strong>strict</strong> check used in skip-tests mode: no exception
+     * is made for upstream prerequisites.
+     *
+     * @param project the Maven project to test
+     * @param reactorRoot the reactor root directory
+     * @return {@code true} if the module path matches at least one include pattern
+     */
+    boolean matchesIncludePaths(MavenProject project, Path reactorRoot) {
+        String relPath = relativePath(reactorRoot, project);
+        Path modulePath = Path.of(relPath);
+        for (PathMatcher matcher : includeMatchers) {
+            if (matcher.matches(modulePath) || matcher.matches(modulePath.resolve("pom.xml"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Filters a build set for <strong>trim mode</strong>: removes downstream modules outside
+     * {@code includePaths} scope while keeping directly/transitively affected modules and
+     * upstream build prerequisites. Upstream prerequisites survive even when their path falls
+     * outside the include scope, because removing them would break compilation.
+     *
+     * @param buildSet the full build set from {@code ReactorTrimmer}
+     * @param affected the set of directly and transitively affected modules
+     * @param upstreamOnly the set of modules classified as upstream-only by the trimmer
+     * @param reactorRoot the reactor root directory
+     * @return the filtered build set (a new mutable list); the original list when no include
+     *     filters are configured
+     */
+    List<MavenProject> filterBuildSet(
+            List<MavenProject> buildSet, Set<MavenProject> affected, Set<MavenProject> upstreamOnly, Path reactorRoot) {
+        if (includeMatchers.isEmpty()) {
+            return buildSet;
+        }
+        List<MavenProject> filtered = new ArrayList<>(buildSet);
+        filtered.removeIf(project -> !affected.contains(project)
+                && !upstreamOnly.contains(project)
+                && !matchesIncludePaths(project, reactorRoot));
+        return filtered;
+    }
+
+    // ---- internal helpers ----
+
+    private static List<PathMatcher> compileGlobMatchers(List<String> patterns) {
+        if (patterns.isEmpty()) {
+            return List.of();
+        }
+        List<PathMatcher> matchers = new ArrayList<>(patterns.size());
+        for (String pattern : patterns) {
+            matchers.add(FileSystems.getDefault()
+                    .getPathMatcher(GLOB_PREFIX + ChangedFileClassifier.normalizeGlobPattern(pattern)));
+        }
+        return matchers;
+    }
+
+    /**
+     * Computes the relative path from the reactor root to the project's base directory.
+     * The root must already be normalized via {@code Path.toAbsolutePath().normalize()} — this
+     * method does NOT re-normalize the root on every call (#113).
+     */
+    private static String relativePath(Path normalizedRoot, MavenProject project) {
+        return normalizedRoot
+                .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
+                .toString()
+                .replace('\\', '/');
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssembler.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssembler.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -43,6 +42,7 @@ class ReportAssembler {
             Path reactorRoot,
             List<MavenProject> allProjects,
             AnalysisContext ctx,
+            PathFilters pathFilters,
             Timings timings,
             long analysisStartNano)
             throws MavenExecutionException {
@@ -67,7 +67,7 @@ class ReportAssembler {
 
         addDirectlyAffectedModules(builder, ctx, reactorRoot);
         addTransitivelyAffectedModules(builder, ctx, config, reactorRoot);
-        int excludedUpstream = addTrimResultModules(builder, ctx, config, reactorRoot);
+        int excludedUpstream = addTrimResultModules(builder, ctx, pathFilters, config, reactorRoot);
         builder.excludedUpstreamCount(excludedUpstream);
         addSkippedModules(builder, allProjects, ctx, reactorRoot);
 
@@ -224,7 +224,11 @@ class ReportAssembler {
     }
 
     private int addTrimResultModules(
-            ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
+            ScalpelReport.Builder builder,
+            AnalysisContext ctx,
+            PathFilters pathFilters,
+            ScalpelConfiguration config,
+            Path reactorRoot) {
         if (ctx.trimResult == null) {
             return 0;
         }
@@ -247,6 +251,7 @@ class ReportAssembler {
         addDownstreamModules(
                 builder,
                 ctx,
+                pathFilters,
                 config,
                 reactorRoot,
                 ctx.trimResult.getDownstreamOnly(),
@@ -254,6 +259,7 @@ class ReportAssembler {
         addDownstreamModules(
                 builder,
                 ctx,
+                pathFilters,
                 config,
                 reactorRoot,
                 ctx.trimResult.getDownstreamTestOnly(),
@@ -264,16 +270,16 @@ class ReportAssembler {
     private void addDownstreamModules(
             ScalpelReport.Builder builder,
             AnalysisContext ctx,
+            PathFilters pathFilters,
             ScalpelConfiguration config,
             Path reactorRoot,
             Set<MavenProject> downstreamProjects,
             String reason) {
-        List<PathMatcher> includeMatchers = ChangedFileClassifier.compileGlobMatchers(config.getIncludePaths());
         for (MavenProject project : downstreamProjects) {
             if (ctx.directlyAffected.contains(project) || ctx.transitivelyAffected.containsKey(project)) {
                 continue;
             }
-            addSingleDownstreamModule(builder, ctx, config, reactorRoot, includeMatchers, project, reason);
+            addSingleDownstreamModule(builder, ctx, config, reactorRoot, pathFilters, project, reason);
         }
     }
 
@@ -282,12 +288,11 @@ class ReportAssembler {
             AnalysisContext ctx,
             ScalpelConfiguration config,
             Path reactorRoot,
-            List<PathMatcher> includeMatchers,
+            PathFilters pathFilters,
             MavenProject project,
             String reason) {
         // Skip downstream modules outside includePaths scope
-        if (!includeMatchers.isEmpty()
-                && !ChangedFileClassifier.matchesIncludePaths(project, includeMatchers, reactorRoot)) {
+        if (pathFilters.hasIncludeFilters() && !pathFilters.matchesIncludePaths(project, reactorRoot)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Excluding downstream module {} from report (outside includePaths)", key(project));
             }

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -19,7 +19,6 @@ import eu.maveniverse.maven.scalpel.core.ScalpelReport;
 import eu.maveniverse.maven.scalpel.core.Timings;
 import eu.maveniverse.maven.scalpel.core.Version;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -164,8 +163,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             logger.info("Scalpel: {} changed files detected", changedFiles.size());
 
+            PathFilters pathFilters = new PathFilters(config);
+
             // Check disable triggers
-            if (changedFileClassifier.matchesDisableTrigger(changedFiles, config)) {
+            if (pathFilters.matchesDisableTrigger(changedFiles)) {
                 if (passiveRun(config)) {
                     reportAssembler.writeStatusReport(
                             config, reactorRoot, "skipped", "disabled by disableTriggers match");
@@ -174,7 +175,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Filter out excluded paths
-            changedFiles = changedFileClassifier.filterExcludedPaths(changedFiles, config);
+            changedFiles = pathFilters.filterExcludedPaths(changedFiles);
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: All changed files excluded by path filters, building all modules");
                 if (passiveRun(config)) {
@@ -185,7 +186,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Check full build triggers
-            String triggerFile = changedFileClassifier.findFullBuildTrigger(changedFiles, config);
+            String triggerFile = pathFilters.findFullBuildTrigger(changedFiles);
             if (triggerFile != null) {
                 if (passiveRun(config)) {
                     reportAssembler.writeFullBuildReport(
@@ -314,6 +315,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     changedManagedDepGAs,
                     changedManagedPluginGAs,
                     unmatchedPomPaths,
+                    pathFilters,
                     timings,
                     analysisStartNano,
                     result);
@@ -373,14 +375,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             allAffected.addAll(transitivelyAffected.keySet());
 
             // Apply includePaths module filter
-            List<PathMatcher> includeMatchers = ChangedFileClassifier.compileGlobMatchers(config.getIncludePaths());
-            if (!includeMatchers.isEmpty()) {
+            if (pathFilters.hasIncludeFilters()) {
                 int beforeCount = allAffected.size();
-                directlyAffected.removeIf(
-                        p -> !ChangedFileClassifier.matchesIncludePaths(p, includeMatchers, normalizedRoot));
-                transitivelyAffected
-                        .keySet()
-                        .removeIf(p -> !ChangedFileClassifier.matchesIncludePaths(p, includeMatchers, normalizedRoot));
+                directlyAffected.removeIf(p -> !pathFilters.matchesIncludePaths(p, normalizedRoot));
+                transitivelyAffected.keySet().removeIf(p -> !pathFilters.matchesIncludePaths(p, normalizedRoot));
                 testOnlyModules.retainAll(directlyAffected);
                 forceIncluded.retainAll(directlyAffected);
 
@@ -450,12 +448,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                     wouldHaveBuilt = new LinkedHashSet<>();
                     List<MavenProject> decisionBuildSet = decision.getBuildSet();
-                    if (!includeMatchers.isEmpty()) {
-                        Set<MavenProject> affected = allAffected;
-                        decisionBuildSet = new ArrayList<>(decisionBuildSet);
-                        decisionBuildSet.removeIf(project -> !affected.contains(project)
-                                && !decision.getUpstreamOnly().contains(project)
-                                && !ChangedFileClassifier.matchesIncludePaths(project, includeMatchers, reactorRoot));
+                    if (pathFilters.hasIncludeFilters()) {
+                        decisionBuildSet = pathFilters.filterBuildSet(
+                                decisionBuildSet, allAffected, decision.getUpstreamOnly(), normalizedRoot);
                     }
                     for (MavenProject project : decisionBuildSet) {
                         wouldHaveBuilt.add(moduleKey.apply(project));
@@ -493,12 +488,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         }
                     }
                     List<MavenProject> reportBuildSet = reportDecision.getBuildSet();
-                    if (!includeMatchers.isEmpty()) {
-                        Set<MavenProject> affected = allAffected;
-                        reportBuildSet = new ArrayList<>(reportBuildSet);
-                        reportBuildSet.removeIf(project -> !affected.contains(project)
-                                && !reportDecision.getUpstreamOnly().contains(project)
-                                && !ChangedFileClassifier.matchesIncludePaths(project, includeMatchers, reactorRoot));
+                    if (pathFilters.hasIncludeFilters()) {
+                        reportBuildSet = pathFilters.filterBuildSet(
+                                reportBuildSet, allAffected, reportDecision.getUpstreamOnly(), normalizedRoot);
                     }
                     decisionId = decisionIdFor(result, config, reactorRoot, reportBuildSet);
                 }
@@ -520,6 +512,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .trimResult(trimResult)
                                 .decisionId(decisionId)
                                 .build(),
+                        pathFilters,
                         timings,
                         analysisStartNano);
                 if (config.isExplain()) {
@@ -583,7 +576,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (config.isModeSkipTests()) {
                 timings.start(Timings.PHASE_APPLY_SKIP_TESTS);
                 try {
-                    skipTestsApplier.applySkipTests(allProjects, trimResult, config, models, includeMatchers, rctx);
+                    skipTestsApplier.applySkipTests(allProjects, trimResult, config, models, pathFilters, rctx);
                 } finally {
                     timings.stop(Timings.PHASE_APPLY_SKIP_TESTS);
                 }
@@ -593,12 +586,9 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             } else {
                 // trim mode: remove unaffected projects from reactor
                 List<MavenProject> buildSet = trimResult.getBuildSet();
-                if (!includeMatchers.isEmpty()) {
-                    Set<MavenProject> finalAllAffected = allAffected;
-                    buildSet = new ArrayList<>(buildSet);
-                    buildSet.removeIf(p -> !finalAllAffected.contains(p)
-                            && !trimResult.getUpstreamOnly().contains(p)
-                            && !ChangedFileClassifier.matchesIncludePaths(p, includeMatchers, normalizedRoot));
+                if (pathFilters.hasIncludeFilters()) {
+                    buildSet = pathFilters.filterBuildSet(
+                            buildSet, allAffected, trimResult.getUpstreamOnly(), normalizedRoot);
                 }
                 logger.info(
                         "Scalpel: Building {} of {} modules: {}", buildSet.size(), allProjects.size(), keys(buildSet));
@@ -627,6 +617,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .filteredBuildSet(buildSet)
                                 .decisionId(trimDecisionId)
                                 .build(),
+                        pathFilters,
                         timings,
                         analysisStartNano);
             }
@@ -668,6 +659,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs,
             Set<String> unmatchedPomPaths,
+            PathFilters pathFilters,
             Timings timings,
             long analysisStartNano,
             ChangeDetectionResult result) {}
@@ -699,6 +691,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             cctx.changedManagedPluginGAs(),
                             cctx.unmatchedPomPaths(),
                             decisionId),
+                    cctx.pathFilters(),
                     cctx.timings(),
                     cctx.analysisStartNano());
         } else if (cctx.config().isModeSkipTests()) {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplier.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/SkipTestsApplier.java
@@ -12,7 +12,6 @@ import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.keys;
 import static eu.maveniverse.maven.scalpel.extension3.internal.Projects.matchesDownstreamExclusion;
 
 import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
-import java.nio.file.PathMatcher;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -44,7 +43,7 @@ class SkipTestsApplier {
             TrimResult trimResult,
             ScalpelConfiguration config,
             TransitiveImpactAnalyzer.EffectiveModels models,
-            List<PathMatcher> includeMatchers,
+            PathFilters pathFilters,
             TransitiveImpactAnalyzer.ResolutionContext rctx) {
 
         List<MavenProject> testProjects = new ArrayList<>();
@@ -54,8 +53,7 @@ class SkipTestsApplier {
         classifyBuildSetProjects(trimResult, config, models, rctx, testProjects, skippedProjects);
 
         // Modules outside the build set
-        classifyRemainingProjects(
-                allProjects, trimResult, models, includeMatchers, rctx, testProjects, skippedProjects);
+        classifyRemainingProjects(allProjects, trimResult, models, pathFilters, rctx, testProjects, skippedProjects);
 
         // Apply per-category args
         applyPerCategoryArgs(trimResult, config);
@@ -102,7 +100,7 @@ class SkipTestsApplier {
             List<MavenProject> allProjects,
             TrimResult trimResult,
             TransitiveImpactAnalyzer.EffectiveModels models,
-            List<PathMatcher> includeMatchers,
+            PathFilters pathFilters,
             TransitiveImpactAnalyzer.ResolutionContext rctx,
             List<MavenProject> testProjects,
             List<MavenProject> skippedProjects) {
@@ -111,20 +109,19 @@ class SkipTestsApplier {
             if (buildSetLookup.contains(project)) {
                 continue;
             }
-            classifySingleRemainingProject(project, models, includeMatchers, rctx, testProjects, skippedProjects);
+            classifySingleRemainingProject(project, models, pathFilters, rctx, testProjects, skippedProjects);
         }
     }
 
     private void classifySingleRemainingProject(
             MavenProject project,
             TransitiveImpactAnalyzer.EffectiveModels models,
-            List<PathMatcher> includeMatchers,
+            PathFilters pathFilters,
             TransitiveImpactAnalyzer.ResolutionContext rctx,
             List<MavenProject> testProjects,
             List<MavenProject> skippedProjects) {
         // Skip tests on modules outside includePaths scope
-        if (!includeMatchers.isEmpty()
-                && !ChangedFileClassifier.matchesIncludePaths(project, includeMatchers, rctx.normalizedRoot())) {
+        if (pathFilters.hasIncludeFilters() && !pathFilters.matchesIncludePaths(project, rctx.normalizedRoot())) {
             project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
             skippedProjects.add(project);
             return;

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifierTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ChangedFileClassifierTest.java
@@ -8,17 +8,12 @@
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.maven.project.MavenProject;
@@ -88,100 +83,6 @@ class ChangedFileClassifierTest {
     }
 
     @Test
-    void compileGlobMatchers_emptyPatterns() {
-        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of());
-        assertTrue(matchers.isEmpty());
-    }
-
-    @Test
-    void compileGlobMatchers_compilesPatterns() {
-        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of("*.md", "docs/**"));
-        assertEquals(2, matchers.size());
-    }
-
-    @Test
-    void matchesIncludePaths_matchesDirectModulePath() {
-        Path root = tempDir;
-        MavenProject project = createProject(root, "module-a", "com.example", "module-a");
-
-        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of("module-a"));
-        assertTrue(ChangedFileClassifier.matchesIncludePaths(project, matchers, root));
-    }
-
-    @Test
-    void matchesIncludePaths_noMatch() {
-        Path root = tempDir;
-        MavenProject project = createProject(root, "module-b", "com.example", "module-b");
-
-        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of("module-a"));
-        assertFalse(ChangedFileClassifier.matchesIncludePaths(project, matchers, root));
-    }
-
-    @Test
-    void matchesIncludePaths_matchesPomXmlPattern() {
-        Path root = tempDir;
-        MavenProject project = createProject(root, "module-a", "com.example", "module-a");
-
-        List<PathMatcher> matchers = ChangedFileClassifier.compileGlobMatchers(List.of("module-a/**"));
-        assertTrue(ChangedFileClassifier.matchesIncludePaths(project, matchers, root));
-    }
-
-    @Test
-    void matchesDisableTrigger_matchesPattern() {
-        ScalpelConfiguration config = configWith("scalpel.disableTriggers", "*.lock");
-
-        // The lock file won't match *.lock, but let's test with a matching one
-        Set<String> files2 = Set.of("deps.lock");
-        assertTrue(classifier.matchesDisableTrigger(files2, config));
-    }
-
-    @Test
-    void matchesDisableTrigger_noMatch() {
-        ScalpelConfiguration config = configWith("scalpel.disableTriggers", "*.lock");
-        Set<String> changedFiles = Set.of("src/main/java/Foo.java");
-
-        assertFalse(classifier.matchesDisableTrigger(changedFiles, config));
-    }
-
-    @Test
-    void filterExcludedPaths_excludesMatchingFiles() {
-        ScalpelConfiguration config = configWith("scalpel.excludePaths", "docs/**");
-        Set<String> changedFiles = new LinkedHashSet<>();
-        changedFiles.add("docs/guide.md");
-        changedFiles.add("src/main/java/Foo.java");
-
-        Set<String> filtered = classifier.filterExcludedPaths(changedFiles, config);
-        assertEquals(Set.of("src/main/java/Foo.java"), filtered);
-    }
-
-    @Test
-    void filterExcludedPaths_noExclusions() {
-        ScalpelConfiguration config = configWith("scalpel.mode", "trim");
-        Set<String> changedFiles = Set.of("src/main/java/Foo.java");
-
-        Set<String> filtered = classifier.filterExcludedPaths(changedFiles, config);
-        assertEquals(changedFiles, filtered);
-    }
-
-    @Test
-    void findFullBuildTrigger_findsMatch() {
-        ScalpelConfiguration config = configWith("scalpel.fullBuildTriggers", ".github/workflows/**");
-        Set<String> changedFiles = Set.of(".github/workflows/ci.yml", "src/main/java/Foo.java");
-
-        String trigger = classifier.findFullBuildTrigger(changedFiles, config);
-        assertEquals(".github/workflows/ci.yml", trigger);
-    }
-
-    @Test
-    void findFullBuildTrigger_noMatch() {
-        ScalpelConfiguration config = configWith("scalpel.fullBuildTriggers", ".github/workflows/**");
-        Set<String> changedFiles = Set.of("src/main/java/Foo.java");
-
-        String trigger = classifier.findFullBuildTrigger(changedFiles, config);
-        assertNull(trigger);
-    }
-
-    @Test
     void relativePath_computesCorrectly() {
         Path root = tempDir;
         MavenProject project = createProject(root, "module-a", "com.example", "module-a");
@@ -198,15 +99,5 @@ class ChangedFileClassifierTest {
         when(project.getFile()).thenReturn(moduleDir.resolve("pom.xml").toFile());
         when(project.getProperties()).thenReturn(new Properties());
         return project;
-    }
-
-    private ScalpelConfiguration configWith(String key, String value) {
-        Properties sysProps = new Properties();
-        Properties userProps = new Properties();
-        userProps.setProperty("scalpel.enabled", "true");
-        userProps.setProperty("scalpel.mode", "trim");
-        userProps.setProperty("scalpel.baseBranch", "main");
-        userProps.setProperty(key, value);
-        return ScalpelConfiguration.fromProperties(sysProps, userProps);
     }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PathFiltersTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PathFiltersTest.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PathFiltersTest {
+
+    @TempDir
+    Path tempDir;
+
+    // ---- helper to build a config from property overrides ----
+
+    private ScalpelConfiguration config(String... keyValuePairs) {
+        Properties sysProps = new Properties();
+        // baseBranch is required for a valid config in most tests
+        sysProps.setProperty("scalpel.baseBranch", "origin/main");
+        for (int i = 0; i < keyValuePairs.length; i += 2) {
+            sysProps.setProperty(keyValuePairs[i], keyValuePairs[i + 1]);
+        }
+        return ScalpelConfiguration.fromProperties(sysProps, new Properties());
+    }
+
+    private MavenProject mockProject(String artifactId, Path baseDir) {
+        MavenProject project = mock(MavenProject.class);
+        when(project.getGroupId()).thenReturn("com.example");
+        when(project.getArtifactId()).thenReturn(artifactId);
+        when(project.getBasedir()).thenReturn(baseDir.toFile());
+        when(project.getFile()).thenReturn(baseDir.resolve("pom.xml").toFile());
+        return project;
+    }
+
+    private Set<String> setOf(String... values) {
+        Set<String> set = new LinkedHashSet<>();
+        for (String v : values) {
+            set.add(v);
+        }
+        return set;
+    }
+
+    // ---- filterExcludedPaths ----
+
+    @Test
+    void filterExcludedPaths_noExcludes_returnsOriginal() {
+        PathFilters pf = new PathFilters(config());
+        Set<String> files = setOf("src/Main.java", "README.md");
+        Set<String> result = pf.filterExcludedPaths(files);
+        assertEquals(files, result);
+    }
+
+    @Test
+    void filterExcludedPaths_excludesMdFiles() {
+        PathFilters pf = new PathFilters(config("scalpel.excludePaths", "*.md"));
+        Set<String> files = setOf("src/Main.java", "README.md", "docs/guide.md");
+        Set<String> result = pf.filterExcludedPaths(files);
+        assertEquals(setOf("src/Main.java"), result);
+    }
+
+    @Test
+    void filterExcludedPaths_excludesNestedXml() {
+        // **/*.xml already contains a '/', so normalizeGlobPattern leaves it unchanged.
+        // The glob **/*.xml matches config/settings.xml but NOT root-level pom.xml.
+        PathFilters pf = new PathFilters(config("scalpel.excludePaths", "**/*.xml"));
+        Set<String> files = setOf("src/Main.java", "config/settings.xml", "pom.xml");
+        Set<String> result = pf.filterExcludedPaths(files);
+        assertEquals(setOf("src/Main.java", "pom.xml"), result);
+    }
+
+    @Test
+    void filterExcludedPaths_multiplePatterns() {
+        PathFilters pf = new PathFilters(config("scalpel.excludePaths", "*.md,*.txt"));
+        Set<String> files = setOf("src/Main.java", "README.md", "NOTES.txt");
+        Set<String> result = pf.filterExcludedPaths(files);
+        assertEquals(setOf("src/Main.java"), result);
+    }
+
+    @Test
+    void filterExcludedPaths_directoryPattern() {
+        PathFilters pf = new PathFilters(config("scalpel.excludePaths", ".github/**"));
+        Set<String> files = setOf("src/Main.java", ".github/workflows/ci.yml");
+        Set<String> result = pf.filterExcludedPaths(files);
+        assertEquals(setOf("src/Main.java"), result);
+    }
+
+    // ---- matchesDisableTrigger ----
+
+    @Test
+    void matchesDisableTrigger_noTriggers_returnsFalse() {
+        PathFilters pf = new PathFilters(config());
+        assertFalse(pf.matchesDisableTrigger(setOf("src/Main.java")));
+    }
+
+    @Test
+    void matchesDisableTrigger_matchingFile_returnsTrue() {
+        PathFilters pf = new PathFilters(config("scalpel.disableTriggers", ".github/**"));
+        assertTrue(pf.matchesDisableTrigger(setOf("src/Main.java", ".github/workflows/ci.yml")));
+    }
+
+    @Test
+    void matchesDisableTrigger_noMatch_returnsFalse() {
+        PathFilters pf = new PathFilters(config("scalpel.disableTriggers", ".github/**"));
+        assertFalse(pf.matchesDisableTrigger(setOf("src/Main.java", "README.md")));
+    }
+
+    @Test
+    void matchesDisableTrigger_bareGlobMatchesNested() {
+        PathFilters pf = new PathFilters(config("scalpel.disableTriggers", "*.lock"));
+        assertTrue(pf.matchesDisableTrigger(setOf("deps/package.lock")));
+    }
+
+    // ---- findFullBuildTrigger ----
+
+    @Test
+    void findFullBuildTrigger_defaultMvn_matchesMvnFiles() {
+        PathFilters pf = new PathFilters(config());
+        // Default fullBuildTriggers is .mvn/**
+        assertEquals(".mvn/extensions.xml", pf.findFullBuildTrigger(setOf(".mvn/extensions.xml")));
+    }
+
+    @Test
+    void findFullBuildTrigger_noMatch_returnsNull() {
+        PathFilters pf = new PathFilters(config());
+        assertNull(pf.findFullBuildTrigger(setOf("src/Main.java")));
+    }
+
+    @Test
+    void findFullBuildTrigger_customTrigger() {
+        PathFilters pf = new PathFilters(config("scalpel.fullBuildTriggers", "build-config/**"));
+        assertEquals(
+                "build-config/settings.xml",
+                pf.findFullBuildTrigger(setOf("src/Main.java", "build-config/settings.xml")));
+    }
+
+    @Test
+    void findFullBuildTrigger_emptyChangedFiles() {
+        PathFilters pf = new PathFilters(config());
+        assertNull(pf.findFullBuildTrigger(setOf()));
+    }
+
+    // ---- hasIncludeFilters ----
+
+    @Test
+    void hasIncludeFilters_noIncludes_returnsFalse() {
+        PathFilters pf = new PathFilters(config());
+        assertFalse(pf.hasIncludeFilters());
+    }
+
+    @Test
+    void hasIncludeFilters_withIncludes_returnsTrue() {
+        PathFilters pf = new PathFilters(config("scalpel.includePaths", "module-a/**"));
+        assertTrue(pf.hasIncludeFilters());
+    }
+
+    // ---- matchesIncludePaths ----
+
+    @Test
+    void matchesIncludePaths_matchingModule() {
+        PathFilters pf = new PathFilters(config("scalpel.includePaths", "module-a/**"));
+        Path root = tempDir.resolve("project");
+        root.toFile().mkdirs();
+        Path moduleDir = root.resolve("module-a");
+        moduleDir.toFile().mkdirs();
+        MavenProject project = mockProject("module-a", moduleDir);
+        assertTrue(pf.matchesIncludePaths(project, root));
+    }
+
+    @Test
+    void matchesIncludePaths_nonMatchingModule() {
+        PathFilters pf = new PathFilters(config("scalpel.includePaths", "module-a/**"));
+        Path root = tempDir.resolve("project");
+        root.toFile().mkdirs();
+        Path moduleDir = root.resolve("module-b");
+        moduleDir.toFile().mkdirs();
+        MavenProject project = mockProject("module-b", moduleDir);
+        assertFalse(pf.matchesIncludePaths(project, root));
+    }
+
+    @Test
+    void matchesIncludePaths_directModuleName() {
+        PathFilters pf = new PathFilters(config("scalpel.includePaths", "module-a"));
+        Path root = tempDir.resolve("project");
+        root.toFile().mkdirs();
+        Path moduleDir = root.resolve("module-a");
+        moduleDir.toFile().mkdirs();
+        MavenProject project = mockProject("module-a", moduleDir);
+        assertTrue(pf.matchesIncludePaths(project, root));
+    }
+
+    @Test
+    void matchesIncludePaths_multiplePatterns() {
+        PathFilters pf = new PathFilters(config("scalpel.includePaths", "module-a/**,module-b/**"));
+        Path root = tempDir.resolve("project");
+        root.toFile().mkdirs();
+        Path moduleDirA = root.resolve("module-a");
+        moduleDirA.toFile().mkdirs();
+        Path moduleDirB = root.resolve("module-b");
+        moduleDirB.toFile().mkdirs();
+        Path moduleDirC = root.resolve("module-c");
+        moduleDirC.toFile().mkdirs();
+
+        assertTrue(pf.matchesIncludePaths(mockProject("module-a", moduleDirA), root));
+        assertTrue(pf.matchesIncludePaths(mockProject("module-b", moduleDirB), root));
+        assertFalse(pf.matchesIncludePaths(mockProject("module-c", moduleDirC), root));
+    }
+
+    // ---- filterBuildSet (trim mode: upstream survive) ----
+
+    @Test
+    void filterBuildSet_noIncludes_returnsSameList() {
+        PathFilters pf = new PathFilters(config());
+        Path root = tempDir.resolve("project");
+        root.toFile().mkdirs();
+
+        MavenProject p = mockProject("module-a", root.resolve("module-a"));
+        root.resolve("module-a").toFile().mkdirs();
+        List<MavenProject> buildSet = List.of(p);
+
+        List<MavenProject> result = pf.filterBuildSet(buildSet, Set.of(), Set.of(), root);
+        assertEquals(buildSet, result);
+    }
+
+    @Test
+    void filterBuildSet_upstreamSurvivesOutsideScope() {
+        PathFilters pf = new PathFilters(config("scalpel.includePaths", "module-a/**"));
+        Path root = tempDir.resolve("project");
+        root.toFile().mkdirs();
+
+        Path moduleADir = root.resolve("module-a");
+        moduleADir.toFile().mkdirs();
+        Path moduleBDir = root.resolve("module-b");
+        moduleBDir.toFile().mkdirs();
+        Path moduleCDir = root.resolve("module-c");
+        moduleCDir.toFile().mkdirs();
+
+        MavenProject affected = mockProject("module-a", moduleADir);
+        MavenProject upstream = mockProject("module-b", moduleBDir);
+        MavenProject downstream = mockProject("module-c", moduleCDir);
+
+        List<MavenProject> buildSet = new ArrayList<>(List.of(affected, upstream, downstream));
+        Set<MavenProject> affectedSet = Set.of(affected);
+        Set<MavenProject> upstreamOnly = Set.of(upstream);
+
+        List<MavenProject> result = pf.filterBuildSet(buildSet, affectedSet, upstreamOnly, root);
+
+        // affected: kept (in affectedSet)
+        // upstream: kept (in upstreamOnly) — this is the trim-mode semantic
+        // downstream: removed (not in affected or upstream, doesn't match includePaths)
+        assertTrue(result.contains(affected), "affected module should be kept");
+        assertTrue(result.contains(upstream), "upstream prerequisite should survive even outside scope");
+        assertFalse(result.contains(downstream), "downstream outside scope should be removed");
+    }
+
+    @Test
+    void filterBuildSet_downstreamInsideScopeKept() {
+        PathFilters pf = new PathFilters(config("scalpel.includePaths", "module-a/**,module-c/**"));
+        Path root = tempDir.resolve("project");
+        root.toFile().mkdirs();
+
+        Path moduleADir = root.resolve("module-a");
+        moduleADir.toFile().mkdirs();
+        Path moduleCDir = root.resolve("module-c");
+        moduleCDir.toFile().mkdirs();
+
+        MavenProject affected = mockProject("module-a", moduleADir);
+        MavenProject downstream = mockProject("module-c", moduleCDir);
+
+        List<MavenProject> buildSet = new ArrayList<>(List.of(affected, downstream));
+        Set<MavenProject> affectedSet = Set.of(affected);
+
+        List<MavenProject> result = pf.filterBuildSet(buildSet, affectedSet, Set.of(), root);
+
+        assertTrue(result.contains(affected));
+        assertTrue(result.contains(downstream), "downstream inside scope should be kept");
+    }
+
+    /**
+     * Documents the intentional semantic difference between trim mode and skip-tests mode:
+     * in trim mode ({@link PathFilters#filterBuildSet}), upstream prerequisites survive even
+     * outside includePaths scope; in skip-tests mode ({@link PathFilters#matchesIncludePaths}),
+     * the strict check has no upstream exception — the module's tests are skipped.
+     */
+    @Test
+    void trimVsSkipTests_upstreamSemanticDifference() {
+        PathFilters pf = new PathFilters(config("scalpel.includePaths", "module-a/**"));
+        Path root = tempDir.resolve("project");
+        root.toFile().mkdirs();
+
+        Path moduleADir = root.resolve("module-a");
+        moduleADir.toFile().mkdirs();
+        Path moduleBDir = root.resolve("module-b");
+        moduleBDir.toFile().mkdirs();
+
+        MavenProject affected = mockProject("module-a", moduleADir);
+        MavenProject upstream = mockProject("module-b", moduleBDir);
+
+        // Trim mode: upstream survives the filter
+        List<MavenProject> buildSet = new ArrayList<>(List.of(affected, upstream));
+        List<MavenProject> trimResult = pf.filterBuildSet(buildSet, Set.of(affected), Set.of(upstream), root);
+        assertTrue(trimResult.contains(upstream), "trim mode: upstream should survive the include filter");
+
+        // Skip-tests mode: strict check — upstream does NOT match
+        assertFalse(
+                pf.matchesIncludePaths(upstream, root),
+                "skip-tests mode: upstream outside scope should NOT match (tests will be skipped)");
+    }
+
+    // ---- normalizeGlobPattern (delegated to ScalpelLifecycleParticipant) ----
+
+    @Test
+    void normalizeGlobPattern_barePattern() {
+        assertEquals("{*.md,**/*.md}", ScalpelLifecycleParticipant.normalizeGlobPattern("*.md"));
+        assertEquals("{LICENSE,**/LICENSE}", ScalpelLifecycleParticipant.normalizeGlobPattern("LICENSE"));
+    }
+
+    @Test
+    void normalizeGlobPattern_patternWithSlash() {
+        assertEquals("docs/*.md", ScalpelLifecycleParticipant.normalizeGlobPattern("docs/*.md"));
+        assertEquals("**/*.md", ScalpelLifecycleParticipant.normalizeGlobPattern("**/*.md"));
+        assertEquals(".github/**", ScalpelLifecycleParticipant.normalizeGlobPattern(".github/**"));
+    }
+
+    // ---- empty pattern lists are no-ops ----
+
+    @Test
+    void emptyPatterns_areNoOps() {
+        PathFilters pf = new PathFilters(config());
+        Set<String> files = setOf("src/Main.java", "README.md");
+
+        // filterExcludedPaths with no excludes returns original
+        assertEquals(files, pf.filterExcludedPaths(files));
+
+        // matchesDisableTrigger with no triggers returns false
+        assertFalse(pf.matchesDisableTrigger(files));
+
+        // findFullBuildTrigger with default .mvn/** doesn't match these
+        assertNull(pf.findFullBuildTrigger(files));
+
+        // hasIncludeFilters with no includes returns false
+        assertFalse(pf.hasIncludeFilters());
+    }
+}


### PR DESCRIPTION
## Summary

Introduce `PathFilters`, a single type that compiles all glob patterns (`excludePaths`, `includePaths`, `disableTriggers`, `fullBuildTriggers`) once and provides evaluation methods for all four sites that previously re-derived them independently.

Fixes #124.

## Changes

- **New class `PathFilters`**: compiles all glob patterns once in the constructor and exposes:
  - `filterExcludedPaths()` — filters changed files against exclude patterns
  - `matchesDisableTrigger()` — checks if any changed file triggers disabling
  - `findFullBuildTrigger()` — finds the first file triggering a full build
  - `matchesIncludePaths()` — strict module-level include check (skip-tests mode)
  - `filterBuildSet()` — trim-mode filtering that preserves upstream prerequisites
  - `hasIncludeFilters()` — whether includePaths are configured

- **Refactored `ScalpelLifecycleParticipant`**:
  - Creates `PathFilters` once early in `afterProjectsRead` and threads it to all call sites
  - Removed 5 private methods that are now in `PathFilters`
  - Removed unused imports and constant
  - `addDownstreamModules` no longer recompiles matchers from config
  - Changed files are converted to `Path` once per evaluation rather than once per pattern

- **Documented semantic difference**:
  - **Trim mode** (`filterBuildSet`): upstream prerequisites survive the include filter
  - **Skip-tests mode** (`matchesIncludePaths`): no exception for upstream — tests are skipped

- **26 new unit tests** for `PathFilters`

## Stats

- `ScalpelLifecycleParticipant.java`: 34 insertions, 106 deletions (net -72 lines)
- `PathFilters.java`: 236 lines (new)
- `PathFiltersTest.java`: 360 lines (new)
- All 216 existing + new tests pass

_AI agent (Hermes on behalf of gnodet)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved consistency when applying include and exclude path filters across build modes.
  - Preserved correct handling of disable triggers and full-build triggers.
  - Refined glob pattern matching, including patterns with and without directory separators.
  - Ensured trim mode retains affected and upstream modules when appropriate, while skip-tests mode applies stricter include-path filtering.

- **Tests**
  - Added comprehensive coverage for path filtering, trigger detection, glob normalization, and build-set behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->