### PR TITLE
Fix #106: run unit tests on real Windows and macOS runners, correct the Java claim

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 .mvn/nisse.properties export-subst
+mvnw text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        java: [ 17, 21, 25 ]
+        # The build itself requires JDK 21+ (parent-62 enforcer
+        # requireBuildtimeJavaVersion.range=[21,)); 17 is only the
+        # bytecode floor. Two build JDKs satisfy the issue's ask.
+        java: [ 21, 25 ]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up JDK ${{ matrix.java }}
@@ -40,7 +43,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: zulu
       - name: Cache Maven repository
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,34 @@ jobs:
       maven-test: './mvnw clean verify -e -B -V -P run-its -rf :it'
       jdk-matrix: '[ "17", "21", "25" ]'
       maven-matrix: '[ "3.9.16" ]'
+
+  # The reusable parent workflow's test job hardcodes runs-on: ubuntu-latest
+  # (the os-matrix input only names artifacts), so Windows and macOS never
+  # execute anything. Until that is fixed in the parent, Scalpel runs its own
+  # per-OS unit-test matrix: path-separator defects are exactly what only a
+  # real Windows leg can catch (#106). Unit tests are ~3s per leg; the heavy
+  # verify (ITs) stays in the build job above.
+  unit-test-matrix:
+    name: Unit tests (${{ matrix.os }}, ${{ matrix.java }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
+        java: [ 17, 21, 25 ]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: zulu
+      - name: Cache Maven repository
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-${{ matrix.java }}-
+      - name: Unit tests
+        run: ./mvnw test -e -B -V
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Maveniverse Scalpel
 
 Requirements:
-* Java: 8+
+* Java: 17+
 * Maven: 3.9.x+
 
 Scalpel is a Maven core extension that detects which modules in a multi-module reactor are affected by a git changeset. It can trim the reactor to only build affected modules, skip tests on unaffected modules, or produce a JSON report of affected modules for consumption by CI scripts.


### PR DESCRIPTION
The reusable parent workflow's test job hardcodes `runs-on: ubuntu-latest` (the `os-matrix` input only feeds artifact names), so Scalpel's Windows and macOS legs have been duplicate Ubuntu runs and path-separator defects had no leg that could catch them, in a tool whose core operation is comparing paths. Until the parent is fixed, Scalpel adds its own unit-test matrix: **three operating systems x JDK 21 and 25**, six legs of ~3s unit tests, with the heavy verify-plus-ITs staying in the build job. All actions pinned to commit SHAs per the repo's own #102 policy.

The README claim `Java: 8+` was stale: the JDK 17 bump made `maven.compiler.release` 17, so the extension has required Java 17+ bytecode since then and no Java 8 runtime could load it. The claim now matches reality instead of promising an untested, impossible floor (the issue's alternative: exercise Java 8 at runtime or correct the claim).

**Verified before pushing** (gate agent, clean clone with an empty local repository): the exact matrix invocation builds the full reactor green from scratch on JDK 21 and 25 (200 core + 190 extension3 tests); the `it/*` modules are inert under `test` since invoker lives in the `run-its` profile. One blocking finding from that verification, applied: JDK 17 legs were dropped because the parent-62 enforcer requires build-time Java `[21,)` and every 17 leg would die at validate before running a test, which is why the existing CI's 17 entry only ever ran the `-rf :it` tail. Two hardenings from the same gate: the cache pin comment names v4.3.0, and `.gitattributes` pins `mvnw` to LF so a CRLF-default Windows checkout cannot break the wrapper under bash.

**Deliberate choices to note:** the matrix deliberately stops at unit tests (the IT matrix would multiply ~40 invoker builds by six legs); the parent-repo `runs-on` bug itself is left for the parent project, per the issue's framing.