### PR TITLE
test: parse the skip-tests-downstream-exclusion-report IT instead of brace-slicing (#96)

### DIFF
--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
@@ -30,20 +30,26 @@ def report = new groovy.json.JsonSlurper().parseText(reportFile.text)
 assert report.version == '2' : "Report should have version 2"
 assert report.fullBuildTriggered == false : "fullBuildTriggered should be false"
 
-def modules = report.affectedModules.collectEntries { [(it.artifactId): it] }
+def modules = report.affectedModules
+def moduleA = modules.find { it.artifactId == 'module-a' }
+def moduleB = modules.find { it.artifactId == 'module-b' }
+def moduleC = modules.find { it.artifactId == 'module-c' }
 
 // module-a should be directly affected with SOURCE_CHANGE
-assert modules['module-a'] : "module-a should appear in report"
-assert modules['module-a'].reasons.contains('SOURCE_CHANGE') : "module-a should have SOURCE_CHANGE reason"
-assert modules['module-a'].category == 'DIRECT' : "module-a should have DIRECT category"
+assert moduleA : "module-a should appear in report"
+assert moduleA.reasons.contains('SOURCE_CHANGE') : "module-a should have SOURCE_CHANGE reason"
+assert moduleA.category == 'DIRECT' : "module-a should have DIRECT category"
 
-// module-b should be downstream with testsSkippedReason=EXCLUDED_DOWNSTREAM
-assert modules['module-b'] : "module-b should appear in report"
-assert modules['module-b'].reasons.contains('DOWNSTREAM_DEPENDENT') : "module-b should have DOWNSTREAM_DEPENDENT reason"
-assert modules['module-b'].testsSkippedReason == 'EXCLUDED_DOWNSTREAM' : \
+// module-b should be downstream with testsSkipped + testsSkippedReason=EXCLUDED_DOWNSTREAM
+assert moduleB : "module-b should appear in report"
+assert moduleB.reasons.contains('DOWNSTREAM_DEPENDENT') : "module-b should have DOWNSTREAM_DEPENDENT reason"
+assert moduleB.testsSkipped == true : "module-b should have testsSkipped=true"
+assert moduleB.testsSkippedReason == 'EXCLUDED_DOWNSTREAM' : \
     "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM"
 
-// module-c should be downstream but WITHOUT testsSkippedReason
-assert modules['module-c'] : "module-c should appear in report"
-assert !modules['module-c'].containsKey('testsSkippedReason') : \
+// module-c should be downstream but WITHOUT testsSkipped/testsSkippedReason
+assert moduleC : "module-c should appear in report"
+assert !moduleC.containsKey('testsSkipped') : \
+    "module-c should NOT have testsSkipped in report"
+assert !moduleC.containsKey('testsSkippedReason') : \
     "module-c should NOT have testsSkippedReason in report"

--- a/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
+++ b/it/extension3-its/src/it/skip-tests-downstream-exclusion-report/verify.groovy
@@ -23,30 +23,27 @@ assert log.contains('BUILD SUCCESS')
 File reportFile = new File(basedir, 'target/scalpel-report.json')
 assert reportFile.exists() : "Report file should have been created at target/scalpel-report.json"
 
-String json = reportFile.text
-assert json.contains('"version": "2"') : "Report should contain version field"
-assert json.contains('"fullBuildTriggered": false') : "fullBuildTriggered should be false"
+// Parsed, not hand-sliced: brace-counting breaks the moment a module object
+// gains a nested field, which is exactly how a schema addition should NOT
+// fail these assertions (see #96).
+def report = new groovy.json.JsonSlurper().parseText(reportFile.text)
+assert report.version == '2' : "Report should have version 2"
+assert report.fullBuildTriggered == false : "fullBuildTriggered should be false"
+
+def modules = report.affectedModules.collectEntries { [(it.artifactId): it] }
 
 // module-a should be directly affected with SOURCE_CHANGE
-assert json.contains('"module-a"') : "module-a should appear in report"
-assert json.contains('"SOURCE_CHANGE"') : "module-a should have SOURCE_CHANGE reason"
-assert json.contains('"category": "DIRECT"') : "module-a should have DIRECT category"
+assert modules['module-a'] : "module-a should appear in report"
+assert modules['module-a'].reasons.contains('SOURCE_CHANGE') : "module-a should have SOURCE_CHANGE reason"
+assert modules['module-a'].category == 'DIRECT' : "module-a should have DIRECT category"
 
 // module-b should be downstream with testsSkippedReason=EXCLUDED_DOWNSTREAM
-assert json.contains('"module-b"') : "module-b should appear in report"
-assert json.contains('"DOWNSTREAM_DEPENDENT"') : "module-b should have DOWNSTREAM_DEPENDENT reason"
-
-// Parse module-b block and verify testsSkippedReason
-def moduleBStart = json.indexOf('"module-b"')
-assert moduleBStart >= 0
-def moduleBBlock = json.substring(json.lastIndexOf('{', moduleBStart), json.indexOf('}', moduleBStart) + 1)
-assert moduleBBlock.contains('"testsSkippedReason": "EXCLUDED_DOWNSTREAM"') : \
-    "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM in report, got: $moduleBBlock"
+assert modules['module-b'] : "module-b should appear in report"
+assert modules['module-b'].reasons.contains('DOWNSTREAM_DEPENDENT') : "module-b should have DOWNSTREAM_DEPENDENT reason"
+assert modules['module-b'].testsSkippedReason == 'EXCLUDED_DOWNSTREAM' : \
+    "module-b should have testsSkippedReason=EXCLUDED_DOWNSTREAM"
 
 // module-c should be downstream but WITHOUT testsSkippedReason
-assert json.contains('"module-c"') : "module-c should appear in report"
-def moduleCStart = json.indexOf('"module-c"')
-assert moduleCStart >= 0
-def moduleCBlock = json.substring(json.lastIndexOf('{', moduleCStart), json.indexOf('}', moduleCStart) + 1)
-assert !moduleCBlock.contains('testsSkippedReason') : \
-    "module-c should NOT have testsSkippedReason in report, got: $moduleCBlock"
+assert modules['module-c'] : "module-c should appear in report"
+assert !modules['module-c'].containsKey('testsSkippedReason') : \
+    "module-c should NOT have testsSkippedReason in report"


### PR DESCRIPTION
The follow-up accepted in https://github.com/maveniverse/scalpel/pull/170#issuecomment-5574803747: the last remaining hand-sliced JSON assertions from issue #96.

The `skip-tests-downstream-exclusion-report` verify script extracted module objects with `lastIndexOf('{')`/`indexOf('}')`, the exact fragility the issue names, since the first nested field inside a module object would silently corrupt those extractions. It now parses with `JsonSlurper` like the other report ITs and asserts per-module fields by artifactId; the module-b `testsSkippedReason=EXCLUDED_DOWNSTREAM` and the module-c absent-field checks run against the typed structure, which is strictly stronger than substring matches on hand-sliced blocks.

Unit-side coverage (escaping tests with raw-output verification, SLPTest substring helpers replaced) ships in #170; this closes the one IT the issue text calls out. Green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved verification of downstream exclusion reports.
  * Added explicit checks for module change reasons, categories, and skipped-test details.
  * Confirmed that unaffected modules omit skipped-test fields entirely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->