### PR TITLE
Fix #188: status-path report writes honour failSafe

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssembler.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssembler.java
@@ -80,26 +80,27 @@ class ReportAssembler {
         }
     }
 
-    void writeStatusReport(ScalpelConfiguration config, Path reactorRoot, String status, String reason) {
+    void writeStatusReport(ScalpelConfiguration config, Path reactorRoot, String status, String reason)
+            throws MavenExecutionException {
         String baseBranch = config.getBaseBranch();
+        if (config.isModeShadow() || config.isVerifyFullBuild()) {
+            writeShadowStatus(reactorRoot, status, reason);
+        }
+        ScalpelReport report = ScalpelReport.builder()
+                .baseBranch(baseBranch != null ? baseBranch : "(unconfigured)")
+                .status(status)
+                .reason(reason)
+                .fullBuildTriggered(true)
+                .build();
         try {
-            if (config.isModeShadow() || config.isVerifyFullBuild()) {
-                writeShadowStatus(reactorRoot, status, reason);
-            }
-            ScalpelReport report = ScalpelReport.builder()
-                    .baseBranch(baseBranch != null ? baseBranch : "(unconfigured)")
-                    .status(status)
-                    .reason(reason)
-                    .fullBuildTriggered(true)
-                    .build();
             report.writeToFile(reactorRoot, config.getReportFile());
             logger.warn(
                     "Scalpel: Analysis did not complete (status={}, reason={}), report at {} overwritten",
                     status,
                     reason,
                     config.getReportFile());
-        } catch (Exception e) {
-            logger.warn("Scalpel: Could not overwrite report with {} status: {}", status, e.toString());
+        } catch (IOException e) {
+            handleWriteFailure(config, "Could not overwrite report with " + status + " status", e);
         }
     }
 
@@ -144,7 +145,8 @@ class ReportAssembler {
         }
     }
 
-    void writeFailedStatusReport(ScalpelConfiguration config, Path reactorRoot, String reason) {
+    void writeFailedStatusReport(ScalpelConfiguration config, Path reactorRoot, String reason)
+            throws MavenExecutionException {
         writeStatusReport(config, reactorRoot, "failed", reason);
     }
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssemblerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssemblerTest.java
@@ -47,8 +47,8 @@ class ReportAssemblerTest {
                         configWith(false, outside), tempDir, "skipped", "no changes detected"),
                 "with failSafe=false a failed status write must fail the build");
         assertTrue(
-                e.getMessage() != null && e.getMessage().contains("scalpel.reportFile"),
-                "the failure should carry the write-failure detail, got: " + e.getMessage());
+                e.getCause() != null && e.getCause().getMessage().contains("scalpel.reportFile"),
+                "the cause should carry the property name, got: " + e.getCause());
     }
 
     @Test
@@ -74,7 +74,7 @@ class ReportAssemblerTest {
                 () -> assembler.writeStatusReport(
                         configWith(false, dirAsFile.toString()), tempDir, "skipped", "no changes detected"));
         assertTrue(
-                e.getMessage() != null && e.getMessage().contains("scalpel.reportFile"),
-                "the failure should name the property, got: " + e.getMessage());
+                e.getCause() != null && e.getCause().getMessage().contains("scalpel.reportFile"),
+                "the cause should name the property, got: " + e.getCause());
     }
 }

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssemblerTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ReportAssemblerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import eu.maveniverse.maven.scalpel.core.ScalpelConfiguration;
+import java.util.Properties;
+import org.apache.maven.MavenExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for the status-path write semantics of {@link ReportAssembler} (#188): a failed
+ * status report write honours failSafe instead of always warn-and-continue, so
+ * failSafe=false means "fail the build when Scalpel cannot do its job" on this path too.
+ */
+class ReportAssemblerTest {
+
+    @TempDir
+    java.nio.file.Path tempDir;
+
+    private static ScalpelConfiguration configWith(boolean failSafe, String reportFile) {
+        java.util.Properties sys = new Properties();
+        sys.setProperty("scalpel.failSafe", String.valueOf(failSafe));
+        sys.setProperty("scalpel.reportFile", reportFile);
+        return ScalpelConfiguration.fromProperties(sys, new Properties());
+    }
+
+    @Test
+    void writeStatusReport_failSafeFalse_failsTheBuildOnWriteFailure() {
+        ReportAssembler assembler = new ReportAssembler();
+        // An absolute path outside the reactor trips resolveContained (#97): same
+        // IOException any unwritable destination produces, deterministic on every OS.
+        String outside = tempDir.resolve("outside").resolve("report.json").toString();
+
+        MavenExecutionException e = assertThrows(
+                MavenExecutionException.class,
+                () -> assembler.writeStatusReport(
+                        configWith(false, outside), tempDir, "skipped", "no changes detected"),
+                "with failSafe=false a failed status write must fail the build");
+        assertTrue(
+                e.getMessage() != null && e.getMessage().contains("scalpel.reportFile"),
+                "the failure should carry the write-failure detail, got: " + e.getMessage());
+    }
+
+    @Test
+    void writeStatusReport_failSafeTrue_warnsAndContinues() {
+        ReportAssembler assembler = new ReportAssembler();
+        String outside = tempDir.resolve("outside2").resolve("report.json").toString();
+
+        assertDoesNotThrow(() ->
+                assembler.writeStatusReport(configWith(true, outside), tempDir, "skipped", "no changes detected"));
+        assertTrue(!java.nio.file.Files.exists(java.nio.file.Path.of(outside)), "nothing written outside the reactor");
+    }
+
+    @Test
+    void writeStatusReport_statusWriteFails_failSafeFalse_failsTheBuild() throws java.io.IOException {
+        // The reportFile itself points at an existing DIRECTORY: writeToFile cannot
+        // overwrite it, exercising the plain write failure (not containment).
+        ReportAssembler assembler = new ReportAssembler();
+        java.nio.file.Path dirAsFile = tempDir.resolve("dir-report");
+        java.nio.file.Files.createDirectories(dirAsFile);
+
+        MavenExecutionException e = assertThrows(
+                MavenExecutionException.class,
+                () -> assembler.writeStatusReport(
+                        configWith(false, dirAsFile.toString()), tempDir, "skipped", "no changes detected"));
+        assertTrue(
+                e.getMessage() != null && e.getMessage().contains("scalpel.reportFile"),
+                "the failure should name the property, got: " + e.getMessage());
+    }
+}


### PR DESCRIPTION
The issue's probe, reproduced: with failSafe=false and an escaping scalpel.reportFile, the status-path write warns and the build exits 0 with the report never written. The main report path (writeReport then handleWriteFailure) honours failSafe correctly; writeStatusReport did not, because its catch-all warned unconditionally and never consulted the flag.

Fix: writeStatusReport now declares MavenExecutionException and routes write failures through handleWriteFailure, so failSafe=false fails the build and failSafe=true keeps warn-and-continue. Its callers (the three early exits in handleSession, and writeFailedStatusReport) already run inside failSafe-aware contexts, so no call site needed changes beyond the declaration.

TDD: the RED tests fail on unmodified main: an escaping destination with failSafe=false must throw naming the property, failSafe=true must keep warn-and-continue, and an existing directory as reportFile (plain write failure, not containment) must fail the build.

Deliberate behaviour change to note: with failSafe=false, a failed status write now fails the build where it previously warned and continued; with the default failSafe=true nothing changes externally.

Full battery green: extension3 192 unit tests (3 new), all 38 ITs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved status-report error handling.
  - Report write failures now produce a clear execution error when fail-safe mode is disabled.
  - When fail-safe mode is enabled, write failures generate a warning and allow processing to continue without creating an external status report.

- **Tests**
  - Added coverage for report-writing failures in both fail-safe and standard execution modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->