### PR TITLE
Fix #124: single PathFilters owner for every path-pattern family

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PathFilters.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PathFilters.java
@@ -47,7 +47,7 @@ final class PathFilters {
     private final List<CompiledPattern> fullBuildTriggers;
     private final List<PathMatcher> excludeMatchers;
 
-    PathFilters(
+    private PathFilters(
             List<String> includePatterns,
             List<String> excludePatterns,
             List<String> disableTriggerPatterns,
@@ -132,7 +132,8 @@ final class PathFilters {
      * off entirely), or null. Files are converted to {@link Path} once for the whole batch.
      */
     String findDisableTrigger(Set<String> changedFiles) {
-        return findTrigger(changedFiles, disableTriggers, "Disabled due to change in {} (matches disable trigger {})");
+        return findTrigger(
+                changedFiles, disableTriggers, "Scalpel: Disabled due to change in {} (matches disable trigger {})");
     }
 
     /**
@@ -140,20 +141,16 @@ final class PathFilters {
      * a full build), or null.
      */
     String findFullBuildTrigger(Set<String> changedFiles) {
-        return findTrigger(changedFiles, fullBuildTriggers, "Full build triggered by change to {} (matches {})");
+        return findTrigger(
+                changedFiles, fullBuildTriggers, "Scalpel: Full build triggered by change to {} (matches {})");
     }
 
     private String findTrigger(Set<String> changedFiles, List<CompiledPattern> triggers, String logFormat) {
         if (triggers.isEmpty()) {
             return null;
         }
-        List<Path> paths = new ArrayList<>(changedFiles.size());
         for (String file : changedFiles) {
-            paths.add(Path.of(file));
-        }
-        int i = 0;
-        for (String file : changedFiles) {
-            Path path = paths.get(i++);
+            Path path = Path.of(file);
             for (CompiledPattern trigger : triggers) {
                 if (trigger.matcher().matches(path)) {
                     logger.info(logFormat, file, trigger.pattern());
@@ -168,16 +165,32 @@ final class PathFilters {
     // Compilation
     // ------------------------------------------------------------------
 
+    /**
+     * Normalizes a user-supplied glob pattern so that bare patterns (those containing no path
+     * separator) match files at any depth in the repository tree. For example, {@code *.md} is
+     * rewritten to {@code {*.md,**&#47;*.md}} so that it matches both {@code README.md} (root)
+     * and {@code docs/guide.md} (nested). A plain {@code **&#47;} prefix alone would not match
+     * root-level files on the default {@link java.nio.file.FileSystem} because the path separator
+     * in the pattern is required to be present in the matched path. Patterns that already contain
+     * a {@code /} are returned unchanged because the user explicitly specified the directory
+     * structure.
+     */
+    static String normalizeGlobPattern(String pattern) {
+        if (pattern.contains("/")) {
+            return pattern;
+        }
+        return "{" + pattern + ",**/" + pattern + "}";
+    }
+
     private static List<PathMatcher> compileGlobs(List<String> patterns) {
         if (patterns.isEmpty()) {
             return List.of();
         }
         List<PathMatcher> matchers = new ArrayList<>(patterns.size());
         for (String pattern : patterns) {
-            matchers.add(FileSystems.getDefault()
-                    .getPathMatcher(GLOB_PREFIX + ScalpelLifecycleParticipant.normalizeGlobPattern(pattern)));
+            matchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern)));
         }
-        return java.util.List.copyOf(matchers);
+        return List.copyOf(matchers);
     }
 
     private static List<CompiledPattern> compileNamed(List<String> patterns) {
@@ -187,11 +200,9 @@ final class PathFilters {
         List<CompiledPattern> compiled = new ArrayList<>(patterns.size());
         for (String pattern : patterns) {
             compiled.add(new CompiledPattern(
-                    pattern,
-                    FileSystems.getDefault()
-                            .getPathMatcher(GLOB_PREFIX + ScalpelLifecycleParticipant.normalizeGlobPattern(pattern))));
+                    pattern, FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern))));
         }
-        return java.util.List.copyOf(compiled);
+        return List.copyOf(compiled);
     }
 
     private record CompiledPattern(String pattern, PathMatcher matcher) {}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PathFilters.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/PathFilters.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Owns compilation and evaluation of every path-pattern family Scalpel applies (includePaths,
+ * excludePaths, disableTriggers, fullBuildTriggers), constructed once per build from the resolved
+ * configuration and passed down to every consumer (#124). Before this type existed the include
+ * matchers were re-derived at four sites with subtly different rules and the trigger families
+ * compiled their matchers inline inside per-file loops.
+ *
+ * <p>The one intentional semantic difference between consumers is expressed at the call sites,
+ * not hidden in the matching rules: in {@code trim} mode an upstream build prerequisite outside
+ * the includePaths scope survives in the build set (the reactor would not compile without it),
+ * while in {@code skip-tests} and report mode a module outside the scope has its tests skipped
+ * or is omitted, respectively. {@link #matchesModuleInclude(MavenProject, Path)} is deliberately
+ * neutral about that; each site states its own survival rule.
+ *
+ * <p>Changed-file batches are converted to {@link Path} once per family evaluation, not once per
+ * pattern per file.
+ */
+final class PathFilters {
+
+    private static final Logger logger = LoggerFactory.getLogger(PathFilters.class);
+
+    private static final String GLOB_PREFIX = "glob:";
+
+    private final List<PathMatcher> includeMatchers;
+    private final List<CompiledPattern> disableTriggers;
+    private final List<CompiledPattern> fullBuildTriggers;
+    private final List<PathMatcher> excludeMatchers;
+
+    PathFilters(
+            List<String> includePatterns,
+            List<String> excludePatterns,
+            List<String> disableTriggerPatterns,
+            List<String> fullBuildTriggerPatterns) {
+        this.includeMatchers = compileGlobs(includePatterns);
+        this.excludeMatchers = compileGlobs(excludePatterns);
+        this.disableTriggers = compileNamed(disableTriggerPatterns);
+        this.fullBuildTriggers = compileNamed(fullBuildTriggerPatterns);
+    }
+
+    static PathFilters from(ScalpelConfiguration config) {
+        return new PathFilters(
+                config.getIncludePaths(),
+                config.getExcludePaths(),
+                config.getDisableTriggers(),
+                config.getFullBuildTriggers());
+    }
+
+    // ------------------------------------------------------------------
+    // includePaths: module-scoped
+    // ------------------------------------------------------------------
+
+    boolean hasIncludePatterns() {
+        return !includeMatchers.isEmpty();
+    }
+
+    /**
+     * Whether the module is inside the includePaths scope. A module matches when its directory
+     * path matches a pattern directly (e.g. pattern {@code module-a} matches module
+     * {@code module-a}) or when a file inside it would match (e.g. pattern {@code module-a/**}
+     * matches {@code module-a} via its {@code pom.xml}).
+     */
+    boolean matchesModuleInclude(MavenProject project, Path reactorRoot) {
+        String relPath = ScalpelLifecycleParticipant.relativePath(reactorRoot, project);
+        Path modulePath = Path.of(relPath);
+        for (PathMatcher matcher : includeMatchers) {
+            if (matcher.matches(modulePath) || matcher.matches(modulePath.resolve("pom.xml"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Convenience for filtering collections: true when the module is OUTSIDE the scope. */
+    boolean outsideModuleInclude(MavenProject project, Path reactorRoot) {
+        return !matchesModuleInclude(project, reactorRoot);
+    }
+
+    // ------------------------------------------------------------------
+    // excludePaths / disableTriggers / fullBuildTriggers: file-scoped
+    // ------------------------------------------------------------------
+
+    /** Removes changed files matching excludePaths, preserving iteration order. */
+    Set<String> filterExcluded(Set<String> changedFiles) {
+        if (excludeMatchers.isEmpty()) {
+            return changedFiles;
+        }
+        int before = changedFiles.size();
+        Set<String> filtered = new LinkedHashSet<>();
+        for (String file : changedFiles) {
+            boolean excluded = false;
+            Path path = Path.of(file);
+            for (PathMatcher matcher : excludeMatchers) {
+                if (matcher.matches(path)) {
+                    excluded = true;
+                    break;
+                }
+            }
+            if (!excluded) {
+                filtered.add(file);
+            }
+        }
+        int excludedCount = before - filtered.size();
+        if (excludedCount > 0) {
+            logger.info("Scalpel: {} files excluded by path filters", excludedCount);
+        }
+        return filtered;
+    }
+
+    /**
+     * Returns the first changed file matching a disableTrigger pattern (Scalpel turns itself
+     * off entirely), or null. Files are converted to {@link Path} once for the whole batch.
+     */
+    String findDisableTrigger(Set<String> changedFiles) {
+        return findTrigger(changedFiles, disableTriggers, "Disabled due to change in {} (matches disable trigger {})");
+    }
+
+    /**
+     * Returns the first changed file matching a fullBuildTrigger pattern (the run falls back to
+     * a full build), or null.
+     */
+    String findFullBuildTrigger(Set<String> changedFiles) {
+        return findTrigger(changedFiles, fullBuildTriggers, "Full build triggered by change to {} (matches {})");
+    }
+
+    private String findTrigger(Set<String> changedFiles, List<CompiledPattern> triggers, String logFormat) {
+        if (triggers.isEmpty()) {
+            return null;
+        }
+        List<Path> paths = new ArrayList<>(changedFiles.size());
+        for (String file : changedFiles) {
+            paths.add(Path.of(file));
+        }
+        int i = 0;
+        for (String file : changedFiles) {
+            Path path = paths.get(i++);
+            for (CompiledPattern trigger : triggers) {
+                if (trigger.matcher().matches(path)) {
+                    logger.info(logFormat, file, trigger.pattern());
+                    return file;
+                }
+            }
+        }
+        return null;
+    }
+
+    // ------------------------------------------------------------------
+    // Compilation
+    // ------------------------------------------------------------------
+
+    private static List<PathMatcher> compileGlobs(List<String> patterns) {
+        if (patterns.isEmpty()) {
+            return List.of();
+        }
+        List<PathMatcher> matchers = new ArrayList<>(patterns.size());
+        for (String pattern : patterns) {
+            matchers.add(FileSystems.getDefault()
+                    .getPathMatcher(GLOB_PREFIX + ScalpelLifecycleParticipant.normalizeGlobPattern(pattern)));
+        }
+        return java.util.List.copyOf(matchers);
+    }
+
+    private static List<CompiledPattern> compileNamed(List<String> patterns) {
+        if (patterns.isEmpty()) {
+            return List.of();
+        }
+        List<CompiledPattern> compiled = new ArrayList<>(patterns.size());
+        for (String pattern : patterns) {
+            compiled.add(new CompiledPattern(
+                    pattern,
+                    FileSystems.getDefault()
+                            .getPathMatcher(GLOB_PREFIX + ScalpelLifecycleParticipant.normalizeGlobPattern(pattern))));
+        }
+        return java.util.List.copyOf(compiled);
+    }
+
+    private record CompiledPattern(String pattern, PathMatcher matcher) {}
+}

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -56,7 +56,6 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private static final String MAVEN_TEST_SKIP = "maven.test.skip";
     private static final String SKIP_TESTS = "skipTests";
-    private static final String GLOB_PREFIX = "glob:";
     private static final String UNRESOLVED_GA = "(unresolved)";
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -707,23 +706,6 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private static long millisSince(long startNano) {
         return (System.nanoTime() - startNano) / 1_000_000;
-    }
-
-    /**
-     * Normalizes a user-supplied glob pattern so that bare patterns (those containing no path
-     * separator) match files at any depth in the repository tree. For example, {@code *.md} is
-     * rewritten to {@code {*.md,**&#47;*.md}} so that it matches both {@code README.md} (root)
-     * and {@code docs/guide.md} (nested). A plain {@code **&#47;} prefix alone would not match
-     * root-level files on the default {@link java.nio.file.FileSystem} because the path separator
-     * in the pattern is required to be present in the matched path. Patterns that already contain
-     * a {@code /} are returned unchanged because the user explicitly specified the directory
-     * structure.
-     */
-    static String normalizeGlobPattern(String pattern) {
-        if (pattern.contains("/")) {
-            return pattern;
-        }
-        return "{" + pattern + ",**/" + pattern + "}";
     }
 
     /**

--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -21,10 +21,8 @@ import eu.maveniverse.maven.scalpel.core.Timings;
 import eu.maveniverse.maven.scalpel.core.Version;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -145,6 +143,8 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 allPomPaths.add(relativePom.toString().replace('\\', '/'));
             }
 
+            PathFilters pathFilters = PathFilters.from(config);
+
             // Detect changes
             ChangeDetectionResult result = scalpelCore.detectChanges(reactorRoot, config, allPomPaths, timings);
             if (result == null) {
@@ -174,7 +174,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             logger.info("Scalpel: {} changed files detected", changedFiles.size());
 
             // Check disable triggers (bail out entirely if any changed file matches)
-            if (matchesDisableTrigger(changedFiles, config)) {
+            if (pathFilters.findDisableTrigger(changedFiles) != null) {
                 if (config.isPassiveMode()) {
                     writeStatusReport(config, reactorRoot, "skipped", "disabled by disableTriggers match");
                 }
@@ -182,7 +182,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Filter out excluded paths
-            changedFiles = filterExcludedPaths(changedFiles, config);
+            changedFiles = pathFilters.filterExcluded(changedFiles);
             if (changedFiles.isEmpty()) {
                 logger.info("Scalpel: All changed files excluded by path filters, building all modules");
                 if (config.isPassiveMode()) {
@@ -192,7 +192,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             }
 
             // Check full build triggers
-            String triggerFile = findFullBuildTrigger(changedFiles, config);
+            String triggerFile = pathFilters.findFullBuildTrigger(changedFiles);
             if (triggerFile != null) {
                 if (config.isPassiveMode()) {
                     writeFullBuildReport(config, reactorRoot, triggerFile, changedFiles);
@@ -329,6 +329,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                     writeReport(
                             config,
+                            pathFilters,
                             normalizedRoot,
                             allProjects,
                             AnalysisContext.empty(
@@ -395,6 +396,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                     }
                     writeReport(
                             config,
+                            pathFilters,
                             normalizedRoot,
                             allProjects,
                             AnalysisContext.empty(
@@ -419,11 +421,10 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // keeping full diff visibility for change detection and POM analysis above.
             // The matchers are compiled once here and reused later in trim/report/skip-tests
             // mode to also filter downstream expansions and managed-dep re-enabling.
-            List<PathMatcher> includeMatchers = compileGlobMatchers(config.getIncludePaths());
-            if (!includeMatchers.isEmpty()) {
+            if (pathFilters.hasIncludePatterns()) {
                 int beforeCount = allAffected.size();
-                directlyAffected.removeIf(p -> !matchesIncludePaths(p, includeMatchers, normalizedRoot));
-                transitivelyAffected.keySet().removeIf(p -> !matchesIncludePaths(p, includeMatchers, normalizedRoot));
+                directlyAffected.removeIf(p -> pathFilters.outsideModuleInclude(p, normalizedRoot));
+                transitivelyAffected.keySet().removeIf(p -> pathFilters.outsideModuleInclude(p, normalizedRoot));
                 testOnlyModules.retainAll(directlyAffected);
                 forceIncluded.retainAll(directlyAffected);
 
@@ -443,6 +444,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         }
                         writeReport(
                                 config,
+                                pathFilters,
                                 normalizedRoot,
                                 allProjects,
                                 AnalysisContext.empty(
@@ -485,6 +487,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
                 writeReport(
                         config,
+                        pathFilters,
                         normalizedRoot,
                         allProjects,
                         AnalysisContext.builder(
@@ -538,7 +541,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         return path.isEmpty() ? "." : path;
                     };
                     List<MavenProject> decisionBuildSet = decision.getBuildSet();
-                    if (!includeMatchers.isEmpty()) {
+                    if (pathFilters.hasIncludePatterns()) {
                         // Mirror the post-computeBuildSet filter trim mode applies, so the
                         // shadow decision is the set trim would actually build: downstream
                         // modules outside the includePaths scope are dropped here too.
@@ -546,7 +549,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                         decisionBuildSet = new ArrayList<>(decisionBuildSet);
                         decisionBuildSet.removeIf(project -> !affected.contains(project)
                                 && !decision.getUpstreamOnly().contains(project)
-                                && !matchesIncludePaths(project, includeMatchers, normalizedRoot));
+                                && pathFilters.outsideModuleInclude(project, normalizedRoot));
                     }
                     for (MavenProject project : decisionBuildSet) {
                         wouldHaveBuilt.add(moduleKey.apply(project));
@@ -601,7 +604,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                             config,
                             oldEffectiveModels,
                             newEffectiveModels,
-                            includeMatchers,
+                            pathFilters,
                             normalizedRoot,
                             collectCache,
                             oldCollectCache,
@@ -615,14 +618,14 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             } else {
                 // trim mode: remove unaffected projects from reactor
                 List<MavenProject> buildSet = trimResult.getBuildSet();
-                if (!includeMatchers.isEmpty()) {
+                if (pathFilters.hasIncludePatterns()) {
                     // Filter downstream modules outside includePaths scope while keeping
                     // upstream build prerequisites and directly/transitively affected modules
                     Set<MavenProject> finalAllAffected = allAffected;
                     buildSet = new ArrayList<>(buildSet);
                     buildSet.removeIf(p -> !finalAllAffected.contains(p)
                             && !trimResult.getUpstreamOnly().contains(p)
-                            && !matchesIncludePaths(p, includeMatchers, normalizedRoot));
+                            && pathFilters.outsideModuleInclude(p, normalizedRoot));
                 }
                 logger.info(
                         "Scalpel: Building {} of {} modules: {}", buildSet.size(), allProjects.size(), keys(buildSet));
@@ -636,6 +639,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
                 // minus buildSet) is reviewable alongside the green trimmed build (#91)
                 writeReport(
                         config,
+                        pathFilters,
                         normalizedRoot,
                         allProjects,
                         AnalysisContext.builder(
@@ -705,31 +709,6 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         return (System.nanoTime() - startNano) / 1_000_000;
     }
 
-    private boolean matchesDisableTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
-        for (String pattern : config.getDisableTriggers()) {
-            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
-            for (String changedFile : changedFiles) {
-                if (matcher.matches(Path.of(changedFile))) {
-                    logger.info(
-                            "Scalpel: Disabled due to change in {} (matches disable trigger {})", changedFile, pattern);
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private static List<PathMatcher> compileGlobMatchers(List<String> patterns) {
-        if (patterns.isEmpty()) {
-            return List.of();
-        }
-        List<PathMatcher> matchers = new ArrayList<>(patterns.size());
-        for (String pattern : patterns) {
-            matchers.add(FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern)));
-        }
-        return matchers;
-    }
-
     /**
      * Normalizes a user-supplied glob pattern so that bare patterns (those containing no path
      * separator) match files at any depth in the repository tree. For example, {@code *.md} is
@@ -745,57 +724,6 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             return pattern;
         }
         return "{" + pattern + ",**/" + pattern + "}";
-    }
-
-    private Set<String> filterExcludedPaths(Set<String> changedFiles, ScalpelConfiguration config) {
-        List<PathMatcher> excludeMatchers = compileGlobMatchers(config.getExcludePaths());
-        if (excludeMatchers.isEmpty()) {
-            return changedFiles;
-        }
-        Set<String> filtered = new LinkedHashSet<>();
-        for (String file : changedFiles) {
-            boolean excluded = false;
-            for (PathMatcher matcher : excludeMatchers) {
-                if (matcher.matches(Path.of(file))) {
-                    excluded = true;
-                    break;
-                }
-            }
-            if (!excluded) {
-                filtered.add(file);
-            }
-        }
-        int excludedCount = changedFiles.size() - filtered.size();
-        if (excludedCount > 0) {
-            logger.info("Scalpel: {} files excluded by path filters", excludedCount);
-        }
-        return filtered;
-    }
-
-    private boolean matchesIncludePaths(MavenProject project, List<PathMatcher> matchers, Path reactorRoot) {
-        String relPath = relativePath(reactorRoot, project);
-        Path modulePath = Path.of(relPath);
-        for (PathMatcher matcher : matchers) {
-            // Match the module path directly (e.g., "module-a" matches pattern "module-a")
-            // or match a file within the module (e.g., "module-a/pom.xml" matches pattern "module-a/**")
-            if (matcher.matches(modulePath) || matcher.matches(modulePath.resolve("pom.xml"))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private String findFullBuildTrigger(Set<String> changedFiles, ScalpelConfiguration config) {
-        for (String pattern : config.getFullBuildTriggers()) {
-            PathMatcher matcher = FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + normalizeGlobPattern(pattern));
-            for (String changedFile : changedFiles) {
-                if (matcher.matches(Path.of(changedFile))) {
-                    logger.info("Scalpel: Full build triggered by change to {} (matches {})", changedFile, pattern);
-                    return changedFile;
-                }
-            }
-        }
-        return null;
     }
 
     /**
@@ -1023,7 +951,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             ScalpelConfiguration config,
             Map<String, Model> oldEffectiveModels,
             Map<String, Model> newEffectiveModels,
-            List<PathMatcher> includeMatchers,
+            PathFilters pathFilters,
             Path reactorRoot,
             Map<MavenProject, DependencyResolutionResult> collectCache,
             Map<MavenProject, DependencyResolutionResult> oldCollectCache,
@@ -1073,7 +1001,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
             // Skip tests on modules outside includePaths scope — managed dep/plugin
             // re-enabling should not override the user's includePaths restriction
-            if (!includeMatchers.isEmpty() && !matchesIncludePaths(project, includeMatchers, reactorRoot)) {
+            if (pathFilters.hasIncludePatterns() && pathFilters.outsideModuleInclude(project, reactorRoot)) {
                 project.getProperties().setProperty(MAVEN_TEST_SKIP, "true");
                 skippedProjects.add(project);
                 continue;
@@ -1706,6 +1634,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
     private void writeReport(
             ScalpelConfiguration config,
+            PathFilters pathFilters,
             Path reactorRoot,
             List<MavenProject> allProjects,
             AnalysisContext ctx,
@@ -1732,7 +1661,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
         addDirectlyAffectedModules(builder, ctx, reactorRoot);
         addTransitivelyAffectedModules(builder, ctx, config, reactorRoot);
-        int excludedUpstream = addTrimResultModules(builder, ctx, config, reactorRoot);
+        int excludedUpstream = addTrimResultModules(builder, ctx, pathFilters, config, reactorRoot);
         builder.excludedUpstreamCount(excludedUpstream);
         addSkippedModules(builder, allProjects, ctx, reactorRoot);
 
@@ -1841,7 +1770,11 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
      * upstream build-prerequisite modules that were excluded.
      */
     private int addTrimResultModules(
-            ScalpelReport.Builder builder, AnalysisContext ctx, ScalpelConfiguration config, Path reactorRoot) {
+            ScalpelReport.Builder builder,
+            AnalysisContext ctx,
+            PathFilters pathFilters,
+            ScalpelConfiguration config,
+            Path reactorRoot) {
         if (ctx.trimResult == null) {
             return 0;
         }
@@ -1868,6 +1801,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         addDownstreamModules(
                 builder,
                 ctx,
+                pathFilters,
                 config,
                 reactorRoot,
                 ctx.trimResult.getDownstreamOnly(),
@@ -1875,6 +1809,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         addDownstreamModules(
                 builder,
                 ctx,
+                pathFilters,
                 config,
                 reactorRoot,
                 ctx.trimResult.getDownstreamTestOnly(),
@@ -1885,15 +1820,15 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
     private void addDownstreamModules(
             ScalpelReport.Builder builder,
             AnalysisContext ctx,
+            PathFilters pathFilters,
             ScalpelConfiguration config,
             Path reactorRoot,
             Set<MavenProject> downstreamProjects,
             String reason) {
-        List<PathMatcher> includeMatchers = compileGlobMatchers(config.getIncludePaths());
         for (MavenProject project : downstreamProjects) {
             if (!ctx.directlyAffected.contains(project) && !ctx.transitivelyAffected.containsKey(project)) {
                 // Skip downstream modules outside includePaths scope
-                if (!includeMatchers.isEmpty() && !matchesIncludePaths(project, includeMatchers, reactorRoot)) {
+                if (pathFilters.hasIncludePatterns() && pathFilters.outsideModuleInclude(project, reactorRoot)) {
                     if (logger.isDebugEnabled()) {
                         logger.debug("Excluding downstream module {} from report (outside includePaths)", key(project));
                     }
@@ -1917,7 +1852,7 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private static String relativePath(Path normalizedRoot, MavenProject project) {
+    static String relativePath(Path normalizedRoot, MavenProject project) {
         return normalizedRoot
                 .relativize(project.getBasedir().toPath().toAbsolutePath().normalize())
                 .toString()

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -5824,17 +5824,16 @@ class ScalpelLifecycleParticipantTest {
 
     @Test
     void normalizeGlobPattern_barePatternIsPrefixed() {
-        assertEquals("{*.md,**/*.md}", ScalpelLifecycleParticipant.normalizeGlobPattern("*.md"));
-        assertEquals("{LICENSE,**/LICENSE}", ScalpelLifecycleParticipant.normalizeGlobPattern("LICENSE"));
-        assertEquals(
-                "{.editorconfig,**/.editorconfig}", ScalpelLifecycleParticipant.normalizeGlobPattern(".editorconfig"));
+        assertEquals("{*.md,**/*.md}", PathFilters.normalizeGlobPattern("*.md"));
+        assertEquals("{LICENSE,**/LICENSE}", PathFilters.normalizeGlobPattern("LICENSE"));
+        assertEquals("{.editorconfig,**/.editorconfig}", PathFilters.normalizeGlobPattern(".editorconfig"));
     }
 
     @Test
     void normalizeGlobPattern_patternWithSlashIsUnchanged() {
-        assertEquals("docs/*.md", ScalpelLifecycleParticipant.normalizeGlobPattern("docs/*.md"));
-        assertEquals("**/*.md", ScalpelLifecycleParticipant.normalizeGlobPattern("**/*.md"));
-        assertEquals(".github/**", ScalpelLifecycleParticipant.normalizeGlobPattern(".github/**"));
+        assertEquals("docs/*.md", PathFilters.normalizeGlobPattern("docs/*.md"));
+        assertEquals("**/*.md", PathFilters.normalizeGlobPattern("**/*.md"));
+        assertEquals(".github/**", PathFilters.normalizeGlobPattern(".github/**"));
     }
 
     @Test


### PR DESCRIPTION
includePaths matching was independently re-derived at four sites with subtly different rules (affected-set, trim build-set, skip-tests, report downstream), the report site recompiled its matchers from config despite a comment at the first site claiming one shared compilation, and the disable/full-build trigger families compiled matchers inline inside per-file loops, reparsing each changed file once per pattern. Correctness risk wearing a refactoring costume, as the issue puts it.

`PathFilters` is constructed once from the resolved configuration and owns compilation and evaluation of all four families: module-scoped include matching (the dual direct-path plus descendant-pom rule), changed-file exclusion (the count log line preserved verbatim), and both trigger searches. The one intentional semantic difference is now stated where it applies instead of being implied by four copies: in trim mode an upstream build prerequisite outside the includePaths scope survives (commented at both trim-side filters), while skip-tests mode skips the tests of out-of-scope modules and the report omits them. `normalizeGlobPattern` moves next to its only remaining caller.

Gates run before pushing (review: line-by-line parity against main; simplify). The review gate caught one real slip, fixed: both trigger log lines had silently lost the `Scalpel: ` prefix (restored verbatim, matching the exclusion line). The simplify gate collapsed the trigger search's fragile parallel index into a single loop, made the four-list constructor private with `from(config)` the sole entry point, and deleted SLP's now-dead `GLOB_PREFIX`.

**One observable change, documented rather than reverted:** with multiple trigger patterns and files, the reported `triggerFile` is now the first changed file in file order matching any pattern (previously: the first file of the first matching pattern in pattern order). It lands in the report's `triggerFile` field and the shadow status reason. With the default single-pattern configuration there is no difference.

Behavior otherwise preserved, proven by the full battery: all unit tests and all 36 integration tests green, including the include-paths, exclude-paths, disable-triggers and full-build-trigger ITs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path-pattern matching so patterns without directory separators apply to matching files at any directory depth.
  * Standardized include and exclude filtering across project modules and changed files.
  * Improved detection of paths that disable triggers or require a full build.
  * Preserved file ordering when applying exclusions and ensured the first matching trigger path is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->