### PR TITLE
docs: fix Java 8→17, update README version, expand GIB migration guide for 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Then run Maven as usual. On a feature branch in CI, Scalpel will automatically d
 
 ```text
 $ mvn verify
-[INFO] Scalpel 0.3.10 activated (mode=trim)
+[INFO] Scalpel 0.4.0 activated (mode=trim)
 [INFO] Scalpel: 3 changed files detected
 [INFO] Scalpel: 2 modules directly affected: [com.example:module-a, com.example:module-b]
 [INFO] Scalpel: Building 3 of 8 modules: [com.example:parent, com.example:module-a, com.example:module-b]

--- a/docs/GIB-MIGRATION.md
+++ b/docs/GIB-MIGRATION.md
@@ -38,7 +38,7 @@ The tradeoff: Scalpel has fewer knobs. If Scalpel's analysis is wrong, your esca
 
 **Explain mode.** `-Dscalpel.explain=true` adds per-module decision evidence to the report: each `affectedModules` entry gets an `evidence` array naming the exact file, property, dependency, or graph relationship that put it in the build set. Diagnose surprising results without guessing.
 
-**Periodic correctness verification.** `-Dscalpel.verifyFullBuild=true` runs the full build under shadow observation and fails it if any module Scalpel would have skipped actually fails, naming the module, its skip reason, and the `decisionId`. A stable `decisionId` (SHA-256 of the merge-base, head, config, and build set) is emitted in every mode so failures are quotable and correlatable. GIB has no equivalent.
+**Periodic correctness verification.** `-Dscalpel.verifyFullBuild=true` runs the full build under shadow observation and fails it if any module Scalpel would have skipped actually fails, naming the module, its skip reason, and the `decisionId`. A stable `decisionId` (SHA-256 of the merge-base, head, config, and build set) is emitted whenever a decision completes so failures are quotable and correlatable. GIB has no equivalent.
 
 **Fine-grained POM change filtering.** `scalpel.excludeChanges` and `scalpel.includeChanges` accept glob patterns over a normalized change-path scheme (`properties/<name>`, `dependencies/<ga>`, `managedDependencies/<ga>`, etc.). Volatile properties (`build.timestamp`, `project.build.outputTimestamp`) are excluded by default. GIB users who reached for `includePathsMatching` to suppress noisy POM changes can express that intent precisely here instead.
 

--- a/docs/GIB-MIGRATION.md
+++ b/docs/GIB-MIGRATION.md
@@ -32,7 +32,15 @@ The tradeoff: Scalpel has fewer knobs. If Scalpel's analysis is wrong, your esca
 
 **Plugin configuration semantic diff.** Plugin `<configuration>` blocks are compared as DOM trees, not strings. Whitespace changes, attribute reordering, and comment additions inside plugin config are ignored.
 
-**Java 8 compatibility.** Scalpel requires Java 8+. GIB requires Java 11+.
+**Java 17 compatibility.** Scalpel requires Java 17+. GIB requires Java 11+.
+
+**Shadow mode.** `mode=shadow` measures what Scalpel would save on your reactor from a single full build — zero extra runner-hours, no control group. It records per-module wall-clock, computes the trim decision it would have made, and emits `estimatedSecondsSaved` and `wouldHaveSkippedButFailed` to `target/scalpel-shadow.json`. GIB has no equivalent.
+
+**Explain mode.** `-Dscalpel.explain=true` adds per-module decision evidence to the report: each `affectedModules` entry gets an `evidence` array naming the exact file, property, dependency, or graph relationship that put it in the build set. Diagnose surprising results without guessing.
+
+**Periodic correctness verification.** `-Dscalpel.verifyFullBuild=true` runs the full build under shadow observation and fails it if any module Scalpel would have skipped actually fails, naming the module, its skip reason, and the `decisionId`. A stable `decisionId` (SHA-256 of the merge-base, head, config, and build set) is emitted in every mode so failures are quotable and correlatable. GIB has no equivalent.
+
+**Fine-grained POM change filtering.** `scalpel.excludeChanges` and `scalpel.includeChanges` accept glob patterns over a normalized change-path scheme (`properties/<name>`, `dependencies/<ga>`, `managedDependencies/<ga>`, etc.). Volatile properties (`build.timestamp`, `project.build.outputTimestamp`) are excluded by default. GIB users who reached for `includePathsMatching` to suppress noisy POM changes can express that intent precisely here instead.
 
 ## GIB Features Not in Scalpel
 


### PR DESCRIPTION
Pre-release doc fixes for 0.4.0:

- **GIB-MIGRATION.md**: Fix incorrect Java 8 claim → Java 17 (broken by the `maven.compiler.release` bump in #87)
- **README.md**: Update activation line example from `0.3.10` to `0.4.0`
- **GIB-MIGRATION.md**: Add four new 0.4.0 features to the 'Where Scalpel Does More' section: shadow mode, explain mode, `verifyFullBuild`/`decisionId`, and `excludeChanges`/`includeChanges`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README trim-mode example to reference Scalpel 0.4.0.
  - Updated the migration guide’s compatibility information to Java 17+.
  - Documented shadow mode, explain mode, periodic correctness verification, and fine-grained POM change filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->