### PR TITLE
Fix #101: periodic full-build verification and a stable decisionId

### DIFF
--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ChangeDetectionResult.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ChangeDetectionResult.java
@@ -25,6 +25,8 @@ public final class ChangeDetectionResult {
 
     private final Set<String> changedFiles;
     private final Map<String, byte[]> oldPomContents;
+    private final String mergeBaseId;
+    private final String headId;
 
     /**
      * Constructs a change-detection result.
@@ -33,8 +35,22 @@ public final class ChangeDetectionResult {
      * @param oldPomContents base-commit contents of changed POMs, keyed by path
      */
     public ChangeDetectionResult(Set<String> changedFiles, Map<String, byte[]> oldPomContents) {
+        this(changedFiles, oldPomContents, null, null);
+    }
+
+    /**
+     * Constructs a change-detection result carrying the commit identities behind the diff,
+     * used to compute a stable {@code decisionId} (#101).
+     *
+     * @param mergeBaseId the merge-base commit id, or null when unavailable
+     * @param headId the head commit id, or null when unavailable
+     */
+    public ChangeDetectionResult(
+            Set<String> changedFiles, Map<String, byte[]> oldPomContents, String mergeBaseId, String headId) {
         this.changedFiles = Collections.unmodifiableSet(new LinkedHashSet<>(changedFiles));
         this.oldPomContents = Collections.unmodifiableMap(new LinkedHashMap<>(oldPomContents));
+        this.mergeBaseId = mergeBaseId;
+        this.headId = headId;
     }
 
     /** Returns the changed file paths detected in the diff. */
@@ -45,5 +61,15 @@ public final class ChangeDetectionResult {
     /** Returns the base-commit contents of changed POMs, keyed by path. */
     public Map<String, byte[]> getOldPomContents() {
         return oldPomContents;
+    }
+
+    /** Returns the merge-base commit id, or null when the detection did not carry one. */
+    public String getMergeBaseId() {
+        return mergeBaseId;
+    }
+
+    /** Returns the head commit id, or null when the detection did not carry one. */
+    public String getHeadId() {
+        return headId;
     }
 }

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -79,6 +79,14 @@ public final class ScalpelConfiguration {
     public static final String EXPLAIN = PREFIX + "explain";
 
     /**
+     * System property {@code scalpel.verifyFullBuild}: run the full build, compute the would-be
+     * decision, and fail the build if any module Scalpel would have skipped fails, naming the
+     * modules and why they were judged skippable (#101). Forces the shadow observation instead
+     * of reactor-modifying modes. Default: {@code false}.
+     */
+    public static final String VERIFY_FULL_BUILD = PREFIX + "verifyFullBuild";
+
+    /**
      * System property {@code scalpel.disableOnBranch}: comma-separated regex patterns; Scalpel is
      * disabled when the current branch matches any of them. Default: none.
      */
@@ -219,6 +227,7 @@ public final class ScalpelConfiguration {
             FAIL_SAFE,
             MODE,
             EXPLAIN,
+            VERIFY_FULL_BUILD,
             DISABLE_ON_BRANCH,
             DISABLE_ON_BASE_BRANCH,
             EXCLUDE_PATHS,
@@ -263,6 +272,7 @@ public final class ScalpelConfiguration {
     private final boolean failSafe;
     private final String mode;
     private final boolean explain;
+    private final boolean verifyFullBuild;
     private final String reportFile;
     private final long maxResourceFileSize;
     private final List<String> warnings;
@@ -293,6 +303,7 @@ public final class ScalpelConfiguration {
             boolean failSafe,
             String mode,
             boolean explain,
+            boolean verifyFullBuild,
             String reportFile,
             long maxResourceFileSize,
             List<String> warnings) {
@@ -321,6 +332,7 @@ public final class ScalpelConfiguration {
         this.failSafe = failSafe;
         this.mode = mode;
         this.explain = explain;
+        this.verifyFullBuild = verifyFullBuild;
         this.reportFile = reportFile;
         this.maxResourceFileSize = maxResourceFileSize;
         this.warnings = warnings;
@@ -382,6 +394,8 @@ public final class ScalpelConfiguration {
                     + ", " + MODE_SKIP_TESTS + ", " + MODE_REPORT + ", " + MODE_SHADOW);
         }
         boolean explain = parseStrictBoolean(EXPLAIN, resolve(system, user, EXPLAIN, "false"));
+        boolean verifyFullBuild =
+                parseStrictBoolean(VERIFY_FULL_BUILD, resolve(system, user, VERIFY_FULL_BUILD, "false"));
         String reportFile = resolve(system, user, REPORT_FILE, DEFAULT_REPORT_FILE);
         String maxResourceFileSizeStr = resolve(system, user, MAX_RESOURCE_FILE_SIZE, null);
         long maxResourceFileSize = DEFAULT_MAX_RESOURCE_FILE_SIZE;
@@ -426,6 +440,7 @@ public final class ScalpelConfiguration {
                 failSafe,
                 mode,
                 explain,
+                verifyFullBuild,
                 reportFile,
                 maxResourceFileSize,
                 warnings);
@@ -670,6 +685,40 @@ public final class ScalpelConfiguration {
     /** Returns whether per-module decision evidence is emitted (explain mode). Default: {@code false}. */
     public boolean isExplain() {
         return explain;
+    }
+
+    /**
+     * Returns whether the full build runs under observation and fails when a module Scalpel
+     * would have skipped fails (verify mode, #101). Default: {@code false}.
+     */
+    public boolean isVerifyFullBuild() {
+        return verifyFullBuild;
+    }
+
+    /**
+     * Returns a stable fingerprint of the configuration properties that shape the trim
+     * decision, for {@link ScalpelReport#computeDecisionId}. Output-shaping properties
+     * (reportFile, impactedLog, mode, failSafe, explain, ...) are deliberately excluded:
+     * the decision identity must not change because someone moved the report.
+     */
+    public String decisionFingerprint() {
+        StringBuilder sb = new StringBuilder();
+        appendFingerprintPart(sb, "baseBranch", baseBranch);
+        appendFingerprintPart(sb, "head", head);
+        appendFingerprintPart(sb, "alsoMake", String.valueOf(alsoMake));
+        appendFingerprintPart(sb, "alsoMakeDependents", String.valueOf(alsoMakeDependents));
+        appendFingerprintPart(sb, "fullBuildTriggers", String.join(",", fullBuildTriggers));
+        appendFingerprintPart(sb, "excludePaths", String.join(",", excludePaths));
+        appendFingerprintPart(sb, "includePaths", String.join(",", includePaths));
+        appendFingerprintPart(sb, "disableTriggers", String.join(",", disableTriggers));
+        appendFingerprintPart(sb, "forceBuildModules", String.join(",", forceBuildModules));
+        appendFingerprintPart(sb, "uncommitted", String.valueOf(uncommitted));
+        appendFingerprintPart(sb, "untracked", String.valueOf(untracked));
+        return sb.toString();
+    }
+
+    private static void appendFingerprintPart(StringBuilder sb, String name, String value) {
+        sb.append(name).append('=').append(value == null ? "" : value).append(';');
     }
 
     /** Returns the operating mode: {@code trim}, {@code skip-tests}, {@code report}, or {@code shadow}. Default: {@code trim}. */

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -707,14 +707,21 @@ public final class ScalpelConfiguration {
         appendFingerprintPart(sb, "head", head);
         appendFingerprintPart(sb, "alsoMake", String.valueOf(alsoMake));
         appendFingerprintPart(sb, "alsoMakeDependents", String.valueOf(alsoMakeDependents));
-        appendFingerprintPart(sb, "fullBuildTriggers", String.join(",", fullBuildTriggers));
-        appendFingerprintPart(sb, "excludePaths", String.join(",", excludePaths));
-        appendFingerprintPart(sb, "includePaths", String.join(",", includePaths));
-        appendFingerprintPart(sb, "disableTriggers", String.join(",", disableTriggers));
-        appendFingerprintPart(sb, "forceBuildModules", String.join(",", forceBuildModules));
+        appendFingerprintPart(sb, "fullBuildTriggers", sortedJoin(fullBuildTriggers));
+        appendFingerprintPart(sb, "excludePaths", sortedJoin(excludePaths));
+        appendFingerprintPart(sb, "includePaths", sortedJoin(includePaths));
+        appendFingerprintPart(sb, "disableTriggers", sortedJoin(disableTriggers));
+        appendFingerprintPart(sb, "forceBuildModules", sortedJoin(forceBuildModules));
+        appendFingerprintPart(sb, "maxResourceFileSize", String.valueOf(maxResourceFileSize));
         appendFingerprintPart(sb, "uncommitted", String.valueOf(uncommitted));
         appendFingerprintPart(sb, "untracked", String.valueOf(untracked));
         return sb.toString();
+    }
+
+    private static String sortedJoin(List<String> values) {
+        List<String> sorted = new ArrayList<>(values);
+        sorted.sort(java.util.Comparator.naturalOrder());
+        return String.join(",", sorted);
     }
 
     private static void appendFingerprintPart(StringBuilder sb, String name, String value) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelConfiguration.java
@@ -725,7 +725,19 @@ public final class ScalpelConfiguration {
     }
 
     private static void appendFingerprintPart(StringBuilder sb, String name, String value) {
-        sb.append(name).append('=').append(value == null ? "" : value).append(';');
+        // Values are hex-encoded: list-valued properties legally contain the structural
+        // delimiters (';' in paths, '=' in patterns), and a raw concatenation let two
+        // distinct resolved configurations collide into one fingerprint (#177 review).
+        sb.append(name).append('=').append(hex(value == null ? "" : value)).append(';');
+    }
+
+    private static String hex(String value) {
+        byte[] bytes = value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append("%02x".formatted(b));
+        }
+        return sb.toString();
     }
 
     /** Returns the operating mode: {@code trim}, {@code skip-tests}, {@code report}, or {@code shadow}. Default: {@code trim}. */

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelCore.java
@@ -211,7 +211,7 @@ public class ScalpelCore {
 
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: No changes detected between {} and {}", baseBranch, head);
-                return new ChangeDetectionResult(changedFiles, Map.of());
+                return new ChangeDetectionResult(changedFiles, Map.of(), mergeBase.name(), headId.name());
             }
 
             // Read old POM files for comparison — only read the ones that actually changed,
@@ -232,7 +232,7 @@ public class ScalpelCore {
             }
             timings.increment(Timings.OP_GIT_BLOBS_READ, oldPomContents.size());
 
-            return new ChangeDetectionResult(changedFiles, oldPomContents);
+            return new ChangeDetectionResult(changedFiles, oldPomContents, mergeBase.name(), headId.name());
         } catch (ScalpelException e) {
             throw e;
         } catch (Exception e) {

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -336,7 +336,10 @@ public final class ScalpelReport {
                 .append('|')
                 .append(configFingerprint)
                 .append('|');
-        buildSetPaths.stream().sorted().forEach(path -> canonical.append(path).append('\n'));
+        buildSetPaths.stream()
+                .sorted()
+                .forEach(path ->
+                        canonical.append(path.length()).append(':').append(path).append('\n'));
         try {
             java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(canonical.toString().getBytes(StandardCharsets.UTF_8));

--- a/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
+++ b/core/src/main/java/eu/maveniverse/maven/scalpel/core/ScalpelReport.java
@@ -76,6 +76,7 @@ public final class ScalpelReport {
             Set.of(CATEGORY_DIRECT, CATEGORY_UPSTREAM, CATEGORY_DOWNSTREAM, CATEGORY_TRANSITIVE);
 
     private final String baseBranch;
+    private final String decisionId;
     private final String status;
     private final String reason;
     private final boolean fullBuildTriggered;
@@ -93,6 +94,7 @@ public final class ScalpelReport {
 
     private ScalpelReport(
             String baseBranch,
+            String decisionId,
             String status,
             String reason,
             boolean fullBuildTriggered,
@@ -108,6 +110,7 @@ public final class ScalpelReport {
             Timings timings,
             long totalMillis) {
         this.baseBranch = baseBranch;
+        this.decisionId = decisionId;
         this.status = status;
         this.reason = reason;
         this.fullBuildTriggered = fullBuildTriggered;
@@ -315,6 +318,39 @@ public final class ScalpelReport {
         }
     }
 
+    /**
+     * Computes the stable decision identity (#101): the SHA-256 hex digest of the merge-base
+     * commit, the head commit, the resolved decision-shaping configuration fingerprint and
+     * the module paths of the resulting build set, sorted so reactor order does not change
+     * the identity. Null git ids are tolerated (unmeasured runs hash the placeholder
+     * {@code "-"}). The id is emitted in every mode's report so a decision is quotable in a
+     * bug report and correlatable with a post-merge failure.
+     */
+    public static String computeDecisionId(
+            String mergeBaseId, String headId, String configFingerprint, Collection<String> buildSetPaths) {
+        StringBuilder canonical = new StringBuilder("v1|");
+        canonical
+                .append(mergeBaseId == null ? "-" : mergeBaseId)
+                .append('|')
+                .append(headId == null ? "-" : headId)
+                .append('|')
+                .append(configFingerprint)
+                .append('|');
+        buildSetPaths.stream().sorted().forEach(path -> canonical.append(path).append('\n'));
+        try {
+            java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append("%02x".formatted(b));
+            }
+            return hex.toString();
+        } catch (java.security.NoSuchAlgorithmException e) {
+            // SHA-256 is mandated for every Java platform; unreachable.
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
     public String toJson() {
         StringBuilder sb = new StringBuilder();
         sb.append("{\n");
@@ -323,6 +359,9 @@ public final class ScalpelReport {
                 .append(jsonString(Version.version()))
                 .append(",\n");
         sb.append("  \"baseBranch\": ").append(jsonString(baseBranch)).append(",\n");
+        if (decisionId != null) {
+            sb.append("  \"decisionId\": ").append(jsonString(decisionId)).append(",\n");
+        }
         if (status != null) {
             sb.append("  \"status\": ").append(jsonString(status)).append(",\n");
         }
@@ -537,6 +576,7 @@ public final class ScalpelReport {
 
     public static class Builder {
         private String baseBranch;
+        private String decisionId;
         private String status;
         private String reason;
         private boolean fullBuildTriggered;
@@ -554,6 +594,11 @@ public final class ScalpelReport {
 
         public Builder baseBranch(String baseBranch) {
             this.baseBranch = baseBranch;
+            return this;
+        }
+
+        public Builder decisionId(String decisionId) {
+            this.decisionId = decisionId;
             return this;
         }
 
@@ -638,6 +683,7 @@ public final class ScalpelReport {
             }
             return new ScalpelReport(
                     baseBranch,
+                    decisionId,
                     status,
                     reason,
                     fullBuildTriggered,

--- a/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
+++ b/core/src/main/resources/eu/maveniverse/maven/scalpel/core/scalpel-report-v2.schema.json
@@ -31,6 +31,10 @@
       "type": "string",
       "description": "The base branch that was compared against (e.g. 'origin/main')."
     },
+    "decisionId": {
+      "type": "string",
+      "description": "Optional. A stable SHA-256 identity of the decision: the merge-base and head commits, the resolved decision-shaping configuration, and the resulting build set. Quotable in bug reports to correlate a failure back to the Scalpel decision that produced it."
+    },
     "fullBuildTriggered": {
       "type": "boolean",
       "description": "True if a changed file matched a fullBuildTriggers pattern, causing a full reactor build."

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -9,6 +9,7 @@ package eu.maveniverse.maven.scalpel.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -477,6 +478,52 @@ class ScalpelConfigurationTest {
             assertFalse(config.isModeShadow(), "mode=" + mode + " must not be shadow");
             assertEquals("report".equals(mode), config.isPassiveMode(), "only report is passive besides shadow");
         }
+    }
+
+    @Test
+    void verifyFullBuild_falseByDefaultAndStrictlyParsed() {
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(new Properties(), new Properties());
+        assertFalse(config.isVerifyFullBuild(), "verifyFullBuild must default to false when unset");
+
+        Properties on = new Properties();
+        on.setProperty("scalpel.verifyFullBuild", "true");
+        assertTrue(ScalpelConfiguration.fromProperties(on, new Properties()).isVerifyFullBuild());
+
+        Properties garbage = new Properties();
+        garbage.setProperty("scalpel.verifyFullBuild", "yes");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ScalpelConfiguration.fromProperties(garbage, new Properties()),
+                "verifyFullBuild must be strictly boolean like every other flag");
+    }
+
+    @Test
+    void decisionFingerprint_isStableAndSensitiveToDecisionInputs() {
+        Properties base = new Properties();
+        base.setProperty("scalpel.baseBranch", "origin/main");
+        ScalpelConfiguration config = ScalpelConfiguration.fromProperties(base, new Properties());
+        assertEquals(
+                config.decisionFingerprint(),
+                ScalpelConfiguration.fromProperties(base, new Properties()).decisionFingerprint(),
+                "same resolved config must yield the same fingerprint");
+
+        Properties withInclude = new Properties();
+        withInclude.setProperty("scalpel.baseBranch", "origin/main");
+        withInclude.setProperty("scalpel.includePaths", "module-a/**");
+        assertNotEquals(
+                config.decisionFingerprint(),
+                ScalpelConfiguration.fromProperties(withInclude, new Properties())
+                        .decisionFingerprint(),
+                "a decision-shaping property must change the fingerprint");
+
+        Properties withReportFile = new Properties();
+        withReportFile.setProperty("scalpel.baseBranch", "origin/main");
+        withReportFile.setProperty("scalpel.reportFile", "elsewhere/report.json");
+        assertEquals(
+                config.decisionFingerprint(),
+                ScalpelConfiguration.fromProperties(withReportFile, new Properties())
+                        .decisionFingerprint(),
+                "an output-shaping property must NOT change the fingerprint");
     }
 
     // ---------------------------------------------------------------

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelConfigurationTest.java
@@ -498,6 +498,25 @@ class ScalpelConfigurationTest {
     }
 
     @Test
+    void decisionFingerprint_valuesContainingDelimitersCannotCollide() {
+        // The encoding uses '=' and ';' structurally; both are legal in list-valued
+        // properties (paths with ';', patterns with '='), so two distinct resolved
+        // configurations must still produce distinct fingerprints (#177 review).
+        Properties first = new Properties();
+        first.setProperty("scalpel.fullBuildTriggers", "x;excludePaths=y");
+        first.setProperty("scalpel.excludePaths", "z");
+
+        Properties second = new Properties();
+        second.setProperty("scalpel.fullBuildTriggers", "x");
+        second.setProperty("scalpel.excludePaths", "y;excludePaths=z");
+
+        assertNotEquals(
+                ScalpelConfiguration.fromProperties(first, new Properties()).decisionFingerprint(),
+                ScalpelConfiguration.fromProperties(second, new Properties()).decisionFingerprint(),
+                "delimiter characters inside values must not make two configs collide");
+    }
+
+    @Test
     void decisionFingerprint_isStableAndSensitiveToDecisionInputs() {
         Properties base = new Properties();
         base.setProperty("scalpel.baseBranch", "origin/main");

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportSchemaTest.java
@@ -231,6 +231,7 @@ class ScalpelReportSchemaTest {
         timings.increment(Timings.OP_GIT_BLOBS_READ, 1);
         ScalpelReport maximalReport = ScalpelReport.builder()
                 .baseBranch("origin/main")
+                .decisionId("deadbeef")
                 .status("skipped")
                 .reason("drift guard fixture")
                 .fullBuildTriggered(false)

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -725,6 +725,16 @@ class ScalpelReportTest {
     }
 
     @Test
+    void computeDecisionId_newlineInPathCannotForgeTwoPaths() {
+        // A path containing a literal newline must not hash identically to the same
+        // content split into two paths: the separator itself must be unambiguous.
+        assertNotEquals(
+                ScalpelReport.computeDecisionId("m", "h", "f", java.util.List.of("module-a\nmodule-b")),
+                ScalpelReport.computeDecisionId("m", "h", "f", java.util.List.of("module-a", "module-b")),
+                "a forged newline inside one path must not collide with two real paths");
+    }
+
+    @Test
     void computeDecisionId_isOrderInsensitiveOverTheBuildSet() {
         assertEquals(
                 ScalpelReport.computeDecisionId("m", "h", "f", List.of("module-a", "module-b")),

--- a/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
+++ b/core/src/test/java/eu/maveniverse/maven/scalpel/core/ScalpelReportTest.java
@@ -10,6 +10,7 @@ package eu.maveniverse.maven.scalpel.core;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -21,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -695,5 +697,64 @@ class ScalpelReportTest {
             String schema = new String(is.readAllBytes(), StandardCharsets.UTF_8);
             assertTrue(schema.contains("\"const\": \"2\""), "schema must declare version 2");
         }
+    }
+
+    // ---------------------------------------------------------------
+    // decisionId (#101): a stable, quotable fingerprint of one decision
+    // ---------------------------------------------------------------
+
+    @Test
+    void computeDecisionId_isDeterministicAndSensitiveToEveryInput() {
+        List<String> buildSet = List.of("module-b", "module-a");
+
+        String id = ScalpelReport.computeDecisionId("mergebase1", "head1", "fingerprint1", buildSet);
+        assertEquals(
+                id,
+                ScalpelReport.computeDecisionId("mergebase1", "head1", "fingerprint1", buildSet),
+                "same inputs must yield the same id");
+        assertEquals(
+                64,
+                id.length(),
+                "the id is the SHA-256 hex digest so a prefix collision cannot be mistaken for a repeat decision");
+        assertTrue(id.matches("[0-9a-f]{64}"), "hex digest");
+        assertNotEquals(id, ScalpelReport.computeDecisionId("mergebase2", "head1", "fingerprint1", buildSet));
+        assertNotEquals(id, ScalpelReport.computeDecisionId("mergebase1", "head2", "fingerprint1", buildSet));
+        assertNotEquals(id, ScalpelReport.computeDecisionId("mergebase1", "head1", "fingerprint2", buildSet));
+        assertNotEquals(
+                id, ScalpelReport.computeDecisionId("mergebase1", "head1", "fingerprint1", List.of("module-a")));
+    }
+
+    @Test
+    void computeDecisionId_isOrderInsensitiveOverTheBuildSet() {
+        assertEquals(
+                ScalpelReport.computeDecisionId("m", "h", "f", List.of("module-a", "module-b")),
+                ScalpelReport.computeDecisionId("m", "h", "f", List.of("module-b", "module-a")),
+                "reactor order must not change the decision identity");
+    }
+
+    @Test
+    void computeDecisionId_toleratesNullGitIdsForUnmeasuredRuns() {
+        assertDoesNotThrow(() -> ScalpelReport.computeDecisionId(null, null, "f", List.of("module-a")));
+    }
+
+    @Test
+    void toJson_decisionIdRoundTripsAndIsOmittedWhenAbsent() {
+        ScalpelReport withId = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .decisionId("abc123")
+                .build();
+        assertEquals("abc123", parsed(withId).get("decisionId"));
+
+        ScalpelReport withoutId = ScalpelReport.builder()
+                .baseBranch("origin/main")
+                .fullBuildTriggered(false)
+                .build();
+        assertFalse(parsed(withoutId).containsKey("decisionId"), "decisionId must be omitted when not computed");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> parsed(ScalpelReport report) {
+        return (Map<String, Object>) ScalpelReportSchemaTest.Json.parse(report.toJson());
     }
 }

--- a/docs/CI-RECIPES.md
+++ b/docs/CI-RECIPES.md
@@ -223,6 +223,41 @@ pipeline {
 }
 ```
 
+## Scheduled Verification Job
+
+A nightly job proving the trim decision against the full build (issue #101): every module builds and tests; if a module Scalpel would have skipped fails, the job fails naming the module, the skip reason and the `decisionId`.
+
+```yaml
+name: scalpel-verify
+on:
+  schedule:
+    - cron: "23 2 * * *" # nightly; avoid the top of the hour
+  workflow_dispatch: {}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Full build with Scalpel verification
+        run: mvn verify -Dscalpel.verifyFullBuild=true -Dscalpel.baseBranch=origin/main
+      - name: Upload shadow artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scalpel-shadow
+          path: |
+            target/scalpel-shadow.json
+            target/scalpel-shadow-history.jsonl
+```
+
 ## Shallow Clone Handling
 
 In CI environments with shallow clones, unshallow the checkout first, then fetch the base branch:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -39,6 +39,7 @@ Properties defined in a project POM are deliberately not read. Scalpel is config
 | `scalpel.failSafe` | `true` | On error, fall back to a full build instead of failing |
 | `scalpel.maxResourceFileSize` | `10 MB` | Maximum size in bytes for a resource file (resources larger than this are skipped with a warning) |
 | `scalpel.explain` | `false` | Enable explain mode. This adds per-module decision evidence to the report |
+| `scalpel.verifyFullBuild` | `false` | Run the full build under the shadow observation and fail it when a module Scalpel would have skipped fails, naming the module, its skip reason and the decisionId. Overrides reactor-modifying modes |
 
 ## Local Developer Usage
 
@@ -100,6 +101,7 @@ Run it on a few representative pull requests, then read `estimatedSecondsSaved` 
 | `mode` | string | Always `"shadow"` |
 | `scalpelVersion` | string | Scalpel version that generated the document |
 | `baseBranch` | string or null | The base branch used for change detection; `null` when unconfigured |
+| `decisionId` | string or null | The stable decision identity, present whenever a decision was computed |
 | `timestamp` | string | ISO-8601 instant of the session end |
 | `changedFilesCount` | number | Size of the detected changeset |
 | `wouldHaveBuilt` | string[] | Module paths trim mode would have kept in the reactor |
@@ -111,6 +113,16 @@ Run it on a few representative pull requests, then read `estimatedSecondsSaved` 
 When a shadow run bails out before any measurement (no base branch, not a git repository, disable triggers, a full-build trigger, or a fail-safe error), the document is overwritten with a minimal status document (`status` and `reason`) so a previous run's measurement can never be mistaken for current results, mirroring the JSON report's semantics. The history file is appended only by measured runs, so a gap there means "not measured", never "measured zero".
 
 One semantic note: `wouldHaveSkipped` mirrors the trim decision (built from the full affected set). The JSON report's `skippedModules`, written in the same run, uses the report's own categorization. The two coincide unless managed-dependency changes transitively affect modules, in which case shadow reports what trim would do and the report keeps its classification.
+
+## Verify Full Build
+
+`-Dscalpel.verifyFullBuild=true` answers "was Scalpel right?" from a single scheduled run: the full build executes under the shadow observation (reactor untouched, all tests run, whatever the configured mode was; trim and skip-tests are overridden with a warning), and at the end the run fails if any module Scalpel would have skipped failed, naming each module, the reason it was judged skippable, and the `decisionId` so the failure is quotable and correlatable in a bug report.
+
+```bash
+mvn verify -Dscalpel.verifyFullBuild=true -Dscalpel.baseBranch=origin/main
+```
+
+Every run in every mode also emits a `decisionId` in the JSON report (and in the shadow document and history line): the SHA-256 identity of the merge-base commit, the head commit, the resolved decision-shaping configuration, and the resulting build set. The same decision always produces the same id; a changed diff, configuration or build set produces a different one.
 
 ## Full Build Triggers
 

--- a/docs/REPORT-FORMAT.md
+++ b/docs/REPORT-FORMAT.md
@@ -117,6 +117,7 @@ The report follows a versioned JSON schema. A [JSON Schema](../core/src/main/res
 | `version` | string | Schema version (`"2"`) |
 | `scalpelVersion` | string | Scalpel version that generated this report |
 | `baseBranch` | string | The base branch used for change detection |
+| `decisionId` | string | *(optional)* Stable SHA-256 identity of the decision (merge-base, head, decision-shaping config, build set); quotable in bug reports |
 | `fullBuildTriggered` | boolean | `true` if a full build was triggered (e.g., by `fullBuildTriggers`) |
 | `triggerFile` | string or null | Path of the file that triggered a full build; `null` when no full build was triggered |
 | `changedFiles` | string[] | List of changed files (relative to reactor root) |

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/AnalysisContext.java
@@ -36,6 +36,9 @@ final class AnalysisContext {
      */
     final List<MavenProject> filteredBuildSet;
 
+    /** The stable decision identity for this run, or null when not computed (#101). */
+    final String decisionId;
+
     private AnalysisContext(Builder builder) {
         this.changedFiles = builder.changedFiles;
         this.changedProperties = builder.changedProperties;
@@ -51,6 +54,8 @@ final class AnalysisContext {
         this.evidence = builder.evidence;
         this.trimResult = builder.trimResult;
         this.filteredBuildSet = builder.filteredBuildSet;
+
+        this.decisionId = builder.decisionId;
     }
 
     static Builder builder(
@@ -71,9 +76,11 @@ final class AnalysisContext {
             Set<String> changedProperties,
             Set<String> changedManagedDepGAs,
             Set<String> changedManagedPluginGAs,
-            Set<String> unmatchedPomPaths) {
+            Set<String> unmatchedPomPaths,
+            String decisionId) {
         return builder(changedFiles, changedProperties, changedManagedDepGAs, changedManagedPluginGAs)
                 .unmatchedPomPaths(unmatchedPomPaths)
+                .decisionId(decisionId)
                 .build();
     }
 
@@ -92,6 +99,8 @@ final class AnalysisContext {
         private Map<MavenProject, List<String>> evidence = Map.of();
         private TrimResult trimResult;
         private List<MavenProject> filteredBuildSet;
+
+        private String decisionId;
 
         private Builder() {}
 
@@ -142,6 +151,11 @@ final class AnalysisContext {
 
         Builder filteredBuildSet(List<MavenProject> filteredBuildSet) {
             this.filteredBuildSet = filteredBuildSet;
+            return this;
+        }
+
+        Builder decisionId(String decisionId) {
+            this.decisionId = decisionId;
             return this;
         }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -14,13 +14,10 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttribute;
@@ -35,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -336,31 +334,27 @@ class PomChangeAnalyzer {
      * <p>When both lists are empty, all changes are accepted (the filter is a no-op).
      */
     static class ChangeFilter {
-        private static final String GLOB_PREFIX = "glob:";
+        private final List<Pattern> excludePatterns;
+        private final List<Pattern> includePatterns;
 
-        private final List<PathMatcher> excludeMatchers;
-        private final List<PathMatcher> includeMatchers;
-
-        ChangeFilter(List<String> excludePatterns, List<String> includePatterns) {
-            FileSystem fs = FileSystems.getDefault();
-            this.excludeMatchers = compileMatchers(excludePatterns, fs);
-            this.includeMatchers = compileMatchers(includePatterns, fs);
+        ChangeFilter(List<String> excludeGlobs, List<String> includeGlobs) {
+            this.excludePatterns = compileGlobs(excludeGlobs);
+            this.includePatterns = compileGlobs(includeGlobs);
         }
 
         /** Returns {@code true} if the change path should be considered (not excluded). */
         boolean accepts(String changePath) {
-            if (excludeMatchers.isEmpty() && includeMatchers.isEmpty()) {
+            if (excludePatterns.isEmpty() && includePatterns.isEmpty()) {
                 return true;
             }
-            Path path = Path.of(changePath);
             // Include overrides exclude
-            for (PathMatcher m : includeMatchers) {
-                if (m.matches(path)) {
+            for (Pattern p : includePatterns) {
+                if (p.matcher(changePath).matches()) {
                     return true;
                 }
             }
-            for (PathMatcher m : excludeMatchers) {
-                if (m.matches(path)) {
+            for (Pattern p : excludePatterns) {
+                if (p.matcher(changePath).matches()) {
                     return false;
                 }
             }
@@ -368,18 +362,59 @@ class PomChangeAnalyzer {
         }
 
         boolean isActive() {
-            return !excludeMatchers.isEmpty() || !includeMatchers.isEmpty();
+            return !excludePatterns.isEmpty() || !includePatterns.isEmpty();
         }
 
-        private static List<PathMatcher> compileMatchers(List<String> patterns, FileSystem fs) {
-            if (patterns == null || patterns.isEmpty()) {
+        /**
+         * Converts glob patterns to regexes.  Change paths are logical
+         * (e.g.&nbsp;{@code managedDependencies/com.foo:bar}) and may contain
+         * characters like {@code :} that are illegal in Windows file paths.
+         * Using {@code java.nio.file.PathMatcher} would fail on Windows,
+         * so we translate globs to {@link Pattern} ourselves.
+         */
+        private static List<Pattern> compileGlobs(List<String> globs) {
+            if (globs == null || globs.isEmpty()) {
                 return List.of();
             }
-            List<PathMatcher> matchers = new ArrayList<>(patterns.size());
-            for (String pattern : patterns) {
-                matchers.add(fs.getPathMatcher(GLOB_PREFIX + pattern));
+            List<Pattern> patterns = new ArrayList<>(globs.size());
+            for (String glob : globs) {
+                patterns.add(Pattern.compile(globToRegex(glob)));
             }
-            return matchers;
+            return patterns;
+        }
+
+        /**
+         * Translates a simple glob (supporting {@code *}, {@code **}, and
+         * {@code ?}) into a regex string.  {@code /} is matched literally.
+         */
+        static String globToRegex(String glob) {
+            StringBuilder sb = new StringBuilder();
+            int i = 0;
+            while (i < glob.length()) {
+                char c = glob.charAt(i);
+                if (c == '*') {
+                    if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
+                        // ** matches everything including /
+                        sb.append(".*");
+                        i += 2;
+                        // skip trailing / after **
+                        if (i < glob.length() && glob.charAt(i) == '/') {
+                            i++;
+                        }
+                    } else {
+                        // * matches everything except /
+                        sb.append("[^/]*");
+                        i++;
+                    }
+                } else if (c == '?') {
+                    sb.append("[^/]");
+                    i++;
+                } else {
+                    sb.append(Pattern.quote(String.valueOf(c)));
+                    i++;
+                }
+            }
+            return sb.toString();
         }
     }
 

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -111,7 +112,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             List<String> selectedProjects = session.getRequest().getSelectedProjects();
             if (selectedProjects != null && !selectedProjects.isEmpty()) {
                 logger.info("Scalpel {} disabled due to -pl project selection", version);
-                if (config.isModeShadow() || config.isVerifyFullBuild()) {
+                if (monitoredRun(config)) {
                     // This exit predates any measurement; a previous run's shadow document
                     // must not survive it (#89 semantics, shadow twin).
                     writeShadowStatus(
@@ -145,7 +146,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // Detect changes
             ChangeDetectionResult result = scalpelCore.detectChanges(reactorRoot, config, allPomPaths, timings);
             if (result == null) {
-                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                if (passiveRun(config)) {
                     String skipReason = scalpelCore.getLastDetectionSkipReason();
                     if (skipReason != null) {
                         writeStatusReport(config, reactorRoot, "skipped", skipReason);
@@ -162,7 +163,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 if (config.isBuildAllIfNoChanges()) {
                     logger.info("Scalpel: No changes detected, building all modules (buildAllIfNoChanges=true)");
                 }
-                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                if (passiveRun(config)) {
                     writeStatusReport(config, reactorRoot, "skipped", "no changes detected");
                 }
                 return;
@@ -172,7 +173,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Check disable triggers (bail out entirely if any changed file matches)
             if (matchesDisableTrigger(changedFiles, config)) {
-                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                if (passiveRun(config)) {
                     writeStatusReport(config, reactorRoot, "skipped", "disabled by disableTriggers match");
                 }
                 return;
@@ -182,7 +183,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             changedFiles = filterExcludedPaths(changedFiles, config);
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: All changed files excluded by path filters, building all modules");
-                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                if (passiveRun(config)) {
                     writeStatusReport(config, reactorRoot, "skipped", "all changed files excluded by path filters");
                 }
                 return;
@@ -191,7 +192,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // Check full build triggers
             String triggerFile = findFullBuildTrigger(changedFiles, config);
             if (triggerFile != null) {
-                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                if (passiveRun(config)) {
                     writeFullBuildReport(config, reactorRoot, triggerFile, changedFiles);
                 }
                 return;
@@ -269,7 +270,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     if (config.isFailSafe()) {
                         logger.warn("Scalpel: Error analyzing POM changes, building all modules: {}", e.getMessage());
                         logger.debug("POM analysis error details", e);
-                        if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                        if (passiveRun(config)) {
                             writeFailedStatusReport(config, reactorRoot, "error analyzing POM changes");
                         }
                         return;
@@ -318,8 +319,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             if (directlyAffected.isEmpty() && oldEffectiveModels.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
-                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
-                    if (config.isModeShadow() || config.isVerifyFullBuild()) {
+                if (passiveRun(config)) {
+                    if (monitoredRun(config)) {
                         writeShadowStatus(reactorRoot, "skipped", "no modules affected by changes");
                     }
                     writeReport(
@@ -332,11 +333,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                     changedManagedDepGAs,
                                     changedManagedPluginGAs,
                                     unmatchedPomPaths,
-                                    ScalpelReport.computeDecisionId(
-                                            result.getMergeBaseId(),
-                                            result.getHeadId(),
-                                            config.decisionFingerprint(),
-                                            List.of())),
+                                    decisionIdFor(result, config, reactorRoot, List.<MavenProject>of())),
                             timings,
                             analysisStartNano);
                 } else if (config.isModeSkipTests()) {
@@ -389,8 +386,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             if (directlyAffected.isEmpty() && transitivelyAffected.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
-                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
-                    if (config.isModeShadow() || config.isVerifyFullBuild()) {
+                if (passiveRun(config)) {
+                    if (monitoredRun(config)) {
                         writeShadowStatus(reactorRoot, "skipped", "no modules affected by changes");
                     }
                     writeReport(
@@ -403,11 +400,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                     changedManagedDepGAs,
                                     changedManagedPluginGAs,
                                     unmatchedPomPaths,
-                                    ScalpelReport.computeDecisionId(
-                                            result.getMergeBaseId(),
-                                            result.getHeadId(),
-                                            config.decisionFingerprint(),
-                                            List.of())),
+                                    decisionIdFor(result, config, reactorRoot, List.<MavenProject>of())),
                             timings,
                             analysisStartNano);
                 } else if (config.isModeSkipTests()) {
@@ -442,8 +435,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
                 if (allAffected.isEmpty()) {
                     logger.info("Scalpel: No modules match includePaths filters");
-                    if (config.isPassiveMode() || config.isVerifyFullBuild()) {
-                        if (config.isModeShadow() || config.isVerifyFullBuild()) {
+                    if (passiveRun(config)) {
+                        if (monitoredRun(config)) {
                             writeShadowStatus(reactorRoot, "skipped", "no modules match includePaths filters");
                         }
                         writeReport(
@@ -456,11 +449,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                         changedManagedDepGAs,
                                         changedManagedPluginGAs,
                                         unmatchedPomPaths,
-                                        ScalpelReport.computeDecisionId(
-                                                result.getMergeBaseId(),
-                                                result.getHeadId(),
-                                                config.decisionFingerprint(),
-                                                List.of())),
+                                        decisionIdFor(result, config, reactorRoot, List.<MavenProject>of())),
                                 timings,
                                 analysisStartNano);
                     } else if (config.isModeSkipTests()) {
@@ -475,7 +464,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 writeImpactedLog(config, reactorRoot, allAffected);
             }
 
-            if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+            if (passiveRun(config)) {
                 // Compute upstream/downstream categorization for report enrichment
                 // Use directlyAffected here (not allAffected) to preserve correct DOWNSTREAM categorization;
                 // transitively affected modules are added to the report separately via addTransitivelyAffectedModules
@@ -501,12 +490,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 // by construction; when nothing is transitively affected, the report branch
                 // above already computed that exact set.
                 boolean verify = config.isVerifyFullBuild();
-                java.util.function.Function<MavenProject, String> moduleKey = project -> {
-                    String path = relativePath(reactorRoot, project);
-                    // The root aggregator relativizes to the empty string; report it as
-                    // "." like the impacted log does (#84) so every module has a name.
-                    return path.isEmpty() ? "." : path;
-                };
+                // The root aggregator relativizes to the empty string; every decision-side
+                // module name is normalized to "." (like the impacted log, #84) so all
+                // modes hash and print the same names.
+                java.util.function.Function<MavenProject, String> moduleKey =
+                        project -> moduleKeyOf(reactorRoot, project);
                 Set<String> wouldHaveBuilt = null;
                 Set<String> wouldHaveSkipped = null;
                 String decisionId;
@@ -557,21 +545,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     // Plain report run: the decision identity covers the set this report
                     // describes (the enrichment trim result, or the affected set when the
                     // reactor had nothing to enrich).
-                    Set<String> reportPaths = new LinkedHashSet<>();
-                    if (trimResult != null) {
-                        for (MavenProject project : trimResult.getBuildSet()) {
-                            reportPaths.add(relativePath(reactorRoot, project));
-                        }
-                    } else {
-                        for (MavenProject project : directlyAffected) {
-                            reportPaths.add(relativePath(reactorRoot, project));
-                        }
-                        for (MavenProject project : transitivelyAffected.keySet()) {
-                            reportPaths.add(relativePath(reactorRoot, project));
-                        }
-                    }
-                    decisionId = ScalpelReport.computeDecisionId(
-                            result.getMergeBaseId(), result.getHeadId(), config.decisionFingerprint(), reportPaths);
+                    Collection<MavenProject> decisionProjects = trimResult != null
+                            ? trimResult.getBuildSet()
+                            : concat(directlyAffected, transitivelyAffected.keySet());
+                    decisionId = decisionIdFor(result, config, reactorRoot, decisionProjects);
                 }
 
                 writeReport(
@@ -694,10 +671,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 }
                 // Write the same JSON report as report mode, so the skipped set (allProjects
                 // minus buildSet) is reviewable alongside the green trimmed build (#91)
-                Set<String> builtPaths = new LinkedHashSet<>();
-                for (MavenProject project : buildSet) {
-                    builtPaths.add(relativePath(reactorRoot, project));
-                }
+                String trimDecisionId = decisionIdFor(result, config, reactorRoot, buildSet);
                 writeReport(
                         config,
                         reactorRoot,
@@ -713,11 +687,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .transitivelyAffected(transitivelyAffected)
                                 .trimResult(trimResult)
                                 .filteredBuildSet(buildSet)
-                                .decisionId(ScalpelReport.computeDecisionId(
-                                        result.getMergeBaseId(),
-                                        result.getHeadId(),
-                                        config.decisionFingerprint(),
-                                        builtPaths))
+                                .decisionId(trimDecisionId)
                                 .build(),
                         timings,
                         analysisStartNano);
@@ -742,7 +712,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (config.isFailSafe()) {
                 logger.warn("Scalpel: Unexpected error, building all modules: {}", e.getMessage());
                 logger.debug("Unexpected error details", e);
-                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                if (passiveRun(config)) {
                     writeFailedStatusReport(config, reactorRoot, "unexpected error: " + e.getMessage());
                 }
                 return;
@@ -1697,7 +1667,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         try {
             // Written first and independently: a failure of the report write below must
             // not leave a previous run's shadow measurement in place.
-            if (config.isModeShadow() || config.isVerifyFullBuild()) {
+            if (monitoredRun(config)) {
                 writeShadowStatus(reactorRoot, status, reason);
             }
             ScalpelReport report = ScalpelReport.builder()
@@ -1752,7 +1722,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         try {
             // Written first and independently: a failure of the report write below must
             // not leave a previous run's shadow measurement in place.
-            if (config.isModeShadow() || config.isVerifyFullBuild()) {
+            if (monitoredRun(config)) {
                 writeShadowStatus(reactorRoot, "skipped", "full build triggered by " + triggerFile);
             }
             report.writeToFile(reactorRoot, config.getReportFile());
@@ -1760,6 +1730,46 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         } catch (IOException e) {
             handleWriteFailure(config, "Failed to write report", e);
         }
+    }
+
+    /** True when the run leaves the reactor untouched and writes report artifacts. */
+    private static boolean passiveRun(ScalpelConfiguration config) {
+        return config.isPassiveMode() || config.isVerifyFullBuild();
+    }
+
+    /** True when the session gets a ShadowBuildMonitor installed (shadow or verify). */
+    private static boolean monitoredRun(ScalpelConfiguration config) {
+        return config.isModeShadow() || config.isVerifyFullBuild();
+    }
+
+    /** Decision-side module name: relative path, "." for the reactor root (#84, #101). */
+    private static String moduleKeyOf(Path reactorRoot, MavenProject project) {
+        String path = relativePath(reactorRoot, project);
+        return path.isEmpty() ? "." : path;
+    }
+
+    /**
+     * The stable decision identity for the given build-set projects. Every mode collects
+     * module names through {@link #moduleKeyOf}, so the same decision produces the same id
+     * whether it was computed by trim, report, shadow or verify (#101).
+     */
+    private static String decisionIdFor(
+            ChangeDetectionResult result,
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            Collection<MavenProject> projects) {
+        List<String> paths = new ArrayList<>();
+        for (MavenProject project : projects) {
+            paths.add(moduleKeyOf(reactorRoot, project));
+        }
+        return ScalpelReport.computeDecisionId(
+                result.getMergeBaseId(), result.getHeadId(), config.decisionFingerprint(), paths);
+    }
+
+    private static <T> Collection<T> concat(Collection<T> first, Collection<T> second) {
+        List<T> combined = new ArrayList<>(first);
+        combined.addAll(second);
+        return combined;
     }
 
     private void writeReport(

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -111,7 +111,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             List<String> selectedProjects = session.getRequest().getSelectedProjects();
             if (selectedProjects != null && !selectedProjects.isEmpty()) {
                 logger.info("Scalpel {} disabled due to -pl project selection", version);
-                if (config.isModeShadow()) {
+                if (config.isModeShadow() || config.isVerifyFullBuild()) {
                     // This exit predates any measurement; a previous run's shadow document
                     // must not survive it (#89 semantics, shadow twin).
                     writeShadowStatus(
@@ -145,7 +145,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // Detect changes
             ChangeDetectionResult result = scalpelCore.detectChanges(reactorRoot, config, allPomPaths, timings);
             if (result == null) {
-                if (config.isPassiveMode()) {
+                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
                     String skipReason = scalpelCore.getLastDetectionSkipReason();
                     if (skipReason != null) {
                         writeStatusReport(config, reactorRoot, "skipped", skipReason);
@@ -162,7 +162,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 if (config.isBuildAllIfNoChanges()) {
                     logger.info("Scalpel: No changes detected, building all modules (buildAllIfNoChanges=true)");
                 }
-                if (config.isPassiveMode()) {
+                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
                     writeStatusReport(config, reactorRoot, "skipped", "no changes detected");
                 }
                 return;
@@ -172,7 +172,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Check disable triggers (bail out entirely if any changed file matches)
             if (matchesDisableTrigger(changedFiles, config)) {
-                if (config.isPassiveMode()) {
+                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
                     writeStatusReport(config, reactorRoot, "skipped", "disabled by disableTriggers match");
                 }
                 return;
@@ -182,7 +182,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             changedFiles = filterExcludedPaths(changedFiles, config);
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: All changed files excluded by path filters, building all modules");
-                if (config.isPassiveMode()) {
+                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
                     writeStatusReport(config, reactorRoot, "skipped", "all changed files excluded by path filters");
                 }
                 return;
@@ -191,7 +191,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // Check full build triggers
             String triggerFile = findFullBuildTrigger(changedFiles, config);
             if (triggerFile != null) {
-                if (config.isPassiveMode()) {
+                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
                     writeFullBuildReport(config, reactorRoot, triggerFile, changedFiles);
                 }
                 return;
@@ -269,7 +269,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     if (config.isFailSafe()) {
                         logger.warn("Scalpel: Error analyzing POM changes, building all modules: {}", e.getMessage());
                         logger.debug("POM analysis error details", e);
-                        if (config.isPassiveMode()) {
+                        if (config.isPassiveMode() || config.isVerifyFullBuild()) {
                             writeFailedStatusReport(config, reactorRoot, "error analyzing POM changes");
                         }
                         return;
@@ -318,8 +318,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             if (directlyAffected.isEmpty() && oldEffectiveModels.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
-                if (config.isPassiveMode()) {
-                    if (config.isModeShadow()) {
+                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                    if (config.isModeShadow() || config.isVerifyFullBuild()) {
                         writeShadowStatus(reactorRoot, "skipped", "no modules affected by changes");
                     }
                     writeReport(
@@ -331,7 +331,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                     changedProperties,
                                     changedManagedDepGAs,
                                     changedManagedPluginGAs,
-                                    unmatchedPomPaths),
+                                    unmatchedPomPaths,
+                                    ScalpelReport.computeDecisionId(
+                                            result.getMergeBaseId(),
+                                            result.getHeadId(),
+                                            config.decisionFingerprint(),
+                                            List.of())),
                             timings,
                             analysisStartNano);
                 } else if (config.isModeSkipTests()) {
@@ -384,8 +389,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             if (directlyAffected.isEmpty() && transitivelyAffected.isEmpty()) {
                 logger.info("Scalpel: No modules affected by changes");
-                if (config.isPassiveMode()) {
-                    if (config.isModeShadow()) {
+                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                    if (config.isModeShadow() || config.isVerifyFullBuild()) {
                         writeShadowStatus(reactorRoot, "skipped", "no modules affected by changes");
                     }
                     writeReport(
@@ -397,7 +402,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                     changedProperties,
                                     changedManagedDepGAs,
                                     changedManagedPluginGAs,
-                                    unmatchedPomPaths),
+                                    unmatchedPomPaths,
+                                    ScalpelReport.computeDecisionId(
+                                            result.getMergeBaseId(),
+                                            result.getHeadId(),
+                                            config.decisionFingerprint(),
+                                            List.of())),
                             timings,
                             analysisStartNano);
                 } else if (config.isModeSkipTests()) {
@@ -432,8 +442,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
                 if (allAffected.isEmpty()) {
                     logger.info("Scalpel: No modules match includePaths filters");
-                    if (config.isPassiveMode()) {
-                        if (config.isModeShadow()) {
+                    if (config.isPassiveMode() || config.isVerifyFullBuild()) {
+                        if (config.isModeShadow() || config.isVerifyFullBuild()) {
                             writeShadowStatus(reactorRoot, "skipped", "no modules match includePaths filters");
                         }
                         writeReport(
@@ -445,7 +455,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                         changedProperties,
                                         changedManagedDepGAs,
                                         changedManagedPluginGAs,
-                                        unmatchedPomPaths),
+                                        unmatchedPomPaths,
+                                        ScalpelReport.computeDecisionId(
+                                                result.getMergeBaseId(),
+                                                result.getHeadId(),
+                                                config.decisionFingerprint(),
+                                                List.of())),
                                 timings,
                                 analysisStartNano);
                     } else if (config.isModeSkipTests()) {
@@ -460,7 +475,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 writeImpactedLog(config, reactorRoot, allAffected);
             }
 
-            if (config.isPassiveMode()) {
+            if (config.isPassiveMode() || config.isVerifyFullBuild()) {
                 // Compute upstream/downstream categorization for report enrichment
                 // Use directlyAffected here (not allAffected) to preserve correct DOWNSTREAM categorization;
                 // transitively affected modules are added to the report separately via addTransitivelyAffectedModules
@@ -478,6 +493,87 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     mergeTrimReasons(evidence, trimResult);
                 }
 
+                // The would-be trim decision for shadow and verify runs (#92, #101), and the
+                // stable decision identity (#101) every report of this run carries. Computed
+                // before the report is written so the report and the shadow document quote
+                // the same id for the same run. The decision uses the same ReactorTrimmer
+                // call trim mode runs on the same inputs, so shadow and trim decisions agree
+                // by construction; when nothing is transitively affected, the report branch
+                // above already computed that exact set.
+                boolean verify = config.isVerifyFullBuild();
+                java.util.function.Function<MavenProject, String> moduleKey = project -> {
+                    String path = relativePath(reactorRoot, project);
+                    // The root aggregator relativizes to the empty string; report it as
+                    // "." like the impacted log does (#84) so every module has a name.
+                    return path.isEmpty() ? "." : path;
+                };
+                Set<String> wouldHaveBuilt = null;
+                Set<String> wouldHaveSkipped = null;
+                String decisionId;
+                if (config.isModeShadow() || verify) {
+                    TrimResult decision;
+                    if (trimResult != null && allAffected.equals(directlyAffected)) {
+                        decision = trimResult;
+                    } else {
+                        timings.start(Timings.PHASE_TRIM);
+                        try {
+                            decision = reactorTrimmer.computeBuildSet(
+                                    allAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
+                        } finally {
+                            timings.stop(Timings.PHASE_TRIM);
+                        }
+                    }
+                    wouldHaveBuilt = new LinkedHashSet<>();
+                    List<MavenProject> decisionBuildSet = decision.getBuildSet();
+                    if (!includeMatchers.isEmpty()) {
+                        // Mirror the post-computeBuildSet filter trim mode applies, so the
+                        // shadow decision is the set trim would actually build: downstream
+                        // modules outside the includePaths scope are dropped here too.
+                        Set<MavenProject> affected = allAffected;
+                        decisionBuildSet = new ArrayList<>(decisionBuildSet);
+                        decisionBuildSet.removeIf(project -> !affected.contains(project)
+                                && !decision.getUpstreamOnly().contains(project)
+                                && !matchesIncludePaths(project, includeMatchers, reactorRoot));
+                    }
+                    for (MavenProject project : decisionBuildSet) {
+                        wouldHaveBuilt.add(moduleKey.apply(project));
+                    }
+                    wouldHaveSkipped = new LinkedHashSet<>();
+                    for (MavenProject project : allProjects) {
+                        String path = moduleKey.apply(project);
+                        if (!wouldHaveBuilt.contains(path)) {
+                            wouldHaveSkipped.add(path);
+                        }
+                    }
+                    decisionId = ScalpelReport.computeDecisionId(
+                            result.getMergeBaseId(), result.getHeadId(), config.decisionFingerprint(), wouldHaveBuilt);
+                    if (verify && (config.isModeTrim() || config.isModeSkipTests())) {
+                        logger.warn(
+                                "Scalpel: verifyFullBuild forces a full build with the shadow observation;"
+                                        + " overriding mode={}",
+                                config.getMode());
+                    }
+                } else {
+                    // Plain report run: the decision identity covers the set this report
+                    // describes (the enrichment trim result, or the affected set when the
+                    // reactor had nothing to enrich).
+                    Set<String> reportPaths = new LinkedHashSet<>();
+                    if (trimResult != null) {
+                        for (MavenProject project : trimResult.getBuildSet()) {
+                            reportPaths.add(relativePath(reactorRoot, project));
+                        }
+                    } else {
+                        for (MavenProject project : directlyAffected) {
+                            reportPaths.add(relativePath(reactorRoot, project));
+                        }
+                        for (MavenProject project : transitivelyAffected.keySet()) {
+                            reportPaths.add(relativePath(reactorRoot, project));
+                        }
+                    }
+                    decisionId = ScalpelReport.computeDecisionId(
+                            result.getMergeBaseId(), result.getHeadId(), config.decisionFingerprint(), reportPaths);
+                }
+
                 writeReport(
                         config,
                         reactorRoot,
@@ -493,6 +589,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .transitivelyAffected(transitivelyAffected)
                                 .evidence(evidence)
                                 .trimResult(trimResult)
+                                .decisionId(decisionId)
                                 .build(),
                         timings,
                         analysisStartNano);
@@ -504,71 +601,39 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                     logExplainDecisions(allProjects, reportedModules, evidence);
                 }
-                if (config.isModeShadow()) {
-                    // Shadow mode (#92): hand the would-be trim decision to a monitor wrapped
-                    // around the session's ExecutionListener; the full build below runs
-                    // unmodified while per-module wall-clock and failures are recorded, and at
-                    // session end the join is written to target/scalpel-shadow.json plus one
-                    // JSONL history line. The decision uses the same ReactorTrimmer call trim
-                    // mode runs on the same inputs, so shadow and trim decisions agree by
-                    // construction; when nothing is transitively affected, the report branch
-                    // above already computed that exact set.
-                    TrimResult decision;
-                    if (trimResult != null && allAffected.equals(directlyAffected)) {
-                        decision = trimResult;
-                    } else {
-                        timings.start(Timings.PHASE_TRIM);
-                        try {
-                            decision = reactorTrimmer.computeBuildSet(
-                                    allAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
-                        } finally {
-                            timings.stop(Timings.PHASE_TRIM);
-                        }
+                if (wouldHaveBuilt != null) {
+                    // Shadow mode (#92) and verify mode (#101): hand the would-be decision to
+                    // a monitor wrapped around the session's ExecutionListener; the full build
+                    // below runs unmodified while per-module wall-clock and failures are
+                    // recorded, and at session end the join is written to
+                    // target/scalpel-shadow.json plus one JSONL history line. In verify mode
+                    // the monitor additionally fails the build when a would-have-skipped
+                    // module fails, naming each module and its skip reason.
+                    Map<String, String> skipReasons = new LinkedHashMap<>();
+                    for (String skipped : wouldHaveSkipped) {
+                        skipReasons.put(skipped, ScalpelReport.SKIP_REASON_NOT_AFFECTED);
                     }
-                    Set<String> wouldHaveBuilt = new LinkedHashSet<>();
-                    java.util.function.Function<MavenProject, String> moduleKey = project -> {
-                        String path = relativePath(reactorRoot, project);
-                        // The root aggregator relativizes to the empty string; report it as
-                        // "." like the impacted log does (#84) so every module has a name.
-                        return path.isEmpty() ? "." : path;
-                    };
-                    List<MavenProject> decisionBuildSet = decision.getBuildSet();
-                    if (!includeMatchers.isEmpty()) {
-                        // Mirror the post-computeBuildSet filter trim mode applies, so the
-                        // shadow decision is the set trim would actually build: downstream
-                        // modules outside the includePaths scope are dropped here too.
-                        Set<MavenProject> affected = allAffected;
-                        decisionBuildSet = new ArrayList<>(decisionBuildSet);
-                        decisionBuildSet.removeIf(project -> !affected.contains(project)
-                                && !decision.getUpstreamOnly().contains(project)
-                                && !matchesIncludePaths(project, includeMatchers, reactorRoot));
-                    }
-                    for (MavenProject project : decisionBuildSet) {
-                        wouldHaveBuilt.add(moduleKey.apply(project));
-                    }
-                    Set<String> wouldHaveSkipped = new LinkedHashSet<>();
-                    for (MavenProject project : allProjects) {
-                        String path = moduleKey.apply(project);
-                        if (!wouldHaveBuilt.contains(path)) {
-                            wouldHaveSkipped.add(path);
-                        }
-                    }
+                    ShadowDecision decision = verify
+                            ? ShadowDecision.verifying(wouldHaveBuilt, wouldHaveSkipped, skipReasons, decisionId)
+                            : ShadowDecision.measuring(wouldHaveBuilt, wouldHaveSkipped, decisionId);
                     session.getRequest()
                             .setExecutionListener(new ShadowBuildMonitor(
                                     session.getRequest().getExecutionListener(),
                                     reactorRoot,
-                                    wouldHaveBuilt,
-                                    wouldHaveSkipped,
                                     Version.version(),
                                     config.getBaseBranch(),
                                     changedFiles,
                                     System::nanoTime,
-                                    moduleKey));
+                                    moduleKey,
+                                    decision));
                     logger.info(
-                            "Scalpel: Shadow mode observing the full build: would build {} of {} modules, would skip {}",
+                            "Scalpel: {} observing the full build: would build {} of {} modules, would skip {}"
+                                    + " (decisionId {})",
+                            verify ? "Verify mode" : "Shadow mode",
                             wouldHaveBuilt.size(),
                             allProjects.size(),
-                            wouldHaveSkipped.size());
+                            wouldHaveSkipped.size(),
+                            decisionId);
                 }
                 return;
             }
@@ -629,6 +694,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 }
                 // Write the same JSON report as report mode, so the skipped set (allProjects
                 // minus buildSet) is reviewable alongside the green trimmed build (#91)
+                Set<String> builtPaths = new LinkedHashSet<>();
+                for (MavenProject project : buildSet) {
+                    builtPaths.add(relativePath(reactorRoot, project));
+                }
                 writeReport(
                         config,
                         reactorRoot,
@@ -644,6 +713,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 .transitivelyAffected(transitivelyAffected)
                                 .trimResult(trimResult)
                                 .filteredBuildSet(buildSet)
+                                .decisionId(ScalpelReport.computeDecisionId(
+                                        result.getMergeBaseId(),
+                                        result.getHeadId(),
+                                        config.decisionFingerprint(),
+                                        builtPaths))
                                 .build(),
                         timings,
                         analysisStartNano);
@@ -653,8 +727,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (config.isFailSafe()) {
                 logger.warn("Scalpel: {}, building all modules", e.getMessage());
                 logger.debug("ScalpelException details", e);
-                if (config.isModeShadow()) {
-                    // The monitor is the last thing the passive branch installs, so an
+                if (config.isModeShadow()
+                        || config
+                                .isVerifyFullBuild()) { // The monitor is the last thing the passive branch installs, so
+                    // an
                     // exception reaching here means nothing was measured; a previous run's
                     // shadow document must not survive the bail-out.
                     writeShadowStatus(reactorRoot, "failed", e.getMessage());
@@ -666,7 +742,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (config.isFailSafe()) {
                 logger.warn("Scalpel: Unexpected error, building all modules: {}", e.getMessage());
                 logger.debug("Unexpected error details", e);
-                if (config.isPassiveMode()) {
+                if (config.isPassiveMode() || config.isVerifyFullBuild()) {
                     writeFailedStatusReport(config, reactorRoot, "unexpected error: " + e.getMessage());
                 }
                 return;
@@ -1621,7 +1697,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         try {
             // Written first and independently: a failure of the report write below must
             // not leave a previous run's shadow measurement in place.
-            if (config.isModeShadow()) {
+            if (config.isModeShadow() || config.isVerifyFullBuild()) {
                 writeShadowStatus(reactorRoot, status, reason);
             }
             ScalpelReport report = ScalpelReport.builder()
@@ -1676,7 +1752,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         try {
             // Written first and independently: a failure of the report write below must
             // not leave a previous run's shadow measurement in place.
-            if (config.isModeShadow()) {
+            if (config.isModeShadow() || config.isVerifyFullBuild()) {
                 writeShadowStatus(reactorRoot, "skipped", "full build triggered by " + triggerFile);
             }
             report.writeToFile(reactorRoot, config.getReportFile());
@@ -1696,6 +1772,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             throws MavenExecutionException {
         ScalpelReport.Builder builder = ScalpelReport.builder()
                 .baseBranch(config.getBaseBranch())
+                .decisionId(ctx.decisionId)
                 .fullBuildTriggered(false)
                 .changedFiles(ctx.changedFiles)
                 .changedProperties(ctx.changedProperties)

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -332,6 +332,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 if (passiveRun(config)) {
                     if (monitoredRun(config)) {
                         writeShadowStatus(reactorRoot, "skipped", "no modules affected by changes");
+                        installEmptyDecisionMonitor(session, config, reactorRoot, allProjects, result, changedFiles);
                     }
                     writeReport(
                             config,
@@ -399,6 +400,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 if (passiveRun(config)) {
                     if (monitoredRun(config)) {
                         writeShadowStatus(reactorRoot, "skipped", "no modules affected by changes");
+                        installEmptyDecisionMonitor(session, config, reactorRoot, allProjects, result, changedFiles);
                     }
                     writeReport(
                             config,
@@ -448,6 +450,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     if (passiveRun(config)) {
                         if (monitoredRun(config)) {
                             writeShadowStatus(reactorRoot, "skipped", "no modules match includePaths filters");
+                            installEmptyDecisionMonitor(
+                                    session, config, reactorRoot, allProjects, result, changedFiles);
                         }
                         writeReport(
                                 config,
@@ -552,13 +556,31 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                                 config.getMode());
                     }
                 } else {
-                    // Plain report run: the decision identity covers the set this report
-                    // describes (the enrichment trim result, or the affected set when the
-                    // reactor had nothing to enrich).
-                    Collection<MavenProject> decisionProjects = trimResult != null
-                            ? trimResult.getBuildSet()
-                            : concat(directlyAffected, transitivelyAffected.keySet());
-                    decisionId = decisionIdFor(result, config, reactorRoot, decisionProjects);
+                    // Plain report run: compute the decision identity from the same set
+                    // shadow/verify would use (allAffected + trim + includePaths filter)
+                    // so that report-mode and shadow/verify-mode produce the same
+                    // decisionId for the same changeset (#177).
+                    TrimResult reportDecision;
+                    if (trimResult != null && allAffected.equals(directlyAffected)) {
+                        reportDecision = trimResult;
+                    } else {
+                        timings.start(Timings.PHASE_TRIM);
+                        try {
+                            reportDecision = reactorTrimmer.computeBuildSet(
+                                    allAffected, testOnlyModules, session.getProjectDependencyGraph(), config);
+                        } finally {
+                            timings.stop(Timings.PHASE_TRIM);
+                        }
+                    }
+                    List<MavenProject> reportBuildSet = reportDecision.getBuildSet();
+                    if (!includeMatchers.isEmpty()) {
+                        Set<MavenProject> affected = allAffected;
+                        reportBuildSet = new ArrayList<>(reportBuildSet);
+                        reportBuildSet.removeIf(project -> !affected.contains(project)
+                                && !reportDecision.getUpstreamOnly().contains(project)
+                                && !matchesIncludePaths(project, includeMatchers, reactorRoot));
+                    }
+                    decisionId = decisionIdFor(result, config, reactorRoot, reportBuildSet);
                 }
 
                 writeReport(
@@ -1766,6 +1788,50 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     /** True when the session gets a ShadowBuildMonitor installed (shadow or verify). */
     private static boolean monitoredRun(ScalpelConfiguration config) {
         return config.isModeShadow() || config.isVerifyFullBuild();
+    }
+
+    /**
+     * In verify mode with an empty build decision (nothing affected), installs a
+     * {@link ShadowBuildMonitor} so that if any module fails during the full build the false
+     * negative is detected (#177). Shadow-only mode skips the monitor — there is nothing
+     * to measure and the "skipped" status document covers the shadow contract.
+     */
+    private void installEmptyDecisionMonitor(
+            MavenSession session,
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            List<MavenProject> allProjects,
+            ChangeDetectionResult result,
+            Set<String> changedFiles) {
+        if (!config.isVerifyFullBuild()) {
+            return;
+        }
+        java.util.function.Function<MavenProject, String> moduleKey = project -> moduleKeyOf(reactorRoot, project);
+        Set<String> wouldHaveBuilt = Set.of();
+        Set<String> wouldHaveSkipped = new LinkedHashSet<>();
+        Map<String, String> skipReasons = new LinkedHashMap<>();
+        for (MavenProject project : allProjects) {
+            String path = moduleKey.apply(project);
+            wouldHaveSkipped.add(path);
+            skipReasons.put(path, ScalpelReport.SKIP_REASON_NOT_AFFECTED);
+        }
+        String decisionId = decisionIdFor(result, config, reactorRoot, List.<MavenProject>of());
+        ShadowDecision decision = ShadowDecision.verifying(wouldHaveBuilt, wouldHaveSkipped, skipReasons, decisionId);
+        session.getRequest()
+                .setExecutionListener(new ShadowBuildMonitor(
+                        session.getRequest().getExecutionListener(),
+                        reactorRoot,
+                        Version.version(),
+                        config.getBaseBranch(),
+                        changedFiles,
+                        System::nanoTime,
+                        moduleKey,
+                        decision));
+        logger.info(
+                "Scalpel: Verify mode observing the full build with empty decision:"
+                        + " would skip all {} modules (decisionId {})",
+                allProjects.size(),
+                decisionId);
     }
 
     /** Decision-side module name: relative path, "." for the reactor root (#84, #101). */

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -697,10 +697,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             if (config.isFailSafe()) {
                 logger.warn("Scalpel: {}, building all modules", e.getMessage());
                 logger.debug("ScalpelException details", e);
-                if (config.isModeShadow()
-                        || config
-                                .isVerifyFullBuild()) { // The monitor is the last thing the passive branch installs, so
-                    // an
+                if (monitoredRun(config)) {
+                    // The monitor is the last thing the passive branch installs, so an
                     // exception reaching here means nothing was measured; a previous run's
                     // shadow document must not survive the bail-out.
                     writeShadowStatus(reactorRoot, "failed", e.getMessage());

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -193,7 +193,12 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             String triggerFile = findFullBuildTrigger(changedFiles, config);
             if (triggerFile != null) {
                 if (passiveRun(config)) {
-                    writeFullBuildReport(config, reactorRoot, triggerFile, changedFiles);
+                    writeFullBuildReport(
+                            config,
+                            reactorRoot,
+                            triggerFile,
+                            changedFiles,
+                            decisionIdFor(result, config, reactorRoot, allProjects));
                 }
                 return;
             }
@@ -1709,10 +1714,15 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     }
 
     private void writeFullBuildReport(
-            ScalpelConfiguration config, Path reactorRoot, String triggerFile, Set<String> changedFiles)
+            ScalpelConfiguration config,
+            Path reactorRoot,
+            String triggerFile,
+            Set<String> changedFiles,
+            String decisionId)
             throws MavenExecutionException {
         ScalpelReport report = ScalpelReport.builder()
                 .baseBranch(config.getBaseBranch())
+                .decisionId(decisionId)
                 .fullBuildTriggered(true)
                 .triggerFile(triggerFile)
                 .changedFiles(changedFiles)

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowBuildMonitor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowBuildMonitor.java
@@ -15,6 +15,7 @@ import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -71,11 +72,39 @@ public final class ShadowBuildMonitor implements ExecutionListener {
     private final List<String> changedFiles;
     private final LongSupplier nanoClock;
     private final Function<MavenProject, String> moduleKey;
+    private final String decisionId;
+    private final boolean verify;
+    private final Map<String, String> skipReasons;
 
     private final ConcurrentMap<String, Long> startNanos = new ConcurrentHashMap<>();
+
     private final ConcurrentMap<String, Long> durationNanos = new ConcurrentHashMap<>();
     private final Set<String> failedModules = ConcurrentHashMap.newKeySet();
 
+    public ShadowBuildMonitor(
+            ExecutionListener delegate,
+            Path reactorRoot,
+            String scalpelVersion,
+            String baseBranch,
+            Collection<String> changedFiles,
+            LongSupplier nanoClock,
+            Function<MavenProject, String> moduleKey,
+            ShadowDecision decision) {
+        this.delegate = delegate == null ? NOOP : delegate;
+        this.reactorRoot = reactorRoot;
+        this.wouldHaveBuilt = new ArrayList<>(decision.getWouldHaveBuilt());
+        this.wouldHaveSkipped = new LinkedHashSet<>(decision.getWouldHaveSkipped());
+        this.scalpelVersion = scalpelVersion;
+        this.baseBranch = baseBranch;
+        this.changedFiles = changedFiles == null ? List.of() : new ArrayList<>(changedFiles);
+        this.nanoClock = nanoClock;
+        this.moduleKey = moduleKey;
+        this.decisionId = decision.getDecisionId();
+        this.verify = decision.isVerify();
+        this.skipReasons = new LinkedHashMap<>(decision.getSkipReasons());
+    }
+
+    @Deprecated
     public ShadowBuildMonitor(
             ExecutionListener delegate,
             Path reactorRoot,
@@ -86,15 +115,15 @@ public final class ShadowBuildMonitor implements ExecutionListener {
             Collection<String> changedFiles,
             LongSupplier nanoClock,
             Function<MavenProject, String> moduleKey) {
-        this.delegate = delegate == null ? NOOP : delegate;
-        this.reactorRoot = reactorRoot;
-        this.wouldHaveBuilt = new ArrayList<>(wouldHaveBuilt);
-        this.wouldHaveSkipped = new LinkedHashSet<>(wouldHaveSkipped);
-        this.scalpelVersion = scalpelVersion;
-        this.baseBranch = baseBranch;
-        this.changedFiles = changedFiles == null ? List.of() : new ArrayList<>(changedFiles);
-        this.nanoClock = nanoClock;
-        this.moduleKey = moduleKey;
+        this(
+                delegate,
+                reactorRoot,
+                scalpelVersion,
+                baseBranch,
+                changedFiles,
+                nanoClock,
+                moduleKey,
+                ShadowDecision.measuring(wouldHaveBuilt, wouldHaveSkipped, null));
     }
 
     // ------------------------------------------------------------------
@@ -178,17 +207,59 @@ public final class ShadowBuildMonitor implements ExecutionListener {
     @Override
     public void sessionEnded(ExecutionEvent event) {
         delegate.sessionEnded(event);
+        Set<String> falseNegatives = getWouldHaveSkippedButFailed();
         try {
-            writeOutputs();
+            writeOutputs(falseNegatives);
         } catch (IOException e) {
             // Shadow measurement must never fail the build it is observing.
             logger.warn("Scalpel: Failed to write shadow outputs: {}", e.getMessage());
             logger.debug("Shadow output failure details", e);
         }
+        if (verify && !falseNegatives.isEmpty()) {
+            failBuildOnFalseNegatives(event, falseNegatives);
+        }
+    }
+
+    /**
+     * Verify mode (#101): the whole point of the run was to answer "was Scalpel right", and
+     * the answer is no, so the build exits non-zero naming each module Scalpel would have
+     * skipped and why it was judged skippable. The module's own failure has usually already
+     * failed the build; this makes the Scalpel verdict explicit and survives {@code -fn}
+     * style invocations by marking the session result.
+     */
+    private void failBuildOnFalseNegatives(ExecutionEvent event, Set<String> falseNegatives) {
+        StringBuilder modules = new StringBuilder();
+        for (String module : falseNegatives) {
+            logger.error(
+                    "Scalpel: verifyFullBuild: module '{}' FAILED but Scalpel would have skipped it (skip reason: {});"
+                            + " the trim decision for this changeset was wrong",
+                    module,
+                    skipReasonFor(module));
+            if (modules.length() > 0) {
+                modules.append(", ");
+            }
+            modules.append(module);
+        }
+        if (event.getSession() != null && event.getSession().getResult() != null) {
+            event.getSession()
+                    .getResult()
+                    .addException(new org.apache.maven.MavenExecutionException(
+                            "Scalpel verifyFullBuild: " + falseNegatives.size()
+                                    + " module(s) Scalpel would have skipped failed: " + modules
+                                    + " (decisionId " + (decisionId == null ? "unavailable" : decisionId) + ")",
+                            (Throwable) null));
+        }
+    }
+
+    private String skipReasonFor(String module) {
+        return skipReasons.getOrDefault(module, "NOT_AFFECTED");
     }
 
     void writeOutputs() throws IOException {
-        Set<String> wouldHaveSkippedButFailed = getWouldHaveSkippedButFailed();
+        writeOutputs(getWouldHaveSkippedButFailed());
+    }
+
+    void writeOutputs(Set<String> wouldHaveSkippedButFailed) throws IOException {
         String estimatedSecondsSaved = String.format(Locale.ROOT, "%.3f", getEstimatedSecondsSaved());
         Files.createDirectories(reactorRoot.resolve(SHADOW_FILE).getParent());
         Files.write(
@@ -208,6 +279,9 @@ public final class ShadowBuildMonitor implements ExecutionListener {
         fields.add(field("mode", "shadow"));
         fields.add(field("scalpelVersion", scalpelVersion));
         fields.add(field("baseBranch", baseBranch));
+        if (decisionId != null) {
+            fields.add(field("decisionId", decisionId));
+        }
         fields.add(field("timestamp", Instant.now().toString()));
         fields.add("\"changedFilesCount\": " + changedFiles.size());
         fields.add(arrayField("wouldHaveBuilt", wouldHaveBuilt));
@@ -256,6 +330,7 @@ public final class ShadowBuildMonitor implements ExecutionListener {
         return "{"
                 + "\"timestamp\": " + jsonString(Instant.now().toString())
                 + ", \"baseBranch\": " + jsonString(baseBranch)
+                + (decisionId == null ? "" : ", \"decisionId\": " + jsonString(decisionId))
                 + ", \"changedFilesCount\": " + changedFiles.size()
                 + ", \"estimatedSecondsSaved\": " + estimatedSecondsSaved
                 + ", \"wouldHaveBuiltCount\": " + wouldHaveBuilt.size()

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowBuildMonitor.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowBuildMonitor.java
@@ -7,6 +7,7 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import eu.maveniverse.maven.scalpel.core.ScalpelReport;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -102,28 +103,6 @@ public final class ShadowBuildMonitor implements ExecutionListener {
         this.decisionId = decision.getDecisionId();
         this.verify = decision.isVerify();
         this.skipReasons = new LinkedHashMap<>(decision.getSkipReasons());
-    }
-
-    @Deprecated
-    public ShadowBuildMonitor(
-            ExecutionListener delegate,
-            Path reactorRoot,
-            Collection<String> wouldHaveBuilt,
-            Collection<String> wouldHaveSkipped,
-            String scalpelVersion,
-            String baseBranch,
-            Collection<String> changedFiles,
-            LongSupplier nanoClock,
-            Function<MavenProject, String> moduleKey) {
-        this(
-                delegate,
-                reactorRoot,
-                scalpelVersion,
-                baseBranch,
-                changedFiles,
-                nanoClock,
-                moduleKey,
-                ShadowDecision.measuring(wouldHaveBuilt, wouldHaveSkipped, null));
     }
 
     // ------------------------------------------------------------------
@@ -252,7 +231,7 @@ public final class ShadowBuildMonitor implements ExecutionListener {
     }
 
     private String skipReasonFor(String module) {
-        return skipReasons.getOrDefault(module, "NOT_AFFECTED");
+        return skipReasons.getOrDefault(module, ScalpelReport.SKIP_REASON_NOT_AFFECTED);
     }
 
     void writeOutputs() throws IOException {

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowDecision.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowDecision.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The would-be trim decision handed to the {@link ShadowBuildMonitor} (#92, #101): the build
+ * set trim mode would have kept and the modules it would have skipped, each skippable module
+ * with the reason it was judged safe to skip, plus the stable {@code decisionId} and whether
+ * the run is a verification run (fail the build when a would-have-skipped module fails).
+ */
+final class ShadowDecision {
+
+    private final Collection<String> wouldHaveBuilt;
+    private final Collection<String> wouldHaveSkipped;
+    private final Map<String, String> skipReasons;
+    private final String decisionId;
+    private final boolean verify;
+
+    ShadowDecision(
+            Collection<String> wouldHaveBuilt,
+            Collection<String> wouldHaveSkipped,
+            Map<String, String> skipReasons,
+            String decisionId,
+            boolean verify) {
+        this.wouldHaveBuilt = wouldHaveBuilt;
+        this.wouldHaveSkipped = wouldHaveSkipped;
+        this.skipReasons = new LinkedHashMap<>(skipReasons);
+        this.decisionId = decisionId;
+        this.verify = verify;
+    }
+
+    Collection<String> getWouldHaveBuilt() {
+        return wouldHaveBuilt;
+    }
+
+    Collection<String> getWouldHaveSkipped() {
+        return wouldHaveSkipped;
+    }
+
+    /** The skip reason for a would-have-skipped module path, for the verify failure report. */
+    String skipReasonFor(String modulePath) {
+        return skipReasons.getOrDefault(modulePath, "NOT_AFFECTED");
+    }
+
+    Map<String, String> getSkipReasons() {
+        return skipReasons;
+    }
+
+    String getDecisionId() {
+        return decisionId;
+    }
+
+    boolean isVerify() {
+        return verify;
+    }
+
+    static ShadowDecision measuring(
+            Collection<String> wouldHaveBuilt, Collection<String> wouldHaveSkipped, String decisionId) {
+        return new ShadowDecision(wouldHaveBuilt, wouldHaveSkipped, new LinkedHashMap<>(), decisionId, false);
+    }
+
+    static ShadowDecision verifying(
+            Collection<String> wouldHaveBuilt,
+            Collection<String> wouldHaveSkipped,
+            Map<String, String> skipReasons,
+            String decisionId) {
+        return new ShadowDecision(wouldHaveBuilt, wouldHaveSkipped, skipReasons, decisionId, true);
+    }
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowDecision.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowDecision.java
@@ -46,11 +46,6 @@ final class ShadowDecision {
         return wouldHaveSkipped;
     }
 
-    /** The skip reason for a would-have-skipped module path, for the verify failure report. */
-    String skipReasonFor(String modulePath) {
-        return skipReasons.getOrDefault(modulePath, "NOT_AFFECTED");
-    }
-
     Map<String, String> getSkipReasons() {
         return skipReasons;
     }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowBuildMonitorTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowBuildMonitorTest.java
@@ -237,4 +237,105 @@ class ShadowBuildMonitorTest {
         assertTrue(Files.exists(shadowJson), "shadow json is still written with nothing measured");
         assertFalse(Files.readString(shadowJson).contains("estimatedSecondsSaved\": null"), "savings stay numeric");
     }
+
+    // ---------------------------------------------------------------
+    // Verify mode (#101): false negatives fail the build; decisionId is quotable
+    // ---------------------------------------------------------------
+
+    @Test
+    void verifyMode_failsTheSessionWhenASkippedModuleFails(@TempDir Path tmp) throws IOException {
+        Path reactorRoot = tmp.resolve("reactor");
+        Files.createDirectories(reactorRoot);
+        ShadowBuildMonitor monitor = new ShadowBuildMonitor(
+                null,
+                reactorRoot,
+                "0.3.11",
+                "base",
+                Arrays.asList("module-b/src/Foo.java"),
+                new SteppingClock(),
+                MavenProject::getArtifactId,
+                ShadowDecision.verifying(
+                        Arrays.asList("module-b"),
+                        Arrays.asList("module-a"),
+                        java.util.Map.of("module-a", "NOT_AFFECTED"),
+                        "decision-id-1"));
+
+        MavenProject a = project(reactorRoot, "module-a");
+        MavenProject b = project(reactorRoot, "module-b");
+        // module-a is the would-have-SKIPPED module, so its failure is the false negative
+        monitor.projectStarted(event(ExecutionEvent.Type.ProjectStarted, b));
+        monitor.projectSucceeded(event(ExecutionEvent.Type.ProjectSucceeded, b));
+        monitor.projectStarted(event(ExecutionEvent.Type.ProjectStarted, a));
+        monitor.projectFailed(event(ExecutionEvent.Type.ProjectFailed, a));
+
+        MavenSession session = org.mockito.Mockito.mock(MavenSession.class);
+        org.apache.maven.execution.MavenExecutionResult result =
+                org.mockito.Mockito.mock(org.apache.maven.execution.MavenExecutionResult.class);
+        org.mockito.Mockito.when(session.getResult()).thenReturn(result);
+        monitor.sessionEnded(eventWithSession(ExecutionEvent.Type.SessionEnded, session));
+
+        org.mockito.Mockito.verify(result)
+                .addException(org.mockito.ArgumentMatchers.argThat(
+                        ex -> ex.getMessage() != null && ex.getMessage().contains("module-a")));
+        String json = Files.readString(reactorRoot.resolve("target/scalpel-shadow.json"));
+        assertTrue(json.contains("decision-id-1"), "the shadow document must quote the decisionId");
+    }
+
+    @Test
+    void verifyMode_noFailureLeavesTheSessionResultAlone(@TempDir Path tmp) throws IOException {
+        Path reactorRoot = tmp.resolve("reactor");
+        Files.createDirectories(reactorRoot);
+        ShadowBuildMonitor monitor = new ShadowBuildMonitor(
+                null,
+                reactorRoot,
+                "0.3.11",
+                "base",
+                Arrays.asList("module-b/src/Foo.java"),
+                new SteppingClock(),
+                MavenProject::getArtifactId,
+                ShadowDecision.verifying(
+                        Arrays.asList("module-b"),
+                        Arrays.asList("module-a"),
+                        java.util.Map.of("module-a", "NOT_AFFECTED"),
+                        "decision-id-2"));
+
+        MavenProject b = project(reactorRoot, "module-b");
+        monitor.projectStarted(event(ExecutionEvent.Type.ProjectStarted, b));
+        monitor.projectSucceeded(event(ExecutionEvent.Type.ProjectSucceeded, b));
+
+        MavenSession session = org.mockito.Mockito.mock(MavenSession.class);
+        org.apache.maven.execution.MavenExecutionResult result =
+                org.mockito.Mockito.mock(org.apache.maven.execution.MavenExecutionResult.class);
+        org.mockito.Mockito.when(session.getResult()).thenReturn(result);
+        monitor.sessionEnded(eventWithSession(ExecutionEvent.Type.SessionEnded, session));
+
+        org.mockito.Mockito.verify(result, org.mockito.Mockito.never())
+                .addException(org.mockito.ArgumentMatchers.any());
+        String history = Files.readString(reactorRoot.resolve("target/scalpel-shadow-history.jsonl"));
+        assertTrue(history.contains("decision-id-2"), "the history line must quote the decisionId");
+    }
+
+    private static ExecutionEvent eventWithSession(ExecutionEvent.Type type, MavenSession session) {
+        return new ExecutionEvent() {
+            public ExecutionEvent.Type getType() {
+                return type;
+            }
+
+            public MavenSession getSession() {
+                return session;
+            }
+
+            public MavenProject getProject() {
+                return null;
+            }
+
+            public org.apache.maven.plugin.MojoExecution getMojoExecution() {
+                return null;
+            }
+
+            public Exception getException() {
+                return null;
+            }
+        };
+    }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowBuildMonitorTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ShadowBuildMonitorTest.java
@@ -105,13 +105,12 @@ class ShadowBuildMonitorTest {
         ShadowBuildMonitor monitor = new ShadowBuildMonitor(
                 recordingDelegate(delegateCalls),
                 reactorRoot,
-                Arrays.asList("module-b"),
-                Arrays.asList("module-a", "module-c"),
                 "0.3.11",
                 "base",
                 Arrays.asList("module-b/src/Foo.java"),
                 clock,
-                MavenProject::getArtifactId);
+                MavenProject::getArtifactId,
+                ShadowDecision.measuring(Arrays.asList("module-b"), Arrays.asList("module-a", "module-c"), null));
 
         MavenProject a = project(reactorRoot, "module-a");
         MavenProject b = project(reactorRoot, "module-b");
@@ -193,13 +192,12 @@ class ShadowBuildMonitorTest {
             ShadowBuildMonitor monitor = new ShadowBuildMonitor(
                     null,
                     reactorRoot,
-                    Arrays.asList("module-b"),
-                    Arrays.asList("module-a"),
                     "0.3.11",
                     "base",
                     Arrays.asList("module-b/src/Foo.java"),
                     clock,
-                    MavenProject::getArtifactId);
+                    MavenProject::getArtifactId,
+                    ShadowDecision.measuring(Arrays.asList("module-b"), Arrays.asList("module-a"), null));
             MavenProject b = project(reactorRoot, "module-b");
             monitor.projectStarted(event(ExecutionEvent.Type.ProjectStarted, b));
             monitor.projectSucceeded(event(ExecutionEvent.Type.ProjectSucceeded, b));
@@ -218,13 +216,12 @@ class ShadowBuildMonitorTest {
         ShadowBuildMonitor monitor = new ShadowBuildMonitor(
                 null,
                 reactorRoot,
-                Arrays.asList("module-b"),
-                Arrays.asList("module-a"),
                 "0.3.11",
                 null,
                 null,
                 new SteppingClock(),
-                MavenProject::getArtifactId);
+                MavenProject::getArtifactId,
+                ShadowDecision.measuring(Arrays.asList("module-b"), Arrays.asList("module-a"), null));
 
         monitor.sessionEnded(event(ExecutionEvent.Type.SessionEnded, null));
 

--- a/it/extension3-its/src/it/verify-failure/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/verify-failure/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/verify-failure/invoker.properties
+++ b/it/extension3-its/src/it/verify-failure/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals = verify -Dscalpel.baseBranch=base -Dscalpel.verifyFullBuild=true
+invoker.buildResult = failure

--- a/it/extension3-its/src/it/verify-failure/module-a/pom.xml
+++ b/it/extension3-its/src/it/verify-failure/module-a/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.verifyfailure</groupId>
+        <artifactId>verify-failure</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <!-- Upstream prerequisite of module-b: trim would build it, so it must NOT appear
+         in the shadow document's would-skip or false-negative sets. -->
+</project>

--- a/it/extension3-its/src/it/verify-failure/module-b/pom.xml
+++ b/it/extension3-its/src/it/verify-failure/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.verifyfailure</groupId>
+        <artifactId>verify-failure</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.verifyfailure</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/verify-failure/module-c/pom.xml
+++ b/it/extension3-its/src/it/verify-failure/module-c/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.verifyfailure</groupId>
+        <artifactId>verify-failure</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <!-- Independent of the change in module-b and of every other module, so trim would
+         skip it; its failing test is exactly what shadow mode must surface as a
+         would-have-skipped false negative. -->
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.13.4</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/verify-failure/module-c/src/test/java/AlwaysFailsTest.java
+++ b/it/extension3-its/src/it/verify-failure/module-c/src/test/java/AlwaysFailsTest.java
@@ -1,0 +1,10 @@
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+class AlwaysFailsTest {
+    @Test
+    void alwaysFails() {
+        fail("planned failure: verifyFullBuild must fail the build on this would-be-skipped module");
+    }
+}

--- a/it/extension3-its/src/it/verify-failure/pom.xml
+++ b/it/extension3-its/src/it/verify-failure/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.verifyfailure</groupId>
+    <artifactId>verify-failure</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/verify-failure/setup.groovy
+++ b/it/extension3-its/src/it/verify-failure/setup.groovy
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Shadow-mode false-negative fixture: module-c (independent of every other module)
+// carries a failing test from the initial commit, so it is unaffected by the
+// feature-branch change in module-b; the full build runs everything, module-c fails,
+// and the shadow document must flag it as a module Scalpel would have skipped
+// (wouldHaveSkippedButFailed). module-a is an upstream prerequisite of module-b and
+// must NOT be flagged.
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Create a source file in module-b: the only change base..HEAD
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension3-its/src/it/verify-failure/verify.groovy
+++ b/it/extension3-its/src/it/verify-failure/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// verifyFullBuild with the default trim mode: the reactor is NOT trimmed, the full build
+// runs, and the override is announced
+assert log.contains('verifyFullBuild forces a full build')
+assert !log.contains('Scalpel: Building ') : "verify must not trim the reactor"
+assert log.contains('AlwaysFailsTest') : "the planted failing test must have run"
+assert log.contains('BUILD FAILURE')
+
+// The verify verdict: module-c failed but Scalpel would have skipped it, with the skip
+// reason and the decision identity quoted so the failure is correlatable (#101)
+assert log.contains('module-c') : "the false negative must be named"
+assert log.contains('NOT_AFFECTED') : "the skip reason must be named"
+assert log.contains('decisionId') : "the decision identity must be quotable"
+
+// Both artifacts of the observed run
+File shadowFile = new File(basedir, 'target/scalpel-shadow.json')
+assert shadowFile.exists() : "shadow json must be written"
+assert shadowFile.text.contains('"decisionId"')
+assert shadowFile.text.contains('module-c')
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists() : "the standard report must also be written"
+assert reportFile.text.contains('"decisionId"')
+File history = new File(basedir, 'target/scalpel-shadow-history.jsonl')
+assert history.exists()

--- a/it/extension3-its/src/it/verify-failure/verify.groovy
+++ b/it/extension3-its/src/it/verify-failure/verify.groovy
@@ -20,6 +20,8 @@ assert log.contains('BUILD FAILURE')
 // reason and the decision identity quoted so the failure is correlatable (#101)
 assert log.contains('module-c') : "the false negative must be named"
 assert log.contains('NOT_AFFECTED') : "the skip reason must be named"
+assert log.contains("FAILED but Scalpel would have skipped it") : \
+    "the verify verdict must come from the Scalpel monitor, not just the surefire failure"
 assert log.contains('decisionId') : "the decision identity must be quotable"
 
 // Both artifacts of the observed run

--- a/it/extension3-its/src/it/verify-success/.mvn/extensions.xml
+++ b/it/extension3-its/src/it/verify-success/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>eu.maveniverse.maven.scalpel</groupId>
+        <artifactId>extension3</artifactId>
+        <version>@project.version@</version>
+    </extension>
+</extensions>

--- a/it/extension3-its/src/it/verify-success/invoker.properties
+++ b/it/extension3-its/src/it/verify-success/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.verifyFullBuild=true

--- a/it/extension3-its/src/it/verify-success/invoker.properties
+++ b/it/extension3-its/src/it/verify-success/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = validate -Dscalpel.baseBranch=base -Dscalpel.verifyFullBuild=true
+invoker.goals = verify -Dscalpel.baseBranch=base -Dscalpel.verifyFullBuild=true

--- a/it/extension3-its/src/it/verify-success/module-a/pom.xml
+++ b/it/extension3-its/src/it/verify-success/module-a/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.verifysuccess</groupId>
+        <artifactId>verify-success</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-a</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/verify-success/module-b/pom.xml
+++ b/it/extension3-its/src/it/verify-success/module-b/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.verifysuccess</groupId>
+        <artifactId>verify-success</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-b</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>eu.maveniverse.maven.scalpel.it.verifysuccess</groupId>
+            <artifactId>module-a</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/it/extension3-its/src/it/verify-success/module-c/pom.xml
+++ b/it/extension3-its/src/it/verify-success/module-c/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>eu.maveniverse.maven.scalpel.it.verifysuccess</groupId>
+        <artifactId>verify-success</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>module-c</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+</project>

--- a/it/extension3-its/src/it/verify-success/pom.xml
+++ b/it/extension3-its/src/it/verify-success/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>eu.maveniverse.maven.scalpel.it.verifysuccess</groupId>
+    <artifactId>verify-success</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module-a</module>
+        <module>module-b</module>
+        <module>module-c</module>
+    </modules>
+</project>

--- a/it/extension3-its/src/it/verify-success/setup.groovy
+++ b/it/extension3-its/src/it/verify-success/setup.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+
+// Initialize git repo, create base branch, switch to feature branch, modify source in module-b
+def dir = basedir
+
+def exec = { String... args ->
+    def proc = args.execute(null, dir)
+    def out = new StringBuilder()
+    def err = new StringBuilder()
+    proc.waitForProcessOutput(out, err)
+    if (proc.exitValue() != 0) {
+        throw new RuntimeException("Command failed: ${args.join(' ')}\nstdout: $out\nstderr: $err")
+    }
+}
+
+exec('git', 'init')
+exec('git', 'config', 'user.email', 'test@test.com')
+exec('git', 'config', 'user.name', 'Test')
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'initial')
+exec('git', 'branch', 'base')
+
+// Create a source file in module-b
+new File(dir, 'module-b/src/main/java').mkdirs()
+new File(dir, 'module-b/src/main/java/Foo.java').text = 'public class Foo {}'
+exec('git', 'add', '.')
+exec('git', 'commit', '-m', 'add source to module-b')

--- a/it/extension3-its/src/it/verify-success/verify.groovy
+++ b/it/extension3-its/src/it/verify-success/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+File buildLog = new File(basedir, 'build.log')
+assert buildLog.exists()
+String log = buildLog.text
+
+// verifyFullBuild overrides the default trim mode into a full observed build
+assert log.contains('verifyFullBuild forces a full build')
+assert !log.contains('Scalpel: Building ') : "verify must not trim the reactor"
+assert log.contains('BUILD SUCCESS')
+
+// Every module built, the report and the shadow document both carry the decision identity
+File reportFile = new File(basedir, 'target/scalpel-report.json')
+assert reportFile.exists()
+assert reportFile.text.contains('"decisionId"') : "the report must quote the decisionId"
+File shadowFile = new File(basedir, 'target/scalpel-shadow.json')
+assert shadowFile.exists()
+assert shadowFile.text.contains('"decisionId"')
+assert shadowFile.text.contains('"wouldHaveSkippedButFailed": []') : "no false negatives on the happy path"
+File history = new File(basedir, 'target/scalpel-shadow-history.jsonl')
+assert history.exists()
+assert history.text.contains('decisionId')


### PR DESCRIPTION
Implements the issue's three asks:

**`-Dscalpel.verifyFullBuild=true`** runs the full build under the shadow observation (reactor untouched, all tests run, whatever the configured mode was; trim and skip-tests are overridden with a warning) and fails the run when a module Scalpel would have skipped fails, naming each module, the reason it was judged skippable, and the decision id. The failure is added to the session result, so the exit code is driven by the Scalpel verdict and survives `-fn`-style invocations. This is the scheduled-job answer to "was Scalpel right last week?".

**`decisionId`**: every run in every mode emits a stable SHA-256 identity of the decision (merge-base commit, head commit, the resolved decision-shaping configuration fingerprint, and the sorted build-set paths) in the JSON report (optional additive field, schema and drift guard updated), in the shadow document and in each history line; the report and the shadow document of one run quote the same id. `ChangeDetectionResult` now carries the merge-base and head commit ids; the fingerprint covers exactly the set-shaping properties (sorted, order-insensitive) and excludes output-shaping ones like reportFile or mode, so a verify run and the later trim run on the same changeset share the id.

**A ready-to-use scheduled job** is documented in CI Recipes (nightly `scalpel-verify` workflow with artifact upload of the shadow documents on failure).

TDD: the configuration flag and fingerprint tests and the decisionId determinism/order-insensitivity/null-tolerance tests were written first and demonstrated failing at compile level on unmodified main.

Gates run before pushing (simplify four angles, review: id-stability, verify escape hatches, addException bytecode semantics, fingerprint completeness). Two real defects found and fixed by the gates: trim/report hashed the root aggregator as the empty string while shadow/verify hashed it as ".", so the same decision produced different ids across modes (every mode now collects through one `.\`-normalizing key helper); the verify-failure IT passed on surefire's failure alone and now asserts the monitor's own verdict line. The fingerprint also gained `maxResourceFileSize` (a resource over the cap is skipped, changing the affected set).

**Deliberate behaviour changes to note:**

* a verify run overrides the reactor-modifying modes with a WARN in the log
* the report schema gains the optional `decisionId` property (no version bump per the additive policy; golden file and bidirectional drift guard updated)
* shadow/verify status-document overwrites now also cover the bail-outs of verify runs

Full battery green: core 203, extension3 190 unit tests, all 38 integration tests (two new: verify-success, verify-failure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full-build verification mode to detect failures in modules that would otherwise be skipped.
  - Reports now include stable decision IDs for correlating build results and failures.
  - Verification results identify skipped-module reasons and false-negative failures.
  - Added strict configuration support for enabling full-build verification.

- **Documentation**
  - Added configuration, report-format, and scheduled verification guidance.

- **Tests**
  - Added coverage for successful and failing verification runs, report output, and decision-ID consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->