### PR TITLE
Fix #185: files under non-reactor modules no longer cascade to the root

### DIFF
--- a/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
+++ b/extension3/src/main/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapper.java
@@ -7,6 +7,7 @@
  */
 package eu.maveniverse.maven.scalpel.extension3.internal;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -88,7 +89,7 @@ class ModuleMapper {
         }
 
         for (String changedFile : changedFiles) {
-            MavenProject matched = findOwningModule(changedFile, moduleByDir, rootProject);
+            MavenProject matched = findOwningModule(changedFile, moduleByDir, rootProject, rootDir);
             if (matched != null) {
                 String projectPath = matched == rootProject ? "" : pathByProject.get(matched);
                 boolean isTest = isTestPath(changedFile, projectPath);
@@ -131,7 +132,7 @@ class ModuleMapper {
      * @return the owning project, or {@code null} if no module owns this file
      */
     private static MavenProject findOwningModule(
-            String changedFile, Map<String, MavenProject> moduleByDir, MavenProject rootProject) {
+            String changedFile, Map<String, MavenProject> moduleByDir, MavenProject rootProject, Path rootDir) {
         // Walk parent directories from deepest to shallowest
         int slash = changedFile.lastIndexOf('/');
         if (slash <= 0) {
@@ -145,10 +146,18 @@ class ModuleMapper {
             if (project != null) {
                 return project;
             }
+            // The deepest ancestor directory holding its own pom.xml is the module
+            // boundary. When that directory is not in this reactor (profile-gated or
+            // otherwise excluded module), the file belongs to a module the current build
+            // does not contain and must contribute nothing, rather than falling through
+            // to the root project and marking the whole reactor affected (#185).
+            if (Files.isRegularFile(rootDir.resolve(dir).resolve("pom.xml"))) {
+                return null;
+            }
             slash = dir.lastIndexOf('/');
         }
-        // No module directory matched; fall back to root project for files
-        // that are in subdirectories (src/main/..., scripts/..., etc.)
+        // No module directory matched and no pom.xml boundary found; fall back to root
+        // project for files that are in subdirectories (src/main/..., scripts/..., etc.)
         return rootProject;
     }
 

--- a/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperOutsideReactorTest.java
+++ b/extension3/src/test/java/eu/maveniverse/maven/scalpel/extension3/internal/ModuleMapperOutsideReactorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Maveniverse Org.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ */
+package eu.maveniverse.maven.scalpel.extension3.internal;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A file living under a directory that holds its own pom.xml but whose module is ABSENT from
+ * the current reactor (profile-gated module, disabled module) must contribute nothing: the
+ * old fallback mapped such files to the root project, marking the entire reactor affected
+ * (#185). Bare root files keep mapping to the root project, unchanged.
+ */
+class ModuleMapperOutsideReactorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void fileUnderNonReactorModuleDirectory_isIgnored() throws IOException {
+        ModuleMapper mapper = new ModuleMapper();
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        // operator/ holds its own pom.xml on disk but is not part of the reactor list:
+        // exactly the profile-gated-module situation from the issue's apicurio case.
+        Path operatorPom = root.resolve("operator/pom.xml");
+        Files.createDirectories(operatorPom.getParent());
+        Files.write(operatorPom, "<project/>".getBytes(StandardCharsets.UTF_8));
+
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("operator/Makefile"));
+
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertTrue(result.getMainAffected().isEmpty(), "outside-reactor files must not affect any module");
+        assertTrue(result.getTestOnlyAffected().isEmpty());
+        assertTrue(result.getAllAffected().isEmpty(), "the build set must not widen to the root project");
+    }
+
+    @Test
+    void nestedFileUnderNonReactorModuleDirectory_isIgnored() throws IOException {
+        ModuleMapper mapper = new ModuleMapper();
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        Path operatorPom = root.resolve("operator/pom.xml");
+        Files.createDirectories(operatorPom.getParent());
+        Files.write(operatorPom, "<project/>".getBytes(StandardCharsets.UTF_8));
+
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("operator/install/deploy/catalog.yaml"));
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        assertTrue(result.getAllAffected().isEmpty(), "nested files under operator/ contribute nothing");
+    }
+
+    @Test
+    void bareRootFile_contributesNothing() throws IOException {
+        ModuleMapper mapper = new ModuleMapper();
+        Path root = tempDir;
+        List<MavenProject> projects = createProjects(root);
+
+        Set<String> changedFiles = new LinkedHashSet<>(List.of("renovate.json"));
+        ModuleMapper.Result result = mapper.mapToProjectsClassified(changedFiles, projects, root);
+
+        // Bare root files (no directory separator) return null today and keep doing so:
+        // per the issue's own verification they contribute nothing, and 57 of 57 modules
+        // were skipped on such a commit.
+        assertTrue(result.getAllAffected().isEmpty(), "bare root files contribute nothing");
+    }
+
+    private List<MavenProject> createProjects(Path root) {
+        MavenProject parent =
+                createProject("com.example", "parent", root.resolve("pom.xml").toFile());
+        MavenProject moduleA = createProject(
+                "com.example", "module-a", root.resolve("module-a/pom.xml").toFile());
+        MavenProject moduleB = createProject(
+                "com.example", "module-b", root.resolve("module-b/pom.xml").toFile());
+        return List.of(parent, moduleA, moduleB);
+    }
+
+    private MavenProject createProject(String groupId, String artifactId, java.io.File pomFile) {
+        org.apache.maven.model.Model model = new org.apache.maven.model.Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion("1.0");
+        model.setPomFile(pomFile);
+        MavenProject project = new MavenProject(model);
+        project.setFile(pomFile);
+        return project;
+    }
+}


### PR DESCRIPTION
findOwningModule walked a changed file's parent directories and fell back to the root project whenever none of them was a reactor module. A file belonging to a module that exists in the repository but is absent from the current reactor (profile-gated, excluded) therefore landed on the root aggregator, marking every module DOWNSTREAM_DEPENDENT and building the whole tree. On the issue's apicurio replay this path produced ten full builds, five of which should have been zero-module builds (operator-only and typescript-sdk-only commits).

The walk now probes each ancestor directory (deepest first) for its own pom.xml: the first directory holding one is the module boundary, and when that directory is not in the reactor map the file belongs to a module this build does not contain, so it contributes nothing. With no pom.xml boundary anywhere above the file the root fallback keeps its old meaning (genuine root-owned subdirectory content like scripts/), and bare root files (no separator) keep returning null, the behaviour the issue verified as correct on renovate.json, so directory depth no longer decides the outcome between equally irrelevant files.

TDD: the outside-reactor and nested-outside tests fail on the previous commit with the root project affected; the bare-root pinning test passed before and after.

**Deliberate behaviour change to note:** a changed file under a directory that holds a pom.xml but is not part of the reactor now contributes nothing (previously: full build via the root aggregator). That is the issue's own recommendation, symmetric to what #90 did for changed POM files.

Full battery green: core 304, extension3 306 unit tests (3 new), all 38 ITs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Files located in module directories excluded from the active reactor no longer incorrectly mark the root project or entire reactor as affected.
  * Improved handling of direct, nested, and root-level files when determining affected projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->