### PR TITLE
Fix Windows CI test failures in ChangeFilter and ReactorFirstModelResolver

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -14,13 +14,10 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttribute;
@@ -35,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -336,15 +334,12 @@ class PomChangeAnalyzer {
      * <p>When both lists are empty, all changes are accepted (the filter is a no-op).
      */
     static class ChangeFilter {
-        private static final String GLOB_PREFIX = "glob:";
-
-        private final List<PathMatcher> excludeMatchers;
-        private final List<PathMatcher> includeMatchers;
+        private final List<Pattern> excludeMatchers;
+        private final List<Pattern> includeMatchers;
 
         ChangeFilter(List<String> excludePatterns, List<String> includePatterns) {
-            FileSystem fs = FileSystems.getDefault();
-            this.excludeMatchers = compileMatchers(excludePatterns, fs);
-            this.includeMatchers = compileMatchers(includePatterns, fs);
+            this.excludeMatchers = compileMatchers(excludePatterns);
+            this.includeMatchers = compileMatchers(includePatterns);
         }
 
         /** Returns {@code true} if the change path should be considered (not excluded). */
@@ -352,15 +347,14 @@ class PomChangeAnalyzer {
             if (excludeMatchers.isEmpty() && includeMatchers.isEmpty()) {
                 return true;
             }
-            Path path = Path.of(changePath);
             // Include overrides exclude
-            for (PathMatcher m : includeMatchers) {
-                if (m.matches(path)) {
+            for (Pattern m : includeMatchers) {
+                if (m.matcher(changePath).matches()) {
                     return true;
                 }
             }
-            for (PathMatcher m : excludeMatchers) {
-                if (m.matches(path)) {
+            for (Pattern m : excludeMatchers) {
+                if (m.matcher(changePath).matches()) {
                     return false;
                 }
             }
@@ -371,15 +365,51 @@ class PomChangeAnalyzer {
             return !excludeMatchers.isEmpty() || !includeMatchers.isEmpty();
         }
 
-        private static List<PathMatcher> compileMatchers(List<String> patterns, FileSystem fs) {
+        private static List<Pattern> compileMatchers(List<String> patterns) {
             if (patterns == null || patterns.isEmpty()) {
                 return List.of();
             }
-            List<PathMatcher> matchers = new ArrayList<>(patterns.size());
+            List<Pattern> matchers = new ArrayList<>(patterns.size());
             for (String pattern : patterns) {
-                matchers.add(fs.getPathMatcher(GLOB_PREFIX + pattern));
+                matchers.add(globToPattern(pattern));
             }
             return matchers;
+        }
+
+        /**
+         * Converts a simple glob pattern to a compiled {@link Pattern}.
+         * The glob syntax supports: {@code *} (any chars except {@code /}),
+         * {@code **} (any chars including {@code /}), {@code ?} (single char).
+         * Forward-slash {@code /} is the separator.  No filesystem is involved,
+         * so characters like {@code :} that are illegal in Windows file paths
+         * are handled correctly.
+         */
+        static Pattern globToPattern(String glob) {
+            StringBuilder regex = new StringBuilder();
+            int i = 0;
+            while (i < glob.length()) {
+                char c = glob.charAt(i);
+                if (c == '*') {
+                    if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
+                        regex.append(".*");
+                        i += 2;
+                        // skip trailing slash after ** (e.g. **/ → match any prefix)
+                        if (i < glob.length() && glob.charAt(i) == '/') {
+                            i++;
+                        }
+                    } else {
+                        regex.append("[^/]*");
+                        i++;
+                    }
+                } else if (c == '?') {
+                    regex.append("[^/]");
+                    i++;
+                } else {
+                    regex.append(Pattern.quote(String.valueOf(c)));
+                    i++;
+                }
+            }
+            return Pattern.compile(regex.toString());
         }
     }
 
@@ -2139,12 +2169,15 @@ class PomChangeAnalyzer {
 
         @Override
         public void addRepository(Repository repository) throws InvalidRepositoryException {
-            delegate.addRepository(repository);
+            // Deliberately ignores repository declarations: the reactor model resolver
+            // resolves parents and BOM imports from the reactor itself, and the delegate's
+            // addRepository requires a fully configured RemoteRepositoryManager (which may
+            // not be available during standalone effective model building).
         }
 
         @Override
         public void addRepository(Repository repository, boolean replace) throws InvalidRepositoryException {
-            delegate.addRepository(repository, replace);
+            // Deliberately ignores repository declarations — see above.
         }
 
         @Override

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -396,9 +396,14 @@ class PomChangeAnalyzer {
                             // **/ → optionally match any path segment(s) ending with /
                             regex.append("(.*/)?");
                             i++;
-                        } else {
-                            // ** at end → match anything
+                        } else if (i >= glob.length()) {
+                            // ** at end of pattern → match anything (safe, no following literal)
                             regex.append(".*");
+                        } else {
+                            // ** followed by a non-'/' char (e.g. **Test.java) →
+                            // treat as single-segment wildcard to prevent ReDoS from
+                            // chained .* groups with interleaved literals
+                            regex.append("[^/]*");
                         }
                     } else {
                         regex.append("[^/]*");

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzer.java
@@ -391,11 +391,14 @@ class PomChangeAnalyzer {
                 char c = glob.charAt(i);
                 if (c == '*') {
                     if (i + 1 < glob.length() && glob.charAt(i + 1) == '*') {
-                        regex.append(".*");
                         i += 2;
-                        // skip trailing slash after ** (e.g. **/ → match any prefix)
                         if (i < glob.length() && glob.charAt(i) == '/') {
+                            // **/ → optionally match any path segment(s) ending with /
+                            regex.append("(.*/)?");
                             i++;
+                        } else {
+                            // ** at end → match anything
+                            regex.append(".*");
                         }
                     } else {
                         regex.append("[^/]*");

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
@@ -3093,6 +3094,35 @@ class PomChangeAnalyzerTest {
         assertFalse(filter.accepts("properties/project.build.outputTimestamp"));
         assertFalse(filter.accepts("properties/git.commit.id"));
         assertTrue(filter.accepts("properties/dep.version"));
+    }
+
+    @Test
+    void globToPattern_doubleStarSlashRequiresSeparator() {
+        // **/pom.xml should match paths with separator or at root, but not "parentpom.xml"
+        Pattern p = PomChangeAnalyzer.ChangeFilter.globToPattern("**/pom.xml");
+        assertTrue(p.matcher("pom.xml").matches());
+        assertTrue(p.matcher("foo/pom.xml").matches());
+        assertTrue(p.matcher("foo/bar/pom.xml").matches());
+        assertFalse(p.matcher("parentpom.xml").matches());
+    }
+
+    @Test
+    void globToPattern_middleDoubleStarRequiresSeparator() {
+        // a/**/b should match a/b, a/x/b, a/x/y/b but not a/xb
+        Pattern p = PomChangeAnalyzer.ChangeFilter.globToPattern("a/**/b");
+        assertTrue(p.matcher("a/b").matches());
+        assertTrue(p.matcher("a/x/b").matches());
+        assertTrue(p.matcher("a/x/y/b").matches());
+        assertFalse(p.matcher("a/xb").matches());
+    }
+
+    @Test
+    void globToPattern_trailingDoubleStar() {
+        // docs/** should match anything under docs/
+        Pattern p = PomChangeAnalyzer.ChangeFilter.globToPattern("docs/**");
+        assertTrue(p.matcher("docs/foo").matches());
+        assertTrue(p.matcher("docs/foo/bar").matches());
+        assertFalse(p.matcher("docs").matches());
     }
 
     @Test

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/PomChangeAnalyzerTest.java
@@ -3126,6 +3126,26 @@ class PomChangeAnalyzerTest {
     }
 
     @Test
+    void globToPattern_doubleStarMidSegmentFallsBackToSingleSegment() {
+        // **Test.java is not a standard glob; ** mid-segment should behave as single-segment
+        // wildcard to prevent ReDoS from chained .* groups
+        Pattern p = PomChangeAnalyzer.ChangeFilter.globToPattern("**Test.java");
+        assertTrue(p.matcher("FooTest.java").matches());
+        assertFalse(p.matcher("foo/BarTest.java").matches()); // no cross-segment matching
+    }
+
+    @Test
+    void globToPattern_doubleStarMidSegmentNoReDoS() {
+        // Ensure patterns that previously caused catastrophic backtracking complete quickly
+        Pattern p = PomChangeAnalyzer.ChangeFilter.globToPattern("**a**a**z");
+        String input = "a".repeat(400) + "z";
+        long start = System.nanoTime();
+        p.matcher(input).matches(); // should not hang
+        long elapsed = (System.nanoTime() - start) / 1_000_000;
+        assertTrue(elapsed < 1000, "Pattern match took " + elapsed + "ms, expected < 1000ms");
+    }
+
+    @Test
     void analyzeChanges_excludeVolatileProperty() throws Exception {
         // Parent has dep.version property that changes. Child's my.ref depends on it.
         // With excludeChanges for properties/my.*, child should NOT be affected.


### PR DESCRIPTION
## Problem

Windows CI fails with 11 test failures (2 in PomChangeAnalyzerTest, 9 in ScalpelLifecycleParticipantTest).

### Root Cause 1: ChangeFilter uses java.nio.file.Path for logical paths

`ChangeFilter.accepts()` calls `Path.of(changePath)` on strings like `managedDependencies/com.foo:bar`. On Windows, `:` is illegal in file paths → `InvalidPathException`.

**Fix:** Replace `PathMatcher`/`Path.of()` with a simple glob-to-regex converter. The glob syntax (`*`, `**`, `?`) is converted to regex patterns at construction time, then matched against the string directly. No filesystem involvement.

### Root Cause 2: ReactorFirstModelResolver corrupts delegate state

`ReactorFirstModelResolver.addRepository()` delegated to the wrapped `ProjectModelResolver`, which calls `RemoteRepositoryManager.aggregateRepositories()`. During standalone effective model building (for old/new POM comparison), the `RemoteRepositoryManager` may not be fully configured, causing the delegate's internal repository list to become null and subsequent `resolveModel` calls to fail. This made `buildEffectiveModels()` return empty maps, causing all parent-POM analysis to fall back to conservative "mark everything affected" behavior.

**Fix:** Made `addRepository()` a no-op in `ReactorFirstModelResolver`. The reactor-first resolver only resolves from reactor POMs; it never needs remote repositories, so absorbing repository declarations is both safe and correct.

## Testing

All 221 extension3 tests pass on Linux. The fixes are cross-platform by design — no OS-specific checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change-path filtering consistency across operating systems, including support for nested and root-level glob patterns.
  * Repository declarations are now excluded from delegated resolution.

* **Tests**
  * Added coverage for wildcard matching across path roots, nested segments, and trailing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->