### PR TITLE
Fix #184: all-changes-excluded honours buildAllIfNoChanges

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipant.java
@@ -177,11 +177,22 @@ class ScalpelLifecycleParticipant extends AbstractMavenLifecycleParticipant {
             // Filter out excluded paths
             changedFiles = pathFilters.filterExcludedPaths(changedFiles);
             if (changedFiles.isEmpty()) {
-                logger.info("Scalpel: All changed files excluded by path filters, building all modules");
+                // Nothing relevant changed: the same state as "no changes", so
+                // buildAllIfNoChanges selects between a full build and an EMPTY one (#184).
                 if (passiveRun(config)) {
+                    logger.info("Scalpel: All changed files excluded by path filters");
                     reportAssembler.writeStatusReport(
                             config, reactorRoot, "skipped", "all changed files excluded by path filters");
+                    return;
                 }
+                if (config.isBuildAllIfNoChanges()) {
+                    logger.info("Scalpel: All changed files excluded by path filters, building all modules"
+                            + " (buildAllIfNoChanges=true)");
+                    return;
+                }
+                logger.info("Scalpel: All changed files excluded by path filters, trimming reactor to empty"
+                        + " (buildAllIfNoChanges=false)");
+                session.setProjects(new ArrayList<>());
                 return;
             }
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ScalpelLifecycleParticipantTest.java
@@ -3482,6 +3482,49 @@ class ScalpelLifecycleParticipantTest {
     }
 
     @Test
+    void allFilesExcludedByPathFilters_defaultTrimsToEmptyBuildSet() throws Exception {
+        Path root = tempDir.resolve("project");
+        Files.createDirectories(root);
+
+        String parentPom = simpleParentPom("module-a", "module-b");
+        writePom(root, "pom.xml", parentPom);
+        writePom(root, "module-a/pom.xml", simpleChildPom("module-a"));
+        writePom(root, "module-b/pom.xml", simpleChildPom("module-b"));
+
+        MavenProject parentProject = createProject("com.example", "parent", "1.0", root, "pom.xml", parentPom);
+        parentProject.getModel().setPackaging("pom");
+        MavenProject moduleA =
+                createProject("com.example", "module-a", "1.0", root, "module-a/pom.xml", simpleChildPom("module-a"));
+        moduleA.setParent(parentProject);
+        MavenProject moduleB =
+                createProject("com.example", "module-b", "1.0", root, "module-b/pom.xml", simpleChildPom("module-b"));
+        moduleB.setParent(parentProject);
+
+        List<MavenProject> allProjects = List.of(parentProject, moduleA, moduleB);
+
+        // Every changed file is excluded: nothing relevant changed, so with the default
+        // buildAllIfNoChanges=false the reactor trims to EMPTY instead of building all (#184)
+        Set<String> changedFiles = new LinkedHashSet<>();
+        changedFiles.add("docs/guide.md");
+        when(scalpelCore.detectChanges(any(), any(), any(), any()))
+                .thenReturn(new ChangeDetectionResult(changedFiles, new HashMap<String, byte[]>()));
+        setupEmptyDependencyResolution();
+
+        MavenSession session = createSimpleSession(root, allProjects, "trim");
+        session.getSystemProperties().setProperty("scalpel.excludePaths", "docs/**");
+
+        participant.afterProjectsRead(session);
+
+        org.mockito.ArgumentCaptor<List<MavenProject>> captor = org.mockito.ArgumentCaptor.forClass(List.class);
+        org.mockito.Mockito.verify(session).setProjects(captor.capture());
+        assertTrue(
+                captor.getValue().isEmpty(),
+                "with only excluded files changed and buildAllIfNoChanges=false, the build set must be empty, got: "
+                        + captor.getValue());
+        assertFalse(Files.exists(root.resolve("target/scalpel-report.json")));
+    }
+
+    @Test
     void allFilesExcludedByPathFilters_buildsAll() throws Exception {
         Path root = tempDir.resolve("project");
         Files.createDirectories(root);


### PR DESCRIPTION
When excludePaths emptied the changeset, the gate logged and returned with the reactor untrimmed: every module built, regardless of buildAllIfNoChanges, whose only other read site gated a log line at the no-changes gate. The property was dead code on this path, exactly as measured in the issue (35% of the last 40 apicurio-registry merges built all 57 modules on docs/ui-only changes).

The all-excluded state is the same state as no-changes, so it now routes through the same property, as the issue proposes: buildAllIfNoChanges=true keeps the full build, false trims the reactor to EMPTY (nothing relevant changed, nothing to build). Passive modes (report, shadow, verify) are untouched: they still observe the full build and write the status report, so verify runs keep measuring the full reactor and the shadow document keeps recording zero false negatives.

TDD: the new RED test (trim mode, docs/** excluded, only a doc file changed) failed on the previous commit with setProjects never invoked, and now passes capturing setProjects(List.of()) via ArgumentCaptor. The pre-existing allFilesExcludedByPathFilters_buildsAll test still passes unchanged (its assertion, no report file, is orthogonal).

**Deliberate behaviour change to note:** with the default buildAllIfNoChanges=false, a changeset made entirely of excluded files now produces an empty build (Maven succeeds building zero modules) where it previously built the entire reactor. Set buildAllIfNoChanges=true to restore the full build on such changesets.

Full battery green: core 304, extension3 96 SLP-scoped unit tests, all 38 ITs.